### PR TITLE
aws-crt-python: upgrade 0.16.15 -> 0.16.16, readd shared patch

### DIFF
--- a/recipes-sdk/aws-crt-python/aws-crt-python_0.16.16.bb
+++ b/recipes-sdk/aws-crt-python/aws-crt-python_0.16.16.bb
@@ -21,11 +21,13 @@ DEPENDS += "\
         "
 
 BRANCH ?= "main"
+# nooelint: oelint.file.patchsignedoff
 SRC_URI = "\
            git://github.com/awslabs/aws-crt-python.git;protocol=https;branch=${BRANCH} \
+           file://fix-shared-linking.patch \
            file://run-ptest \
            "
-SRCREV = "80a1f21474096f6b54698a483ffe9b024ee43a3c"
+SRCREV = "11eb2a45de915623344754a2f3bfdc2197dc5e62"
 UPSTREAM_CHECK_GITTAGREGEX = "v(?P<pver>.*)"
 
 S = "${WORKDIR}/git"

--- a/recipes-sdk/aws-crt-python/files/fix-shared-linking.patch
+++ b/recipes-sdk/aws-crt-python/files/fix-shared-linking.patch
@@ -1,0 +1,21 @@
+Index: git/setup.py
+===================================================================
+--- git.orig/setup.py
++++ git/setup.py
+@@ -306,16 +306,6 @@ def awscrt_ext():
+         extra_link_args += ['-framework', 'Security']
+ 
+     else:  # unix
+-        # linker will prefer shared libraries over static if it can find both.
+-        # force linker to choose static variant by using using
+-        # "-l:libaws-c-common.a" syntax instead of just "-laws-c-common".
+-        #
+-        # This helps AWS developers creating Lambda applications from Brazil.
+-        # In Brazil, both shared and static libs are available.
+-        # But Lambda requires all shared libs to be explicitly packaged up.
+-        # So it's simpler to link them in statically and have less runtime dependencies.
+-        libraries = [':lib{}.a'.format(x) for x in libraries]
+-
+         # OpenBSD doesn't have librt; functions are found in libc instead.
+         if not sys.platform.startswith('openbsd'):
+             libraries += ['rt']


### PR DESCRIPTION
shared lib patch is again necessary:
https://github.com/awslabs/aws-crt-python/commit/11eb2a45de915623344754a2f3bfdc2197dc5e62#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7