### PR TITLE
corretto-11-bin, corretto-17-bin: x11 dependency removed

### DIFF
--- a/recipes-devtools/amazon-corretto/corretto-11-bin_11.0.15.9.1.bb
+++ b/recipes-devtools/amazon-corretto/corretto-11-bin_11.0.15.9.1.bb
@@ -28,11 +28,8 @@ FILES = ""
 FILES:${PN} = "/usr/lib/${SHR} /usr/bin"
 
 RDEPENDS:${PN} += " \
-    libxrender \
-    libxext \
-    libxi \
-    libxtst \
-    alsa-lib \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'alsa', 'alsa-lib', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'x11', 'libxrender libxext libxi libxtst libx11', '', d)} \
 "
 
 do_install() {
@@ -85,7 +82,21 @@ do_install:append:x86-64() {
     ln -s ../lib/ld-linux-x86-64.so.2 ld-linux-x86-64.so.2
 }
 
+do_install:append() {
+    if ${@bb.utils.contains('DISTRO_FEATURES','x11','false','true',d)}; then
+        rm ${D}/usr/lib/${SHR}/lib/libawt_xawt.so
+        rm ${D}/usr/lib/${SHR}/lib/libjawt.so
+        rm ${D}/usr/lib/${SHR}/lib/libsplashscreen.so
+    fi
+}
+
+do_install:append() {
+    if ${@bb.utils.contains('DISTRO_FEATURES','alsa','false','true',d)}; then
+        rm ${D}/usr/lib/${SHR}/lib/libjsound.so
+    fi
+}
+
 FILES:${PN} += " /lib64"
 
 
-INSANE_SKIP:${PN} = "libdir file-rdeps ldflags"
+INSANE_SKIP:${PN} = "libdir"

--- a/recipes-devtools/amazon-corretto/corretto-17-bin_17.0.3.6.1.bb
+++ b/recipes-devtools/amazon-corretto/corretto-17-bin_17.0.3.6.1.bb
@@ -19,11 +19,8 @@ FILES = ""
 FILES:${PN} = "/usr/lib/${SHR} /usr/bin"
 
 RDEPENDS:${PN} += " \
-    libxrender \
-    libxext \
-    libxi \
-    libxtst \
-    alsa-lib \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'alsa', 'alsa-lib', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'x11', 'libxrender libxext libxi libxtst libx11', '', d)} \
 "
 
 do_install() {
@@ -76,5 +73,19 @@ do_install:append:x86-64() {
     ln -s ../lib/ld-linux-x86-64.so.2 ld-linux-x86-64.so.2
 }
 
+do_install:append() {
+    if ${@bb.utils.contains('DISTRO_FEATURES','x11','false','true',d)}; then
+        rm ${D}/usr/lib/${SHR}/lib/libawt_xawt.so
+        rm ${D}/usr/lib/${SHR}/lib/libjawt.so
+        rm ${D}/usr/lib/${SHR}/lib/libsplashscreen.so
+    fi
+}
+
+do_install:append() {
+    if ${@bb.utils.contains('DISTRO_FEATURES','alsa','false','true',d)}; then
+        rm ${D}/usr/lib/${SHR}/lib/libjsound.so
+    fi
+}
+
 FILES:${PN} += " /lib64"
-INSANE_SKIP:${PN} += " libdir file-rdeps"
+INSANE_SKIP:${PN} += "libdir"


### PR DESCRIPTION
dnf, the tool used to create images when using PACKAGE_CLASSES ?= "package_rpm" will scan installed libraries
for dependencies. Since this binary jdk has libs depending on x11 or asound image creation will fail.
This commit will delete those unnecessary libraries to allow building a smaller image.
The deleted libraries are the same as when downloading a headless JRE