### PR TITLE
Correct spelling mistake

### DIFF
--- a/recipes-support/amazon-ssm-agent/amazon-ssm-agent_3.2.582.0.bb
+++ b/recipes-support/amazon-ssm-agent/amazon-ssm-agent_3.2.582.0.bb
@@ -20,7 +20,7 @@ GO_IMPORT = ""
 
 inherit go systemd ptest
 
-SYSTEMD_AUTO_ENABLE = "enabsle"
+SYSTEMD_AUTO_ENABLE = "enable"
 SYSTEMD_SERVICE:${PN} = "amazon-ssm-agent.service"
 
 # src folder will break devtool upgrade


### PR DESCRIPTION
This commit correct spelling mistake in amazon-ssm-agent_3.2.582.0.bb. The word "enabsle" was corrected to "enable".