### PR TITLE
firecracker, jailer, corretto, amazon-sagemaker-neo, greengrass: disa…

### DIFF
--- a/recipes-containers/firecracker/firecracker-0.24.3.inc
+++ b/recipes-containers/firecracker/firecracker-0.24.3.inc
@@ -5,3 +5,4 @@ SRC_URI += "\
     file://0002-kvm-bindings-use-local-version.patch \
     file://0003-Remove-abort-panic-from-the-workspace.patch \
 "
+UPSTREAM_VERSION_UNKNOWN = "1"

--- a/recipes-containers/firecracker/jailer-0.24.3.inc
+++ b/recipes-containers/firecracker/jailer-0.24.3.inc
@@ -2,4 +2,4 @@ SRC_URI += "\
     file://0002-kvm-bindings-use-local-version.patch \
     file://0003-Remove-abort-panic-from-the-workspace.patch \
 "
-
+UPSTREAM_VERSION_UNKNOWN = "1"

--- a/recipes-devtools/amazon-corretto/corretto-11-bin_11.0.15.9.1.bb
+++ b/recipes-devtools/amazon-corretto/corretto-11-bin_11.0.15.9.1.bb
@@ -24,6 +24,8 @@ SRC_URI[x86-64.sha256sum] = "1878cfcb1ed374d5c8d3e11f230ec702ad3a6779107b640ddb5
 
 SRC_URI[x86.sha256sum]     = "cfd956be63c33217093161022cb37176e48953e4e9f4d2b7a79de0277ac8c933"
 
+UPSTREAM_VERSION_UNKNOWN = "1"
+
 FILES = ""
 FILES:${PN} = "/usr/lib/${SHR} /usr/bin"
 

--- a/recipes-devtools/amazon-corretto/corretto-17-bin_17.0.3.6.1.bb
+++ b/recipes-devtools/amazon-corretto/corretto-17-bin_17.0.3.6.1.bb
@@ -15,6 +15,8 @@ SRC_URI[aarch64.sha256sum] = "6f3c47ebbe3aded7a9c77276c7165596dd0d0606bf5dddd1eb
 
 SRC_URI[x86-64.sha256sum]  = "e102e77edebb826fe22f5b6e2666d01586a87344618cdbeaed8a593787f4ff8a"
 
+UPSTREAM_VERSION_UNKNOWN = "1"
+
 FILES = ""
 FILES:${PN} = "/usr/lib/${SHR} /usr/bin"
 

--- a/recipes-devtools/amazon-corretto/corretto-8-bin_8.332.08.1.bb
+++ b/recipes-devtools/amazon-corretto/corretto-8-bin_8.332.08.1.bb
@@ -19,6 +19,8 @@ SRC_URI[x86-64.sha256sum]  = "364105ae5825cda8b7426fd819916b78526a279fbfd352bfad
 FILES = ""
 FILES:${PN} = "/usr/lib/${SHR} /usr/bin"
 
+UPSTREAM_VERSION_UNKNOWN = "1"
+
 do_package_qa[noexec] = "1"
 EXCLUDE_FROM_SHLIBS = "1"
 

--- a/recipes-devtools/amazon-sagemaker-neo-treelite/neo-ai-treelite.bb
+++ b/recipes-devtools/amazon-sagemaker-neo-treelite/neo-ai-treelite.bb
@@ -26,6 +26,7 @@ SRC_URI = "${TL_URI};protocol=https;rev=${TL_SR};destsuffix=${TL_PATH};nobranch=
            ${TL_FMT_URI};protocol=https;rev=${TL_FMT_SR};nobranch=1;destsuffix=${TL_FMT_PATH} \
            ${TL_PB_URI};protocol=https;rev=${TL_PB_SR};destsuffix=${TL_PB_PATH}"
 
+UPSTREAM_VERSION_UNKNOWN = "1"
 
 S = "${WORKDIR}/git"
 B = "${WORKDIR}/build"

--- a/recipes-devtools/amazon-sagemaker-neo-tvm/neo-ai-tvm.bb
+++ b/recipes-devtools/amazon-sagemaker-neo-tvm/neo-ai-tvm.bb
@@ -31,6 +31,8 @@ SRCREV_halideir = "b257a9221ee1e5180d994b3488ddcc259b0ac157"
 SRCREV_dlpack = "5c792cef3aee54ad8b7000111c9dc1797f327b59"
 SRCREV_rang = "cabe04d6d6b05356fa8f9741704924788f0dd762"
 
+UPSTREAM_VERSION_UNKNOWN = "1"
+
 S = "${WORKDIR}/git"
 
 inherit setuptools3 cmake python3native

--- a/recipes-devtools/amazon-sagemaker-neo/neo-ai-dlr_1.10.0.bb
+++ b/recipes-devtools/amazon-sagemaker-neo/neo-ai-dlr_1.10.0.bb
@@ -50,6 +50,8 @@ SRC_URI[input-order.sha256sum] = "a34e6c576e5c29c8b7a9cc4c47b836e8375f198a613150
 SRC_URI[inverselabel-static.md5sum] = "191a5ea03439040c789fe5fb0cf8eb10"
 SRC_URI[inverselabel-static.sha256sum] = "aebd1e2457bc6ecb7af783ee37c7531289c2ec8761199520cf41b7ec1b3f31fe"
 
+UPSTREAM_VERSION_UNKNOWN = "1"
+
 S = "${WORKDIR}/git"
 B = "${WORKDIR}/build"
 

--- a/recipes-iot/aws-iot-greengrass/greengrass-bin-demo_2.5.6.bb
+++ b/recipes-iot/aws-iot-greengrass/greengrass-bin-demo_2.5.6.bb
@@ -15,6 +15,8 @@ SRC_URI                    = "https://raw.githubusercontent.com/aws-greengrass/a
 SRC_URI[license.md5sum]    = "34400b68072d710fecd0a2940a0d1658"
 SRC_URI[license.sha256sum] = "09e8a9bcec8067104652c168685ab0931e7868f9c8284b66f5ae6edae5f1130b"
 
+UPSTREAM_VERSION_UNKNOWN = "1"
+
 RDEPENDS:${PN} += "greengrass-bin"
 
 do_configure[noexec] = "1"

--- a/recipes-iot/aws-iot-greengrass/greengrass-bin_2.5.6.bb
+++ b/recipes-iot/aws-iot-greengrass/greengrass-bin_2.5.6.bb
@@ -15,6 +15,8 @@ SRC_URI[payload.sha256sum] = "39744a21cfb6dfa768d4da78692125bc4acccf493c98dd2b49
 
 SRC_URI[license.sha256sum] = "09e8a9bcec8067104652c168685ab0931e7868f9c8284b66f5ae6edae5f1130b"
 
+UPSTREAM_VERSION_UNKNOWN = "1"
+
 GG_USESYSTEMD = "${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'yes', 'no', d)}"
 RDEPENDS:${PN} += "${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'ntp-systemd', '', d)}"
 RDEPENDS:${PN} += "corretto-11-bin ca-certificates python3-core python3-json python3-numbers sudo"

--- a/recipes-iot/aws-iot-greengrass/greengrass_1.11.6.bb
+++ b/recipes-iot/aws-iot-greengrass/greengrass_1.11.6.bb
@@ -32,6 +32,8 @@ SRC_URI[aarch64.sha256sum] = "92dc496efd787fd70701059271986f596086e6d569a539527b
 
 SRC_URI[x86-64.sha256sum]  = "08449a148d311a1bf3f9680f3bb96471f8d11bc36b145cd9bf42e468e871e7a2"
 
+UPSTREAM_VERSION_UNKNOWN = "1"
+
 # Release specific configuration
 
 RDEPENDS:${PN} += "ca-certificates python3-json python3-numbers sqlite3"


### PR DESCRIPTION
…ble update provider, since this is currently not working

UPSTREAM_VERSION_UNKNOWN = "1"
You can perform a per-recipe check for what the latest upstream source code version is by calling devtool latest-version recipe. If no combination of the UPSTREAM_CHECK_URI, UPSTREAM_CHECK_REGEX, UPSTREAM_CHECK_GITTAGREGEX and UPSTREAM_CHECK_COMMITS variables in the recipe allows to determine what the latest upstream version is, you can set UPSTREAM_VERSION_UNKNOWN to 1 in the recipe to acknowledge that the check cannot be performed.