### PR TITLE
amazon-kvs-producer-pic: disable ptest for dunfell

### DIFF
--- a/recipes-sdk/amazon-kvs-producer-sdk/amazon-kvs-producer-pic_git.bb
+++ b/recipes-sdk/amazon-kvs-producer-sdk/amazon-kvs-producer-pic_git.bb
@@ -22,7 +22,7 @@ SRCREV = "d08be2e16303507d21b4cb376aecda98271687ad"
 
 S = "${WORKDIR}/git"
 
-inherit cmake pkgconfig ptest
+inherit cmake pkgconfig
 
 PACKAGECONFIG ??= "\
      ${@bb.utils.contains('PTEST_ENABLED', '1', 'with-tests', '', d)} \


### PR DESCRIPTION
when building for arm64 this error persists - only on dunfell, therefore disable ptest {'amazon-kvs-producer-pic': '2023-09-18T09:25\n'
                            '2023-09-18T09:25\n'
                            '/usr/lib/amazon-kvs-producer-pic/ptest/run-ptest: '
                            'line 2:   375 Bus error               '
                            'tests/kvspic_test '
                            '--gtest_filter=*ClientApiTest.create* '
                            '--gtest_output=json:result.json > /dev/null\n'
                            'Traceback (most recent call last):\n'
                            '  File "ptest_result.py", line 11, in <module>\n'
                            "    with open (sys.argv[1], 'rb') as json_file:\n"
                            'FileNotFoundError: [Errno 2] No such file or '
                            "directory: 'result.json'\n"
                            '\n'
                            'ERROR: Exit status is 1\n'
                            'DURATION: 1\n'}