### PR TITLE
amazon-kvs-webrtc-sdk: add UPSTREAM_CHECK_COMMITS

### DIFF
--- a/recipes-sdk/amazon-kvs-webrtc-sdk/amazon-kvs-webrtc-sdk_git.bb
+++ b/recipes-sdk/amazon-kvs-webrtc-sdk/amazon-kvs-webrtc-sdk_git.bb
@@ -25,6 +25,8 @@ SRC_URI = "\
 
 SRCREV = "b820e2ea3d28c670da2fbc789face742cb949ef1"
 
+UPSTREAM_CHECK_COMMITS = "1"
+
 S = "${WORKDIR}/git"
 
 inherit cmake pkgconfig


### PR DESCRIPTION
If UPSTREAM_CHECK_COMMITS is not set it will not use the specified commit, instead it will be downgraded to the last release tag.