### PR TITLE
python3-timeloop, aws-iot-device-sdk-python-v1: check for the correct…

### DIFF
--- a/recipes-external/python3-timeloop/python3-timeloop_1.0.2.bb
+++ b/recipes-external/python3-timeloop/python3-timeloop_1.0.2.bb
@@ -5,7 +5,6 @@ LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=030635eb18c38d9fd120c13a324721b7"
 
 inherit setuptools3
-PIP_INSTALL_PACKAGE = "timeloop"
 
 SRC_URI = "git://github.com/sankalpjonn/timeloop.git;protocol=https;branch=master"
 SRCREV = "36ec5cbb133a6dcfb5316f59b5e11765c14e62c2"

--- a/recipes-sdk/aws-iot-device-sdk-python-v1/aws-iot-device-sdk-python-v1_1.5.2.bb
+++ b/recipes-sdk/aws-iot-device-sdk-python-v1/aws-iot-device-sdk-python-v1_1.5.2.bb
@@ -6,7 +6,7 @@ HOMEPAGE = "https://github.com/aws/aws-iot-device-sdk-python.git"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=9ac49901b833e769c7d6f21e8dbd7b30"
 
-inherit setuptools3
+inherit setuptools3_legacy
 
 BRANCH ?= "master"
 


### PR DESCRIPTION
… useage of setuptools3_legacy and setuptools3

setuptools3_legacy: is just required if (deprecated) distutils is used
acc. to  https://www.youtube.com/watch?v=To9TSBaIg2Q&amp;index=15