### PR TITLE
aws-crt-cpp: improve ptest

### DIFF
--- a/recipes-sdk/aws-crt-cpp/aws-crt-cpp/run-ptest
+++ b/recipes-sdk/aws-crt-cpp/aws-crt-cpp/run-ptest
@@ -68,4 +68,4 @@ do
 ./aws-crt-cpp-tests $TEST >> tests.log 2>&1
 done
 
-sed  -e '/OK/ s/^/PASS: / ; /FAILED/ s/^/FAIL: /' tests.log
+sed  -e '/\[\s/!d  ; /OK/ s/^/PASS: / ; /FAILED/ s/^/FAIL: /'  tests.log


### PR DESCRIPTION
do not match (OK) from TRACE