### PR TITLE
neo-ai-dlr, python3-timeloop, greengrass-bin, aws-crt-python, aws-iot…

### DIFF
--- a/recipes-devtools/amazon-sagemaker-neo/neo-ai-dlr_1.10.0.bb
+++ b/recipes-devtools/amazon-sagemaker-neo/neo-ai-dlr_1.10.0.bb
@@ -107,7 +107,7 @@ PACKAGES =+ "${PN}-tests"
 FILES:${PN}-tests = "${datadir}/dlr/tests"
 RDEPENDS:${PN}-tests += "${PN}"
 DEPENDS += "googletest python3-setuptools"
-RDEPENDS:${PN} += "python3 python3-shell python3-requests python3-distro python3-numpy"
+RDEPENDS:${PN} += "python3-core python3-shell python3-requests python3-distro python3-numpy"
 
 # Versioned libs are not produced
 FILES_SOLIBSDEV = ""

--- a/recipes-devtools/amazon-sagemaker-neo/neo-ai-dlr_1.7.0.bb
+++ b/recipes-devtools/amazon-sagemaker-neo/neo-ai-dlr_1.7.0.bb
@@ -92,7 +92,7 @@ PACKAGES =+ "${PN}-tests"
 FILES:${PN}-tests = "${datadir}/dlr/tests"
 RDEPENDS:${PN}-tests += "${PN}"
 DEPENDS += "googletest python3-setuptools"
-RDEPENDS:${PN} += "python3 python3-shell python3-requests python3-distro python3-numpy"
+RDEPENDS:${PN} += "python3-core python3-shell python3-requests python3-distro python3-numpy"
 
 # Versioned libs are not produced
 FILES_SOLIBSDEV = ""

--- a/recipes-external/python3-timeloop/python3-timeloop_1.0.2.bb
+++ b/recipes-external/python3-timeloop/python3-timeloop_1.0.2.bb
@@ -12,5 +12,5 @@ SRCREV = "36ec5cbb133a6dcfb5316f59b5e11765c14e62c2"
 
 S = "${WORKDIR}/git"
 
-RDEPENDS:${PN} += "python3"
+RDEPENDS:${PN} += "python3-core"
 

--- a/recipes-iot/aws-iot-greengrass/greengrass-bin_2.0.3.bb
+++ b/recipes-iot/aws-iot-greengrass/greengrass-bin_2.0.3.bb
@@ -18,7 +18,7 @@ SRC_URI[license.sha256sum] = "09e8a9bcec8067104652c168685ab0931e7868f9c8284b66f5
 
 GG_USESYSTEMD = "${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'yes', 'no', d)}"
 RDEPENDS:${PN} += "${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'ntp-systemd', '', d)}"
-RDEPENDS:${PN} += "corretto-11-bin ca-certificates python3 python3-json python3-numbers sudo"
+RDEPENDS:${PN} += "corretto-11-bin ca-certificates python3-core python3-json python3-numbers sudo"
 
 do_configure[noexec] = "1"
 do_compile[noexec]   = "1"

--- a/recipes-iot/aws-iot-greengrass/greengrass-bin_2.1.0.bb
+++ b/recipes-iot/aws-iot-greengrass/greengrass-bin_2.1.0.bb
@@ -18,7 +18,7 @@ SRC_URI[license.sha256sum] = "09e8a9bcec8067104652c168685ab0931e7868f9c8284b66f5
 
 GG_USESYSTEMD = "${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'yes', 'no', d)}"
 RDEPENDS:${PN} += "${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'ntp-systemd', '', d)}"
-RDEPENDS:${PN} += "corretto-11-bin ca-certificates python3 python3-json python3-numbers sudo"
+RDEPENDS:${PN} += "corretto-11-bin ca-certificates python3-core python3-json python3-numbers sudo"
 
 do_configure[noexec] = "1"
 do_compile[noexec]   = "1"

--- a/recipes-iot/aws-iot-greengrass/greengrass-bin_2.2.0.bb
+++ b/recipes-iot/aws-iot-greengrass/greengrass-bin_2.2.0.bb
@@ -18,7 +18,7 @@ SRC_URI[license.sha256sum] = "09e8a9bcec8067104652c168685ab0931e7868f9c8284b66f5
 
 GG_USESYSTEMD = "${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'yes', 'no', d)}"
 RDEPENDS:${PN} += "${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'ntp-systemd', '', d)}"
-RDEPENDS:${PN} += "corretto-11-bin ca-certificates python3 python3-json python3-numbers sudo"
+RDEPENDS:${PN} += "corretto-11-bin ca-certificates python3-core python3-json python3-numbers sudo"
 
 do_configure[noexec] = "1"
 do_compile[noexec]   = "1"

--- a/recipes-iot/aws-iot-greengrass/greengrass-bin_2.3.0.bb
+++ b/recipes-iot/aws-iot-greengrass/greengrass-bin_2.3.0.bb
@@ -18,7 +18,7 @@ SRC_URI[license.sha256sum] = "09e8a9bcec8067104652c168685ab0931e7868f9c8284b66f5
 
 GG_USESYSTEMD = "${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'yes', 'no', d)}"
 RDEPENDS:${PN} += "${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'ntp-systemd', '', d)}"
-RDEPENDS:${PN} += "corretto-11-bin ca-certificates python3 python3-json python3-numbers sudo"
+RDEPENDS:${PN} += "corretto-11-bin ca-certificates python3-core python3-json python3-numbers sudo"
 
 do_configure[noexec] = "1"
 do_compile[noexec]   = "1"

--- a/recipes-iot/aws-iot-greengrass/greengrass-bin_2.4.0.bb
+++ b/recipes-iot/aws-iot-greengrass/greengrass-bin_2.4.0.bb
@@ -18,7 +18,7 @@ SRC_URI[license.sha256sum] = "09e8a9bcec8067104652c168685ab0931e7868f9c8284b66f5
 
 GG_USESYSTEMD = "${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'yes', 'no', d)}"
 RDEPENDS:${PN} += "${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'ntp-systemd', '', d)}"
-RDEPENDS:${PN} += "corretto-11-bin ca-certificates python3 python3-json python3-numbers sudo"
+RDEPENDS:${PN} += "corretto-11-bin ca-certificates python3-core python3-json python3-numbers sudo"
 
 do_configure[noexec] = "1"
 do_compile[noexec]   = "1"

--- a/recipes-sdk/aws-crt-python/aws-crt-python.inc
+++ b/recipes-sdk/aws-crt-python/aws-crt-python.inc
@@ -12,5 +12,5 @@ do_configure:prepend() {
 }
 
 DEPENDS += "cmake-native ${PYTHON_PN}-setuptools-native"
-RDEPENDS:${PN} = "python3"
+RDEPENDS:${PN} = "python3-core"
 CFLAGS:append = " -Wl,-Bsymbolic"

--- a/recipes-sdk/aws-crt-python/aws-crt-python_0.12.1.bb
+++ b/recipes-sdk/aws-crt-python/aws-crt-python_0.12.1.bb
@@ -22,5 +22,5 @@ PKGV = "0.12.1"
 
 AWS_C_INSTALL = "${D}/usr/lib;${S}/source"
 DEPENDS += "cmake-native ${PYTHON_PN}-setuptools-native s2n aws-c-common aws-c-io aws-c-mqtt aws-c-auth aws-c-http aws-checksums aws-c-event-stream aws-c-s3"
-RDEPENDS:${PN} = "python3 s2n aws-c-common aws-c-io aws-c-mqtt aws-c-auth aws-c-http aws-checksums aws-c-event-stream"
+RDEPENDS:${PN} = "python3-core s2n aws-c-common aws-c-io aws-c-mqtt aws-c-auth aws-c-http aws-checksums aws-c-event-stream"
 CFLAGS:append = " -Wl,-Bsymbolic"

--- a/recipes-sdk/aws-iot-device-sdk-python-v2/aws-iot-device-sdk-python-v2_1.5.4.bb
+++ b/recipes-sdk/aws-iot-device-sdk-python-v2/aws-iot-device-sdk-python-v2_1.5.4.bb
@@ -19,4 +19,4 @@ SRCREV = "a7739a6f980292ae146e064b18f3f2723019261e"
 
 S = "${WORKDIR}/git"
 
-RDEPENDS:${PN} += "python3 aws-crt-python"
+RDEPENDS:${PN} += "python3-core aws-crt-python"

--- a/recipes-sdk/aws-iot-device-sdk-python-v2/aws-iot-device-sdk-python-v2_1.7.0.bb
+++ b/recipes-sdk/aws-iot-device-sdk-python-v2/aws-iot-device-sdk-python-v2_1.7.0.bb
@@ -19,4 +19,4 @@ SRCREV = "5aef82573202309063eb540b72cee0e565f85a2d"
 
 S = "${WORKDIR}/git"
 
-RDEPENDS:${PN} += "python3 aws-crt-python"
+RDEPENDS:${PN} += "python3-core aws-crt-python"


### PR DESCRIPTION
…-device-sdk: replace RDEPENDS python by python-core

because RDEPENDS python will install a whole python into the image, python-core only core modules
fix https://github.com/aws4embeddedlinux/meta-aws/issues/305