### PR TITLE
aws-crt-python, aws-lc: fix for arch arm

### DIFF
--- a/recipes-sdk/aws-crt-python/aws-crt-python_0.13.11.bb
+++ b/recipes-sdk/aws-crt-python/aws-crt-python_0.13.11.bb
@@ -5,33 +5,22 @@ HOMEPAGE = "https://github.com/awslabs/aws-crt-python"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
-BRANCH ?= "main"
-SRC_URI = "gitsm://github.com/awslabs/aws-crt-python.git;protocol=https;branch=${BRANCH} \
-           file://fix-library-suffix.patch \
-"
+# note: this software build its depending libraries such as aws-lc in do_compile step, but finally links to the libs specified by DEPENDS!
+# the 0002-disable-building-of-depending-libs.patch disable this behaviour, therefore it's not necessary to checkout the submodules (git:// instead of gitsm://)
 
+BRANCH ?= "main"
+SRC_URI = "git://github.com/awslabs/aws-crt-python.git;protocol=https;branch=${BRANCH} \
+           file://0001-fix-library-suffix.patch \
+           file://0002-disable-building-of-depending-libs.patch \
+           "
 SRCREV = "555e2b802f295ea93eab6e5d8d19a91744b7e72c"
 UPSTREAM_CHECK_GITTAGREGEX = "v(?P<pver>.*)"
 
 S = "${WORKDIR}/git"
 
-inherit setuptools3
-
+inherit setuptools3_legacy
 
 AWS_C_INSTALL = "${D}/usr/lib;${S}/source"
-DEPENDS += "cmake-native ${PYTHON_PN}-setuptools-native s2n aws-c-common aws-c-io aws-c-mqtt aws-c-auth aws-c-http aws-checksums aws-c-event-stream aws-c-s3 aws-lc"
+DEPENDS += "cmake-native ${PYTHON_PN}-setuptools-native s2n aws-c-common aws-c-io aws-c-mqtt aws-c-auth aws-c-http aws-checksums aws-c-event-stream aws-c-s3 aws-c-sdkutils"
 RDEPENDS:${PN} = "python3-core s2n aws-c-common aws-c-io aws-c-mqtt aws-c-auth aws-c-http aws-checksums aws-c-event-stream"
 CFLAGS:append = " -Wl,-Bsymbolic"
-
-# -Werror will cause similiar issue as here: https://github.com/awslabs/aws-lc/issues/487
-# and a compile note is shown
-# ...but Currently, GCC 12.1.0 is not supported due to a memcmp related bug reported
-# in https://gcc.gnu.org/bugzilla/show_bug.cgi?id=95189.
-# We strongly recommend against using the GCC 12.1.0 compiler.
-
-# suppressing errors
-CFLAGS:append = " -Wno-array-bounds  -Wno-stringop-overflow"
-
-# and set as suggested
-# MEMCMP_INVALID_STRIPPED', and compile_flags '-O2 -g -DNDEBUG'
-CFLAGS:append = " -DMEMCMP_INVALID_STRIPPED -O2 -g -DNDEBUG"

--- a/recipes-sdk/aws-crt-python/files/0001-fix-library-suffix.patch
+++ b/recipes-sdk/aws-crt-python/files/0001-fix-library-suffix.patch
@@ -1,4 +1,4 @@
-From 4d5c07fc10f5fbecb50cce1b95872ffca4090fd4 Mon Sep 17 00:00:00 2001
+From 50e12233385a679c642c3799990e62e7b17fbaab Mon Sep 17 00:00:00 2001
 From: rpcme <rich@richelberger.com>
 Date: Mon, 13 Sep 2021 16:27:00 -0400
 Subject: [PATCH] upgrade support for CRT Python and Device SDK Python v2

--- a/recipes-sdk/aws-crt-python/files/0002-disable-building-of-depending-libs.patch
+++ b/recipes-sdk/aws-crt-python/files/0002-disable-building-of-depending-libs.patch
@@ -1,0 +1,67 @@
+# note: this software build its depending libraries such as aws-lc in do_compile step, but finally links to the libs specified by DEPENDS!
+# the 0002-disable-building-of-depending-libs.patch disable this behaviour, therefore it's not necessary to checkout the submodules (git:// instead of gitsm://)
+
+---
+ setup.py | 35 +----------------------------------
+ 1 file changed, 1 insertion(+), 34 deletions(-)
+
+diff --git a/setup.py b/setup.py
+index 46fa4ba..b4d41fc 100644
+--- a/setup.py
++++ b/setup.py
+@@ -111,33 +111,6 @@ class AwsLib:
+         self.libname = libname if libname else name
+ 
+ 
+-# The extension depends on these libs.
+-# They're built along with the extension, in the order listed.
+-AWS_LIBS = []
+-if sys.platform != 'darwin' and sys.platform != 'win32':
+-    AWS_LIBS.append(AwsLib(name='aws-lc',
+-                           libname='crypto',  # We link against libcrypto.a
+-                           extra_cmake_args=[
+-                               # We don't need libssl.a
+-                               '-DBUILD_LIBSSL=OFF',
+-                               # Disable running codegen on user's machine.
+-                               # Up-to-date generated code is already in repo.
+-                               '-DDISABLE_PERL=ON', '-DDISABLE_GO=ON',
+-                           ]))
+-    AWS_LIBS.append(AwsLib(name='s2n', extra_cmake_args=['-DUNSAFE_TREAT_WARNINGS_AS_ERRORS=OFF']))
+-AWS_LIBS.append(AwsLib('aws-c-common'))
+-AWS_LIBS.append(AwsLib('aws-c-sdkutils'))
+-AWS_LIBS.append(AwsLib('aws-c-cal'))
+-AWS_LIBS.append(AwsLib('aws-c-io'))
+-AWS_LIBS.append(AwsLib('aws-checksums'))
+-AWS_LIBS.append(AwsLib('aws-c-compression'))
+-AWS_LIBS.append(AwsLib('aws-c-event-stream'))
+-AWS_LIBS.append(AwsLib('aws-c-http'))
+-AWS_LIBS.append(AwsLib('aws-c-auth'))
+-AWS_LIBS.append(AwsLib('aws-c-mqtt'))
+-AWS_LIBS.append(AwsLib('aws-c-s3'))
+-
+-
+ PROJECT_DIR = os.path.dirname(os.path.realpath(__file__))
+ 
+ VERSION_RE = re.compile(r""".*__version__ = ["'](.*?)['"]""", re.S)
+@@ -245,8 +218,6 @@ class awscrt_build_ext(setuptools.command.build_ext.build_ext):
+         # build dependencies
+         dep_build_dir = os.path.join(self.build_temp, 'deps')
+         dep_install_path = os.path.join(self.build_temp, 'deps', 'install')
+-        for lib in AWS_LIBS:
+-            self._build_dependency(lib, dep_build_dir, dep_install_path)
+ 
+         # update paths so awscrt_ext can access dependencies
+         self.include_dirs.append(os.path.join(dep_install_path, 'include'))
+@@ -269,11 +240,7 @@ def awscrt_ext():
+     extra_compile_args = os.environ.get('CFLAGS', '').split()
+     extra_link_args = os.environ.get('LDFLAGS', '').split()
+     extra_objects = []
+-
+-    libraries = [x.libname for x in AWS_LIBS]
+-
+-    # libraries must be passed to the linker with upstream dependencies listed last.
+-    libraries.reverse()
++    libraries = []
+ 
+     if sys.platform == 'win32':
+         # the windows apis being used under the hood. Since we're static linking we have to follow the entire chain down

--- a/recipes-sdk/aws-lc/aws-lc_1.1.0+.bb
+++ b/recipes-sdk/aws-lc/aws-lc_1.1.0+.bb
@@ -12,7 +12,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=c91257e3cc0bd6026b93fb15aecf6f1c"
 BRANCH ?= "main"
 
 SRC_URI = "git://github.com/awslabs/aws-lc.git;protocol=https;branch=${BRANCH}"
-SRCREV = "e7413d237bb60bf639e78aa43ff3c1b1783f0712"
+SRCREV = "038628d24feab1c4fce75c9b6a47bfa99b7c5edc"
 
 S = "${WORKDIR}/git"
 
@@ -40,4 +40,4 @@ FILES:${PN}-dbg = "/usr/src/debug/aws-lc/*"
 BBCLASSEXTEND = "native nativesdk"
 
 # -Werror will cause https://github.com/awslabs/aws-lc/issues/487
-OECMAKE_C_FLAGS += "-Wno-array-bounds -Wno-stringop-overflow"
+OECMAKE_C_FLAGS += "-Wno-array-parameter"


### PR DESCRIPTION
aws-crt-python: added a patch to disable building of depending libs, they should be used from yocto DEPENDS and build correctly for arch arm
aws-lc: removing suppression parameters, they are not necessary anymore by commit 038628d24feab1c4fce75c9b6a47bfa99b7c5edc