### PR TITLE
aws-iot-securetunneling-localproxy: support any boost version

### DIFF
--- a/recipes-iot/aws-iot-securetunneling-localproxy/aws-iot-securetunneling-localproxy_git.bb
+++ b/recipes-iot/aws-iot-securetunneling-localproxy/aws-iot-securetunneling-localproxy_git.bb
@@ -16,7 +16,8 @@ DEPENDS += "\
 
 BRANCH ?= "main"
 
-SRC_URI = "git://git@github.com/aws-samples/aws-iot-securetunneling-localproxy.git;branch=${BRANCH};protocol=https"
+SRC_URI = "git://git@github.com/aws-samples/aws-iot-securetunneling-localproxy.git;branch=${BRANCH};protocol=https\
+           file://boost-support-any.patch"
 SRCREV = "c9a337567240059a0ea9a5af91868ec775c55e47"
 
 UPSTREAM_CHECK_COMMITS = "1"

--- a/recipes-iot/aws-iot-securetunneling-localproxy/files/boost-support-any.patch
+++ b/recipes-iot/aws-iot-securetunneling-localproxy/files/boost-support-any.patch
@@ -1,0 +1,14 @@
+Index: git/CMakeLists.txt
+===================================================================
+--- git.orig/CMakeLists.txt
++++ git/CMakeLists.txt
+@@ -75,8 +75,7 @@ endif(BUILD_TESTS)
+ set(Boost_USE_STATIC_LIBS ON)
+ set(Boost_USE_DEBUG_RUNTIME OFF)
+ #set_property(GLOBAL PROPERTY Boost_USE_MULTITHREADED ON)
+-set(BOOST_PKG_VERSION "1.81.0" CACHE STRING "")
+-find_package(Boost ${BOOST_PKG_VERSION} REQUIRED COMPONENTS system log log_setup thread program_options date_time filesystem chrono)
++find_package(Boost REQUIRED COMPONENTS system log log_setup thread program_options date_time filesystem chrono)
+ include_directories(${Boost_INCLUDE_DIRS})
+ foreach(BOOST_LIB ${Boost_LIBRARIES})
+     string(REPLACE ${CMAKE_SHARED_LIBRARY_SUFFIX} ${CMAKE_STATIC_LIBRARY_SUFFIX} BOOST_STATIC_LIB ${BOOST_LIB})


### PR DESCRIPTION
this patch allows to compile against any version,
any newer than 1.78 should be okay