### PR TITLE
awscli: set branch parameter in SRC_URI

### DIFF
--- a/recipes-support/awscli/awscli_1.20.54.bb
+++ b/recipes-support/awscli/awscli_1.20.54.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/aws/aws-cli"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=7970352423db76abb33cbe303884afbf"
 
-SRC_URI = "git://github.com/aws/aws-cli.git;protocol=https"
+SRC_URI = "git://github.com/aws/aws-cli.git;protocol=https;branch=master"
 SRCREV = "bf9bb5b60cd24b97d642646c7f7d6c17e320c576"
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
This silences the following warning:

  WARNING: awscli-1.20.54-r0 do_cleanall: URL: git://github.com/aws/aws-cli.git;protocol=https does not set any branch parameter. The future default branch used by tools and repositories is uncertain and we will therefore soon require this is set in all git urls.