### PR TITLE
backport: neo-ai-dlr, python3-timeloop, greengrass-bin, aws-crt-pytho…

### DIFF
--- a/recipes-devtools/amazon-sagemaker-neo/neo-ai-dlr_1.7.0.bb
+++ b/recipes-devtools/amazon-sagemaker-neo/neo-ai-dlr_1.7.0.bb
@@ -93,9 +93,10 @@ do_install() {
 }
 
 PACKAGES =+ "${PN}-tests"
-FILES_${PN}-tests = "${datadir}/dlr/tests"
-RDEPENDS_${PN}-tests += "${PN}"
-DEPENDS += "googletest python3-setuptools python3-distro"
+FILES:${PN}-tests = "${datadir}/dlr/tests"
+RDEPENDS:${PN}-tests += "${PN}"
+DEPENDS += "googletest python3-setuptools"
+RDEPENDS:${PN} += "python3-core python3-shell python3-requests python3-distro python3-numpy"
 
 # Versioned libs are not produced
 FILES_SOLIBSDEV = ""

--- a/recipes-iot/aws-iot-greengrass/greengrass-bin_2.0.3.bb
+++ b/recipes-iot/aws-iot-greengrass/greengrass-bin_2.0.3.bb
@@ -16,8 +16,8 @@ SRC_URI[license.md5sum]    = "34400b68072d710fecd0a2940a0d1658"
 SRC_URI[license.sha256sum] = "09e8a9bcec8067104652c168685ab0931e7868f9c8284b66f5ae6edae5f1130b"
 
 GG_USESYSTEMD = "${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'yes', 'no', d)}"
-RDEPENDS_${PN} += "${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'ntp-systemd', '', d)}"
-RDEPENDS_${PN} += "corretto-11-bin ca-certificates python3 python3-json python3-numbers"
+RDEPENDS:${PN} += "${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'ntp-systemd', '', d)}"
+RDEPENDS:${PN} += "corretto-11-bin ca-certificates python3-core python3-json python3-numbers sudo"
 
 do_configure[noexec] = "1"
 do_compile[noexec]   = "1"

--- a/recipes-iot/aws-iot-greengrass/greengrass-bin_2.1.0.bb
+++ b/recipes-iot/aws-iot-greengrass/greengrass-bin_2.1.0.bb
@@ -17,8 +17,8 @@ SRC_URI[license.md5sum]    = "34400b68072d710fecd0a2940a0d1658"
 SRC_URI[license.sha256sum] = "09e8a9bcec8067104652c168685ab0931e7868f9c8284b66f5ae6edae5f1130b"
 
 GG_USESYSTEMD = "${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'yes', 'no', d)}"
-RDEPENDS_${PN} += "${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'ntp-systemd', '', d)}"
-RDEPENDS_${PN} += "corretto-11-bin ca-certificates python3 python3-json python3-numbers sudo"
+RDEPENDS:${PN} += "${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'ntp-systemd', '', d)}"
+RDEPENDS:${PN} += "corretto-11-bin ca-certificates python3-core python3-json python3-numbers sudo"
 
 do_configure[noexec] = "1"
 do_compile[noexec]   = "1"

--- a/recipes-iot/aws-iot-greengrass/greengrass-bin_2.2.0.bb
+++ b/recipes-iot/aws-iot-greengrass/greengrass-bin_2.2.0.bb
@@ -17,8 +17,8 @@ SRC_URI[license.md5sum]    = "34400b68072d710fecd0a2940a0d1658"
 SRC_URI[license.sha256sum] = "09e8a9bcec8067104652c168685ab0931e7868f9c8284b66f5ae6edae5f1130b"
 
 GG_USESYSTEMD = "${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'yes', 'no', d)}"
-RDEPENDS_${PN} += "${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'ntp-systemd', '', d)}"
-RDEPENDS_${PN} += "corretto-11-bin ca-certificates python3 python3-json python3-numbers sudo"
+RDEPENDS:${PN} += "${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'ntp-systemd', '', d)}"
+RDEPENDS:${PN} += "corretto-11-bin ca-certificates python3-core python3-json python3-numbers sudo"
 
 do_configure[noexec] = "1"
 do_compile[noexec]   = "1"

--- a/recipes-iot/aws-iot-greengrass/greengrass-bin_2.3.0.bb
+++ b/recipes-iot/aws-iot-greengrass/greengrass-bin_2.3.0.bb
@@ -17,8 +17,8 @@ SRC_URI[license.md5sum]    = "34400b68072d710fecd0a2940a0d1658"
 SRC_URI[license.sha256sum] = "09e8a9bcec8067104652c168685ab0931e7868f9c8284b66f5ae6edae5f1130b"
 
 GG_USESYSTEMD = "${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'yes', 'no', d)}"
-RDEPENDS_${PN} += "${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'ntp-systemd', '', d)}"
-RDEPENDS_${PN} += "corretto-11-bin ca-certificates python3 python3-json python3-numbers sudo"
+RDEPENDS:${PN} += "${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'ntp-systemd', '', d)}"
+RDEPENDS:${PN} += "corretto-11-bin ca-certificates python3-core python3-json python3-numbers sudo"
 
 do_configure[noexec] = "1"
 do_compile[noexec]   = "1"

--- a/recipes-iot/aws-iot-greengrass/greengrass-bin_2.4.0.bb
+++ b/recipes-iot/aws-iot-greengrass/greengrass-bin_2.4.0.bb
@@ -17,8 +17,8 @@ SRC_URI[license.md5sum]    = "34400b68072d710fecd0a2940a0d1658"
 SRC_URI[license.sha256sum] = "09e8a9bcec8067104652c168685ab0931e7868f9c8284b66f5ae6edae5f1130b"
 
 GG_USESYSTEMD = "${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'yes', 'no', d)}"
-RDEPENDS_${PN} += "${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'ntp-systemd', '', d)}"
-RDEPENDS_${PN} += "corretto-11-bin ca-certificates python3 python3-json python3-numbers sudo"
+RDEPENDS:${PN} += "${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'ntp-systemd', '', d)}"
+RDEPENDS:${PN} += "corretto-11-bin ca-certificates python3-core python3-json python3-numbers sudo"
 
 do_configure[noexec] = "1"
 do_compile[noexec]   = "1"

--- a/recipes-sdk/aws-crt-python/aws-crt-python.inc
+++ b/recipes-sdk/aws-crt-python/aws-crt-python.inc
@@ -11,5 +11,5 @@ do_configure_prepend() {
 }
 
 DEPENDS += "cmake-native ${PYTHON_PN}-setuptools-native"
-RDEPENDS_${PN} = "python3"
-CFLAGS_append = " -Wl,-Bsymbolic"
+RDEPENDS:${PN} = "python3-core"
+CFLAGS:append = " -Wl,-Bsymbolic"

--- a/recipes-sdk/aws-crt-python/aws-crt-python_0.12.1.bb
+++ b/recipes-sdk/aws-crt-python/aws-crt-python_0.12.1.bb
@@ -18,5 +18,5 @@ inherit setuptools3
 
 AWS_C_INSTALL = "${D}/usr/lib;${S}/source"
 DEPENDS += "cmake-native ${PYTHON_PN}-setuptools-native s2n aws-c-common aws-c-io aws-c-mqtt aws-c-auth aws-c-http aws-checksums aws-c-event-stream aws-c-s3"
-RDEPENDS_${PN} = "python3 s2n aws-c-common aws-c-io aws-c-mqtt aws-c-auth aws-c-http aws-checksums aws-c-event-stream"
+RDEPENDS:${PN} = "python3-core s2n aws-c-common aws-c-io aws-c-mqtt aws-c-auth aws-c-http aws-checksums aws-c-event-stream"
 CFLAGS:append = " -Wl,-Bsymbolic"

--- a/recipes-sdk/aws-iot-device-sdk-python-v2/aws-iot-device-sdk-python-v2_1.5.4.bb
+++ b/recipes-sdk/aws-iot-device-sdk-python-v2/aws-iot-device-sdk-python-v2_1.5.4.bb
@@ -18,4 +18,4 @@ do_configure_append() {
   sed --in-place -E "s/version='.+'/version='${PV}'/" ${S}/setup.py
 }
 
-RDEPENDS_${PN} += "python3 aws-crt-python"
+RDEPENDS_${PN} += "python3-core aws-crt-python"

--- a/recipes-sdk/aws-iot-device-sdk-python-v2/aws-iot-device-sdk-python-v2_1.7.0.bb
+++ b/recipes-sdk/aws-iot-device-sdk-python-v2/aws-iot-device-sdk-python-v2_1.7.0.bb
@@ -14,4 +14,4 @@ SRCREV = "5aef82573202309063eb540b72cee0e565f85a2d"
 
 S = "${WORKDIR}/git"
 
-RDEPENDS_${PN} += "python3 aws-crt-python"
+RDEPENDS:${PN} += "python3-core aws-crt-python"


### PR DESCRIPTION
…n, aws-iot-device-sdk: replace RDEPENDS python by python-core

because RDEPENDS python will install a whole python into the image, python-core only core modules
fix https://github.com/aws4embeddedlinux/meta-aws/issues/305