### PR TITLE
recipes-sdk/*: remove condition on BUILD_SHARED_LIBS in cmake files

### DIFF
--- a/recipes-sdk/aws-c-auth/aws-c-auth_0.6.1.bb
+++ b/recipes-sdk/aws-c-auth/aws-c-auth_0.6.1.bb
@@ -24,16 +24,22 @@ RDEPENDS:${PN} = "s2n aws-c-common aws-c-cal aws-c-io aws-c-compression aws-c-ht
 
 CFLAGS:append = " -Wl,-Bsymbolic"
 
+BUILD_SHARED_LIBS = "ON"
+
 OECMAKE_SOURCEPATH = "${S}/aws-c-auth"
 EXTRA_OECMAKE += "-DBUILD_TESTING=OFF"
 EXTRA_OECMAKE += "-DCMAKE_MODULE_PATH=${S}/aws-c-common/cmake"
 EXTRA_OECMAKE += "-DCMAKE_PREFIX_PATH=$D/usr"
 EXTRA_OECMAKE += "-DCMAKE_INSTALL_PREFIX=$D/usr"
-EXTRA_OECMAKE += "-DBUILD_SHARED_LIBS=ON"
+EXTRA_OECMAKE += "-DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}"
 EXTRA_OECMAKE += "-DCMAKE_BUILD_TYPE=Release"
 
 OECMAKE_BUILDPATH += "${WORKDIR}/build"
 OECMAKE_SOURCEPATH += "${S}"
+
+do_install:append() {
+	sed -i "s/BUILD_SHARED_LIBS/${BUILD_SHARED_LIBS}/" ${D}${libdir}/${BPN}/cmake/${BPN}-config.cmake
+}
 
 FILES:${PN}     = "${libdir}/lib${PN}.so.1.0.0"
 FILES:${PN}-dev = "${includedir}/aws/auth/* \

--- a/recipes-sdk/aws-c-cal/aws-c-cal_0.5.11.bb
+++ b/recipes-sdk/aws-c-cal/aws-c-cal_0.5.11.bb
@@ -21,14 +21,20 @@ S = "${WORKDIR}/git"
 DEPENDS = "openssl s2n aws-c-common"
 RDEPENDS:${PN} = "s2n aws-c-common"
 
+BUILD_SHARED_LIBS = "ON"
+
 CFLAGS:append = " -Wl,-Bsymbolic"
 OECMAKE_SOURCEPATH = "${S}/aws-c-cal"
 OECMAKE_BUILDPATH = "${WORKDIR}/build"
-EXTRA_OECMAKE += "-DBUILD_SHARED_LIBS=ON"
+EXTRA_OECMAKE += "-DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}"
 EXTRA_OECMAKE += "-DCMAKE_MODULE_PATH=${S}/aws-c-common/cmake"
 EXTRA_OECMAKE += "-DCMAKE_PREFIX_PATH=$D/usr"
 EXTRA_OECMAKE += "-DCMAKE_INSTALL_PREFIX=$D/usr"
 EXTRA_OECMAKE += "-DCMAKE_BUILD_TYPE=Release"
+
+do_install:append() {
+	sed -i "s/BUILD_SHARED_LIBS/${BUILD_SHARED_LIBS}/" ${D}${libdir}/${BPN}/cmake/${BPN}-config.cmake
+}
 
 FILES:${PN}     = "${libdir}/lib${PN}.so.1.0.0"
 FILES:${PN}-dev = "${includedir}/aws/cal/* \

--- a/recipes-sdk/aws-c-common/aws-c-common_0.6.8.bb
+++ b/recipes-sdk/aws-c-common/aws-c-common_0.6.8.bb
@@ -16,13 +16,19 @@ SRC_URI = "git://github.com/awslabs/aws-c-common.git;branch=${BRANCH};tag=${TAG}
 
 S = "${WORKDIR}/git"
 
+BUILD_SHARED_LIBS = "ON"
+
 CFLAGS:append = " -Wl,-Bsymbolic"
 EXTRA_OECMAKE:append = " -DCMAKE_INSTALL_PREFIX=$D/usr"
 EXTRA_OECMAKE += "-DBUILD_TESTING=OFF"
-EXTRA_OECMAKE += "-DBUILD_SHARED_LIBS=ON"
+EXTRA_OECMAKE += "-DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}"
 EXTRA_OECMAKE += "-DCMAKE_BUILD_TYPE=Release"
 OECMAKE_BUILDPATH = "${WORKDIR}/build"
 OECMAKE_SOURCEPATH = "${S}"
+
+do_install:append() {
+	sed -i "s/BUILD_SHARED_LIBS/${BUILD_SHARED_LIBS}/" ${D}${libdir}/${BPN}/cmake/${BPN}-config.cmake
+}
 
 FILES:${PN}     = "${libdir}/lib${PN}.so.1.0.0 \
                    ${libdir}/lib${PN}.so.1"

--- a/recipes-sdk/aws-c-compression/aws-c-compression_0.2.14.bb
+++ b/recipes-sdk/aws-c-compression/aws-c-compression_0.2.14.bb
@@ -23,15 +23,21 @@ S = "${WORKDIR}/git"
 DEPENDS = "openssl s2n aws-c-common aws-c-cal aws-c-io"
 RDEPENDS:${PN} = "s2n aws-c-common aws-c-cal aws-c-io"
 
+BUILD_SHARED_LIBS = "ON"
+
 AWS_C_INSTALL = "$D/usr"
 OECMAKE_SOURCEPATH = "${S}/aws-c-compression"
 CFLAGS:append = " -Wl,-Bsymbolic"
 EXTRA_OECMAKE += "-DCMAKE_MODULE_PATH=${S}/aws-c-common/cmake"
 EXTRA_OECMAKE += "-DCMAKE_PREFIX_PATH=$D/usr"
 EXTRA_OECMAKE += "-DCMAKE_INSTALL_PREFIX=$D/usr"
-EXTRA_OECMAKE += "-DBUILD_SHARED_LIBS=ON"
+EXTRA_OECMAKE += "-DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}"
 OECMAKE_BUILDPATH += "${WORKDIR}/build"
 OECMAKE_SOURCEPATH += "${S}"
+
+do_install:append() {
+	sed -i "s/BUILD_SHARED_LIBS/${BUILD_SHARED_LIBS}/" ${D}${libdir}/${BPN}/cmake/${BPN}-config.cmake
+}
 
 FILES:${PN}     = "${libdir}/lib${PN}.so.1.0.0"
 FILES:${PN}-dev = "${includedir}/aws/compression/* \

--- a/recipes-sdk/aws-c-event-stream/aws-c-event-stream_0.2.7.bb
+++ b/recipes-sdk/aws-c-event-stream/aws-c-event-stream_0.2.7.bb
@@ -23,6 +23,8 @@ S = "${WORKDIR}/git"
 DEPENDS = "openssl s2n aws-c-common aws-checksums aws-c-io"
 RDEPENDS:${PN} = "s2n aws-c-common aws-checksums aws-c-io"
 
+BUILD_SHARED_LIBS = "ON"
+
 AWS_C_INSTALL = "$D/usr"
 OECMAKE_SOURCEPATH = "${S}/aws-c-event-stream"
 CFLAGS:append = " -Wl,-Bsymbolic"
@@ -31,9 +33,13 @@ EXTRA_OECMAKE += "-DBUILD_TESTING=OFF"
 EXTRA_OECMAKE += "-DCMAKE_MODULE_PATH=${S}/aws-c-common/cmake"
 EXTRA_OECMAKE += "-DCMAKE_PREFIX_PATH=$D/usr"
 EXTRA_OECMAKE += "-DCMAKE_INSTALL_PREFIX=$D/usr"
-EXTRA_OECMAKE += "-DBUILD_SHARED_LIBS=ON"
+EXTRA_OECMAKE += "-DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}"
 OECMAKE_BUILDPATH += "${WORKDIR}/build"
 OECMAKE_SOURCEPATH += "${S}"
+
+do_install:append() {
+	sed -i "s/BUILD_SHARED_LIBS/${BUILD_SHARED_LIBS}/" ${D}${libdir}/${BPN}/cmake/${BPN}-config.cmake
+}
 
 FILES:${PN}     = "${libdir}/lib${PN}.so.1.0.0"
 FILES:${PN}-dev = "${includedir}/aws/event-stream/* \

--- a/recipes-sdk/aws-c-http/aws-c-http_0.6.5.bb
+++ b/recipes-sdk/aws-c-http/aws-c-http_0.6.5.bb
@@ -23,6 +23,8 @@ S = "${WORKDIR}/git"
 DEPENDS = "openssl s2n aws-c-common aws-c-cal aws-c-io aws-c-compression"
 RDEPENDS:${PN} = "s2n aws-c-common aws-c-cal aws-c-io aws-c-compression"
 
+BUILD_SHARED_LIBS = "ON"
+
 AWS_C_INSTALL = "$D/usr"
 OECMAKE_SOURCEPATH = "${S}/aws-c-http"
 CFLAGS:append = " -Wl,-Bsymbolic"
@@ -32,9 +34,13 @@ EXTRA_OECMAKE += "-DCMAKE_MODULE_PATH=${S}/aws-c-common/cmake"
 EXTRA_OECMAKE += "-DCMAKE_PREFIX_PATH=$D/usr"
 EXTRA_OECMAKE += "-DCMAKE_INSTALL_PREFIX=$D/usr"
 EXTRA_OECMAKE += "-DCMAKE_BUILD_TYPE=Release"
-EXTRA_OECMAKE += "-DBUILD_SHARED_LIBS=ON"
+EXTRA_OECMAKE += "-DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}"
 OECMAKE_BUILDPATH += "${WORKDIR}/build"
 OECMAKE_SOURCEPATH += "${S}"
+
+do_install:append() {
+	sed -i "s/BUILD_SHARED_LIBS/${BUILD_SHARED_LIBS}/" ${D}${libdir}/${BPN}/cmake/${BPN}-config.cmake
+}
 
 FILES:${PN}     = "${libdir}/lib${PN}.so.1.0.0"
 FILES:${PN}-dev = "${includedir}/aws/http/* \

--- a/recipes-sdk/aws-c-io/aws-c-io_0.10.7.bb
+++ b/recipes-sdk/aws-c-io/aws-c-io_0.10.7.bb
@@ -23,15 +23,21 @@ S = "${WORKDIR}/git"
 DEPENDS = "openssl s2n aws-c-common aws-c-cal"
 RDEPENDS:${PN} = "s2n aws-c-common aws-c-cal"
 
+BUILD_SHARED_LIBS = "ON"
+
 AWS_C_INSTALL = "$D/usr"
 OECMAKE_SOURCEPATH = "${S}/aws-c-io"
 CFLAGS:append = " -Wl,-Bsymbolic"
 EXTRA_OECMAKE += "-DCMAKE_MODULE_PATH=${S}/aws-c-common/cmake"
 EXTRA_OECMAKE += "-DCMAKE_PREFIX_PATH=$D/usr"
 EXTRA_OECMAKE += "-DCMAKE_INSTALL_PREFIX=$D/usr"
-EXTRA_OECMAKE += "-DBUILD_SHARED_LIBS=ON"
+EXTRA_OECMAKE += "-DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}"
 OECMAKE_BUILDPATH += "${WORKDIR}/build"
 OECMAKE_SOURCEPATH += "${S}"
+
+do_install:append() {
+	sed -i "s/BUILD_SHARED_LIBS/${BUILD_SHARED_LIBS}/" ${D}${libdir}/${BPN}/cmake/${BPN}-config.cmake
+}
 
 FILES:${PN}     = "${libdir}/lib${PN}.so.1.0.0"
 FILES:${PN}-dev = "${includedir}/aws/io/* \

--- a/recipes-sdk/aws-c-iot/aws-c-iot_0.0.7.bb
+++ b/recipes-sdk/aws-c-iot/aws-c-iot_0.0.7.bb
@@ -23,13 +23,19 @@ S = "${WORKDIR}/git"
 DEPENDS = "aws-crt-cpp"
 RDEPENDS:${PN} = "aws-crt-cpp"
 
+BUILD_SHARED_LIBS = "ON"
+
 OECMAKE_SOURCEPATH = "${S}/aws-c-iot"
 CFLAGS:append = " -Wl,-Bsymbolic"
 EXTRA_OECMAKE += "-DCMAKE_MODULE_PATH=${S}/aws-c-common/cmake"
 EXTRA_OECMAKE += "-DCMAKE_PREFIX_PATH=$D/usr"
 EXTRA_OECMAKE += "-DCMAKE_INSTALL_PREFIX=$D/usr"
-EXTRA_OECMAKE += "-DBUILD_SHARED_LIBS=ON"
+EXTRA_OECMAKE += "-DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}"
 OECMAKE_BUILDPATH += "${WORKDIR}/build"
+
+do_install:append() {
+	sed -i "s/BUILD_SHARED_LIBS/${BUILD_SHARED_LIBS}/" ${D}${libdir}/${BPN}/cmake/${BPN}-config.cmake
+}
 
 FILES:${PN}     = "${libdir}/lib${PN}.so.1.0.0 \
                    ${libdir}/lib${PN}.so.0unstable"

--- a/recipes-sdk/aws-c-mqtt/aws-c-mqtt_0.7.6.bb
+++ b/recipes-sdk/aws-c-mqtt/aws-c-mqtt_0.7.6.bb
@@ -23,6 +23,8 @@ S = "${WORKDIR}/git"
 DEPENDS = "openssl s2n aws-c-common aws-c-cal aws-c-io aws-c-compression aws-c-http"
 RDEPENDS:${PN} = "s2n aws-c-common aws-c-cal aws-c-io aws-c-compression aws-c-http"
 
+BUILD_SHARED_LIBS = "ON"
+
 OECMAKE_SOURCEPATH = "${S}/aws-c-mqtt"
 CFLAGS:append = " -Wl,-Bsymbolic"
 EXTRA_OECMAKE += "-DBUILD_TEST_DEPS=OFF"
@@ -30,9 +32,13 @@ EXTRA_OECMAKE += "-DBUILD_TESTING=OFF"
 EXTRA_OECMAKE += "-DCMAKE_MODULE_PATH=${S}/aws-c-common/cmake"
 EXTRA_OECMAKE += "-DCMAKE_PREFIX_PATH=$D/usr"
 EXTRA_OECMAKE += "-DCMAKE_INSTALL_PREFIX=$D/usr"
-EXTRA_OECMAKE += "-DBUILD_SHARED_LIBS=ON"
+EXTRA_OECMAKE += "-DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}"
 OECMAKE_BUILDPATH += "${WORKDIR}/build"
 OECMAKE_SOURCEPATH += "${S}"
+
+do_install:append() {
+	sed -i "s/BUILD_SHARED_LIBS/${BUILD_SHARED_LIBS}/" ${D}${libdir}/${BPN}/cmake/${BPN}-config.cmake
+}
 
 FILES:${PN}     = "${libdir}/lib${PN}.so.1.0.0"
 FILES:${PN}-dev = "${includedir}/aws/mqtt/* \

--- a/recipes-sdk/aws-c-s3/aws-c-s3_0.1.23.bb
+++ b/recipes-sdk/aws-c-s3/aws-c-s3_0.1.23.bb
@@ -25,15 +25,20 @@ RDEPENDS:${PN} = "aws-c-auth aws-c-http"
 
 CFLAGS:append = " -Wl,-Bsymbolic"
 
+BUILD_SHARED_LIBS = "ON"
+
 OECMAKE_SOURCEPATH = "${S}/aws-c-s3"
 EXTRA_OECMAKE += "-DBUILD_TESTING=OFF"
 EXTRA_OECMAKE += "-DCMAKE_MODULE_PATH=${S}/aws-c-common/cmake"
 EXTRA_OECMAKE += "-DCMAKE_PREFIX_PATH=$D/usr"
 EXTRA_OECMAKE += "-DCMAKE_INSTALL_PREFIX=$D/usr"
-EXTRA_OECMAKE += "-DBUILD_SHARED_LIBS=ON"
+EXTRA_OECMAKE += "-DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}"
 OECMAKE_BUILDPATH += "${WORKDIR}/build"
 OECMAKE_SOURCEPATH += "${S}"
 
+do_install:append() {
+	sed -i "s/BUILD_SHARED_LIBS/${BUILD_SHARED_LIBS}/" ${D}${libdir}/${BPN}/cmake/${BPN}-config.cmake
+}
 
 FILES:${PN}     = "${libdir}/lib${PN}.so.1.0.0 \
                    ${libdir}/lib${PN}.so.0unstable"

--- a/recipes-sdk/aws-checksums/aws-checksums_0.1.11.bb
+++ b/recipes-sdk/aws-checksums/aws-checksums_0.1.11.bb
@@ -24,6 +24,8 @@ S = "${WORKDIR}/git"
 DEPENDS = "openssl s2n aws-c-common"
 RDEPENDS:${PN} = "s2n aws-c-common"
 
+BUILD_SHARED_LIBS = "ON"
+
 AWS_C_INSTALL = "$D/usr"
 OECMAKE_SOURCEPATH = "${S}/aws-checksums"
 CFLAGS:append = " -Wl,-Bsymbolic"
@@ -33,9 +35,13 @@ EXTRA_OECMAKE += "-DCMAKE_MODULE_PATH=${S}/aws-c-common/cmake"
 EXTRA_OECMAKE += "-DCMAKE_PREFIX_PATH=$D/usr"
 EXTRA_OECMAKE += "-DCMAKE_INSTALL_PREFIX=$D/usr"
 EXTRA_OECMAKE += "-DCMAKE_BUILD_TYPE=Release"
-EXTRA_OECMAKE += "-DBUILD_SHARED_LIBS=ON"
+EXTRA_OECMAKE += "-DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}"
 OECMAKE_BUILDPATH += "${WORKDIR}/build"
 OECMAKE_SOURCEPATH += "${S}"
+
+do_install:append() {
+	sed -i "s/BUILD_SHARED_LIBS/${BUILD_SHARED_LIBS}/" ${D}${libdir}/${BPN}/cmake/${BPN}-config.cmake
+}
 
 FILES:${PN}     = "${libdir}/lib${PN}.so.1.0.0"
 FILES:${PN}-dev = "${includedir}/aws/checksums/* \

--- a/recipes-sdk/aws-crt-cpp/aws-crt-cpp_0.15.0.bb
+++ b/recipes-sdk/aws-crt-cpp/aws-crt-cpp_0.15.0.bb
@@ -36,15 +36,21 @@ PREFERRED_VERSION_s2n = "1.0.13"
 DEPENDS = "s2n aws-c-common aws-c-io aws-c-mqtt aws-c-auth aws-c-http aws-checksums aws-c-event-stream aws-c-s3 aws-lc"
 RDEPENDS:${PN} = "s2n aws-c-common"
 
+BUILD_SHARED_LIBS = "ON"
+
 CFLAGS:append = " -Wl,-Bsymbolic"
 EXTRA_OECMAKE += "-DCMAKE_MODULE_PATH=${S}/aws-c-common/cmake"
 EXTRA_OECMAKE += "-DCMAKE_PREFIX_PATH=$D/usr"
 EXTRA_OECMAKE += "-DCMAKE_INSTALL_PREFIX=$D/usr"
 EXTRA_OECMAKE += "-DCMAKE_BUILD_TYPE=Release"
 EXTRA_OECMAKE += "-DBUILD_DEPS=OFF"
-EXTRA_OECMAKE += "-DBUILD_SHARED_LIBS=ON"
+EXTRA_OECMAKE += "-DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}"
 OECMAKE_BUILDPATH += "${WORKDIR}/build"
 OECMAKE_SOURCEPATH += "${S}/aws-crt-cpp"
+
+do_install:append() {
+	sed -i "s/BUILD_SHARED_LIBS/${BUILD_SHARED_LIBS}/" ${D}${libdir}/${BPN}/cmake/${BPN}-config.cmake
+}
 
 FILES:${PN} += "${libdir}/libaws-crt-cpp.so"
 FILES:${PN}-dev = "${includedir}/aws/crt/* \

--- a/recipes-sdk/aws-iot-device-sdk-cpp-v2/aws-iot-device-sdk-cpp-v2_1.14.1.bb
+++ b/recipes-sdk/aws-iot-device-sdk-cpp-v2/aws-iot-device-sdk-cpp-v2_1.14.1.bb
@@ -25,12 +25,26 @@ CFLAGS:append = " -Wl,-Bsymbolic"
 OECMAKE_BUILDPATH += "${WORKDIR}/build"
 OECMAKE_SOURCEPATH += "${S}/aws-iot-device-sdk-cpp-v2"
 
+BUILD_SHARED_LIBS = "ON"
+
 EXTRA_OECMAKE += "-DCMAKE_MODULE_PATH=${S}/aws-c-common/cmake"
 EXTRA_OECMAKE += "-DBUILD_DEPS=OFF"
 EXTRA_OECMAKE += "-DBUILD_TESTING=OFF"
-EXTRA_OECMAKE += "-DBUILD_SHARED_LIBS=ON"
+EXTRA_OECMAKE += "-DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}"
 EXTRA_OECMAKE += "-DCMAKE_BUILD_TYPE=Release"
 EXTRA_OECMAKE += "-DCMAKE_INSTALL_PREFIX=$D/usr"
+
+do_install:append() {
+	sed -i "s/BUILD_SHARED_LIBS/${BUILD_SHARED_LIBS}/" ${D}${libdir}/GreengrassIpc-cpp/cmake/greengrassipc-cpp-config.cmake
+	sed -i "s/BUILD_SHARED_LIBS/${BUILD_SHARED_LIBS}/" ${D}${libdir}/IotDeviceDefender-cpp/cmake/iotdevicedefender-cpp-config.cmake
+	sed -i "s/BUILD_SHARED_LIBS/${BUILD_SHARED_LIBS}/" ${D}${libdir}/IotShadow-cpp/cmake/iotshadow-cpp-config.cmake
+	sed -i "s/BUILD_SHARED_LIBS/${BUILD_SHARED_LIBS}/" ${D}${libdir}/Discovery-cpp/cmake/discovery-cpp-config.cmake
+	sed -i "s/BUILD_SHARED_LIBS/${BUILD_SHARED_LIBS}/" ${D}${libdir}/IotDeviceCommon-cpp/cmake/iotdevicecommon-cpp-config.cmake
+	sed -i "s/BUILD_SHARED_LIBS/${BUILD_SHARED_LIBS}/" ${D}${libdir}/IotIdentity-cpp/cmake/iotidentity-cpp-config.cmake
+	sed -i "s/BUILD_SHARED_LIBS/${BUILD_SHARED_LIBS}/" ${D}${libdir}/IotSecureTunneling-cpp/cmake/iotsecuretunneling-cpp-config.cmake
+	sed -i "s/BUILD_SHARED_LIBS/${BUILD_SHARED_LIBS}/" ${D}${libdir}/EventstreamRpc-cpp/cmake/eventstreamrpc-cpp-config.cmake
+	sed -i "s/BUILD_SHARED_LIBS/${BUILD_SHARED_LIBS}/" ${D}${libdir}/IotJobs-cpp/cmake/iotjobs-cpp-config.cmake
+}
 
 FILES:${PN}     = "${libdir}/*.so \
                    ${libdir}/lib${PN}.so.0unstable"

--- a/recipes-sdk/aws-lc/aws-lc_0.0.1.bb
+++ b/recipes-sdk/aws-lc/aws-lc_0.0.1.bb
@@ -24,11 +24,19 @@ EXTRA_OECMAKE += "-DBUILD_TESTING=OFF"
 EXTRA_OECMAKE += "-DDISABLE_PERL=ON"
 EXTRA_OECMAKE += "-DDISABLE_GO=ON"
 
+BUILD_SHARED_LIBS = "ON"
+
 EXTRA_OECMAKE += "-DCMAKE_PREFIX_PATH=$D/usr/lib/aws-lc"
 EXTRA_OECMAKE += "-DCMAKE_INSTALL_PREFIX=$D/usr/lib/aws-lc"
-EXTRA_OECMAKE += "-DBUILD_SHARED_LIBS=ON"
+EXTRA_OECMAKE += "-DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}"
 OECMAKE_BUILDPATH += "${WORKDIR}/build"
 OECMAKE_SOURCEPATH += "${S}"
+
+do_install:append() {
+	sed -i "s/BUILD_SHARED_LIBS/${BUILD_SHARED_LIBS}/" ${D}${libdir}/${BPN}/lib/ssl/cmake/ssl-config.cmake
+	sed -i "s/BUILD_SHARED_LIBS/${BUILD_SHARED_LIBS}/" ${D}${libdir}/${BPN}/lib/AWSLC/cmake/awslc-config.cmake
+	sed -i "s/BUILD_SHARED_LIBS/${BUILD_SHARED_LIBS}/" ${D}${libdir}/${BPN}/lib/crypto/cmake/crypto-config.cmake
+}
 
 FILES:${PN}     = "${libdir}/aws-lc/lib/libssl.so \
                    ${libdir}/aws-lc/lib/libcrypto.so \

--- a/recipes-sdk/s2n/s2n_1.0.13.bb
+++ b/recipes-sdk/s2n/s2n_1.0.13.bb
@@ -20,10 +20,12 @@ S= "${WORKDIR}/git"
 DEPENDS = "openssl"
 CFLAGS:append = " -Wl,-Bsymbolic"
 
+BUILD_SHARED_LIBS = "ON"
+
 EXTRA_OECMAKE += "-DBUILD_TESTING=OFF"
 EXTRA_OECMAKE += "-DCMAKE_BUILD_TYPE=Release"
 EXTRA_OECMAKE += "-DCMAKE_INSTALL_PREFIX=$D/usr"
-EXTRA_OECMAKE += "-DBUILD_SHARED_LIBS=ON"
+EXTRA_OECMAKE += "-DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}"
 # Fix "doesn't have GNU_HASH (didn't pass LDFLAGS?)" issue
 TARGET_CC_ARCH += "${LDFLAGS}"
 
@@ -31,6 +33,10 @@ TARGET_CC_ARCH += "${LDFLAGS}"
 EXTRA_OECMAKE += "-DUNSAFE_TREAT_WARNINGS_AS_ERRORS=OFF"
 OECMAKE_BUILDPATH += "${WORKDIR}/build"
 OECMAKE_SOURCEPATH += "${S}"
+
+do_install:append() {
+	sed -i "s/BUILD_SHARED_LIBS/${BUILD_SHARED_LIBS}/" ${D}${libdir}/${BPN}/cmake/${BPN}-config.cmake
+}
 
 FILES:${PN} += "${libdir}/libs2n.so"
 


### PR DESCRIPTION
BUILD_SHARED_LIBS controls how AWS SDK libraries get built and packaged.
Since BUILD_SHARED_LIBS defaults to ON during build, the resulting binary
packages only contain dynamic libraries. That means a condifion on this
variable in the corresponding cmake file in the binary package makes no
sense. Moreover, if another component that uses AWS SDK libraries sets its
BUILD_SHARED_LIBS variable to OFF, it will fail as there are no static
AWS SDK libs provided.

Fixes: https://github.com/aws/meta-aws/issues/178

Signed-off-by: Denys Dmytriyenko <denis@denix.org>
