### PR TITLE
aws-cli: install examples in dedicated package to optimize storage use

### DIFF
--- a/recipes-support/aws-cli/aws-cli_1.27.117.bb
+++ b/recipes-support/aws-cli/aws-cli_1.27.117.bb
@@ -47,3 +47,7 @@ do_install_ptest() {
         # just install some tests with low memory (less than 4GB) consumption
         cp -rf ${S}/tests/functional/test_args.py ${D}${PTEST_PATH}/tests/
 }
+
+PACKAGES =+ "${PN}-examples"
+
+FILES:${PN}-examples = "${libdir}/${PYTHON_DIR}/site-packages/awscli/examples"


### PR DESCRIPTION
This pull request is inspired by the desire to improve storage requirements of aws tools in embedded devices.

Separating examples in a dedicated package saves a lot of storage space that is not required for automated operation of aws tools.