### PR TITLE
corretto, greengrass: set COMPATIBLE_MACHINE

### DIFF
--- a/recipes-devtools/amazon-corretto/corretto-11-bin_11.0.15.9.1.bb
+++ b/recipes-devtools/amazon-corretto/corretto-11-bin_11.0.15.9.1.bb
@@ -24,6 +24,12 @@ SRC_URI[x86-64.sha256sum] = "1878cfcb1ed374d5c8d3e11f230ec702ad3a6779107b640ddb5
 
 SRC_URI[x86.sha256sum]     = "cfd956be63c33217093161022cb37176e48953e4e9f4d2b7a79de0277ac8c933"
 
+COMPATIBLE_MACHINE = "(^$)"
+COMPATIBLE_MACHINE:armv7a = "(.*)"
+COMPATIBLE_MACHINE:aarch64 = "(.*)"
+COMPATIBLE_MACHINE:x86 = "(.*)"
+COMPATIBLE_MACHINE:x86-64 = "(.*)"
+
 FILES = ""
 FILES:${PN} = "/usr/lib/${SHR} /usr/bin"
 

--- a/recipes-devtools/amazon-corretto/corretto-17-bin_17.0.3.6.1.bb
+++ b/recipes-devtools/amazon-corretto/corretto-17-bin_17.0.3.6.1.bb
@@ -15,6 +15,10 @@ SRC_URI[aarch64.sha256sum] = "6f3c47ebbe3aded7a9c77276c7165596dd0d0606bf5dddd1eb
 
 SRC_URI[x86-64.sha256sum]  = "e102e77edebb826fe22f5b6e2666d01586a87344618cdbeaed8a593787f4ff8a"
 
+COMPATIBLE_MACHINE = "(^$)"
+COMPATIBLE_MACHINE:aarch64 = "(.*)"
+COMPATIBLE_MACHINE:x86-64 = "(.*)"
+
 FILES = ""
 FILES:${PN} = "/usr/lib/${SHR} /usr/bin"
 

--- a/recipes-devtools/amazon-corretto/corretto-8-bin_8.332.08.1.bb
+++ b/recipes-devtools/amazon-corretto/corretto-8-bin_8.332.08.1.bb
@@ -16,6 +16,10 @@ SRC_URI[aarch64.sha256sum] = "cd3ea7604cca20b7d03e84fe6d8f90e0de5c8fc2d057c2d78d
 
 SRC_URI[x86-64.sha256sum]  = "364105ae5825cda8b7426fd819916b78526a279fbfd352bfada490358c3c0888"
 
+COMPATIBLE_MACHINE = "(^$)"
+COMPATIBLE_MACHINE:aarch64 = "(.*)"
+COMPATIBLE_MACHINE:x86-64 = "(.*)"
+
 FILES = ""
 FILES:${PN} = "/usr/lib/${SHR} /usr/bin"
 

--- a/recipes-iot/aws-iot-greengrass/greengrass_1.11.6.bb
+++ b/recipes-iot/aws-iot-greengrass/greengrass_1.11.6.bb
@@ -32,6 +32,11 @@ SRC_URI[aarch64.sha256sum] = "92dc496efd787fd70701059271986f596086e6d569a539527b
 
 SRC_URI[x86-64.sha256sum]  = "08449a148d311a1bf3f9680f3bb96471f8d11bc36b145cd9bf42e468e871e7a2"
 
+COMPATIBLE_MACHINE = "(^$)"
+COMPATIBLE_MACHINE:armv7a = "(.*)"
+COMPATIBLE_MACHINE:aarch64 = "(.*)"
+COMPATIBLE_MACHINE:x86-64 = "(.*)"
+
 # Release specific configuration
 
 RDEPENDS:${PN} += "ca-certificates python3-json python3-numbers sqlite3"


### PR DESCRIPTION
A regular expression that resolves to one or more target machines with which a recipe is compatible. The regular expression is matched against MACHINEOVERRIDES. You can use the variable to stop recipes from being built for machines with which the recipes are not compatible. Stopping these builds is particularly useful with kernels. The variable also helps to increase parsing speed since the build system skips parsing recipes not compatible with the current machine.