### PR TITLE
aws-sdk-cpp: ptest, oelint-adv, all libs

### DIFF
--- a/recipes-sdk/aws-sdk-cpp/files/run-ptest
+++ b/recipes-sdk/aws-sdk-cpp/files/run-ptest
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+cd tests && python3 run_integration_tests.py
+RETVAL=$?
+
+if [ $RETVAL -eq 0 ] ; then
+    echo "PASS: aws-sdk-cpp integration tests"
+else
+    echo "FAIL: aws-sdk-cpp integration tests"
+fi
+


### PR DESCRIPTION
ptest: run integration tests
oelint-adv: no errors, no warnings
all libs: now all libs a build by default, separate packages, aws-sdk-cpp package contains all libs