### PR TITLE
Remove LICENSE_PATH from config

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -16,5 +16,3 @@ LAYERDEPENDS_meta-aws += "networking-layer"
 LAYERDEPENDS_meta-aws += "meta-python"
 
 LAYERSERIES_COMPAT_meta-aws = "gatesgarth"
-
-LICENSE_PATH += "${LAYERDIR}/licenses"


### PR DESCRIPTION
Description of changes:

Remove LICENSE_PATH from config after /licenses directory was deleted.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.