### PR TITLE
Update aws-iot-fleetwise-edge recipe to v0.1.4

### DIFF
--- a/recipes-iot/aws-iot-fleetwise/aws-iot-fleetwise-edge.bb
+++ b/recipes-iot/aws-iot-fleetwise/aws-iot-fleetwise-edge.bb
@@ -1,12 +1,12 @@
 DESCRIPTION = "AWS IoT FleetWise Edge Agent" 
 LICENSE = "ASL-1.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=79ba3a8bc4e89e76f90b0dadbf304749"
-DEPENDS = "protobuf protobuf-native boost jsoncpp aws-iot-device-sdk-cpp-v2 snappy"
+DEPENDS = "protobuf protobuf-native boost jsoncpp aws-sdk-cpp snappy"
 RDEPENDS:${PN} = "protobuf"
 SRC_URI = "git://github.com/aws/aws-iot-fleetwise-edge.git;protocol=https;branch=main;name=fwe \
            git://github.com/hartkopp/can-isotp.git;protocol=https;name=isotp;destsuffix=isotp \
            "
-SRCREV_fwe = "cb818bbf334e5f872f583740912aa1c33247fed4"
+SRCREV_fwe = "cf0d2a1529d3eab9d393b138b1e79447f2a333b3"
 SRCREV_isotp = "beb4650660179963a8ed5b5cbf2085cc1b34f608"
 S = "${WORKDIR}/git"
 EXTRA_OECMAKE += "-DBUILD_TESTING=OFF"

--- a/recipes-sdk/aws-sdk-cpp/aws-sdk-cpp_1.9.253.bb
+++ b/recipes-sdk/aws-sdk-cpp/aws-sdk-cpp_1.9.253.bb
@@ -1,0 +1,59 @@
+# -*- mode: Conf; -*-
+SUMMARY = "AWS C++ SDK"
+HOMEPAGE = "https://github.com/aws/aws-sdk-cpp"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=e3fc50a88d0a364313df4b21ef20c29e"
+
+SRC_URI = " \
+    gitsm://github.com/aws/aws-sdk-cpp.git;protocol=https;branch=main"
+ 
+
+SRCREV = "e5e38a781307ce2d7b894df152728aa51d2c1394"
+
+S = "${WORKDIR}/git"
+
+inherit cmake
+
+DEPENDS = " \
+    curl \
+    openssl \
+"
+
+PACKAGES =+ " \
+    ${PN}-iot \
+    ${PN}-s3-crt \
+"
+
+PROVIDES += "${PACKAGES}"
+
+FILES_${PN} += "${libdir}/libaws-cpp-sdk-core.so"
+FILES_${PN}-iot = "${libdir}/libaws-cpp-sdk-iot.so"
+FILES_${PN}-s3-crt = "${libdir}/libaws-cpp-sdk-s3-crt.so"
+
+FILES_SOLIBSDEV = ""
+
+# We can't have spaces in -DBUILD_ONLY, hence the strange formatting
+EXTRA_OECMAKE += "-DBUILD_ONLY='\
+iot;\
+s3-crt;\
+'"
+EXTRA_OECMAKE += "-DBUILD_DEPS=ON"
+EXTRA_OECMAKE += "-DENABLE_TESTING=OFF"
+EXTRA_OECMAKE += "-DAUTORUN_UNIT_TESTS=OFF"
+EXTRA_OECMAKE += "-DBUILD_SHARED_LIBS=OFF"
+EXTRA_OECMAKE += "-DAWS_CUSTOM_MEMORY_MANAGEMENT=ON"
+
+# -Werror will cause deprecation warnings to fail the build e.g. OpenSSL cause one, so disable these warnings
+OECMAKE_CXX_FLAGS += "-Wno-deprecated-declarations"
+
+ALLOW_EMPTY_${PN} = "1"
+ALLOW_EMPTY_${PN}-dbg = "1"
+
+FILES_${PN}-staticdev += "${libdir}"
+
+# Patch the resulting aws-cpp-sdk-core-targets.cmake to remove absolute paths to libcurl.so and libz.so
+# This can be an issue with older versions of CMake
+do_install_append() {
+   sed -i -E 's#;[^;]+libcurl\.so;#;libcurl.so;#' ${D}/usr/lib/cmake/aws-cpp-sdk-core/aws-cpp-sdk-core-targets.cmake
+   sed -i -E 's#;[^;]+libz\.so;#;libz.so;#' ${D}/usr/lib/cmake/aws-cpp-sdk-core/aws-cpp-sdk-core-targets.cmake
+}


### PR DESCRIPTION
_Description of changes:_

Updates aws-iot-fleetwise-edge recipe to the latest released version v0.1.4 of aws-iot-fleetwise-edge.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.