### PR TITLE
aws-c-common: fix ptest

### DIFF
--- a/recipes-sdk/aws-c-common/files/run-ptest
+++ b/recipes-sdk/aws-c-common/files/run-ptest
@@ -2,6 +2,11 @@
 # Copyright (c) 2022 Amazon.com, Inc. or its affiliates.
 # SPDX-License-Identifier: MIT
 
-ctest --exclude-regex "assert_test|test_add_u64_saturating|test_add_size_saturating|ring_buffer_acquire_up_to_multi_threaded_test|ring_buffer_acquire_multi_threaded_test|test_stack_trace_decoding|test_memtrace_stacks" --test-dir build/tests/ --output-junit result.xml
+cd build/tests/ && ctest --exclude-regex "assert_test|test_add_u64_saturating|test_add_size_saturating|ring_buffer_acquire_up_to_multi_threaded_test|ring_buffer_acquire_multi_threaded_test|test_stack_trace_decoding|test_memtrace_stacks" -j 16
 
-python3 ptest_result.py build/tests/result.xml 
+RETVAL=$?
+if [ $RETVAL -eq 0 ] ; then
+    echo "PASS: aws-c-common simple test"
+else
+    echo "FAIL: aws-c-common simple test"
+fi


### PR DESCRIPTION
ctest in dunfell does not support json param, so replace by simple test