### PR TITLE
Revert "aws-crt-cpp: upgrade 0.23.1 -> 0.24.0"

### DIFF
--- a/recipes-sdk/aws-crt-cpp/aws-crt-cpp_0.23.1.bb
+++ b/recipes-sdk/aws-crt-cpp/aws-crt-cpp_0.23.1.bb
@@ -26,7 +26,7 @@ SRC_URI = "\
     file://run-ptest \
     "
 
-SRCREV = "4e63460e5f4c0b8c023bb4f405617c6577ab90fe"
+SRCREV = "12a15758c992e3af087ddaf732ee846361fac47d"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
This reverts commit f6750fc2c45ff7afc2865c716ab1ff6226452a13. -> https://github.com/awslabs/aws-crt-cpp/issues/548