### PR TITLE
firecracker-bin, jailer-bin: disable debug split

### DIFF
--- a/recipes-containers/firecracker-bin/firecracker-bin_1.3.3.bb
+++ b/recipes-containers/firecracker-bin/firecracker-bin_1.3.3.bb
@@ -44,3 +44,5 @@ do_install() {
     install -m 0755 ${S}/release-v${PV}-${TARGET_ARCH}/firecracker-v${PV}-${TARGET_ARCH} ${D}${bindir}/firecracker
 }
 
+# there are sporadic errors when enable debug split, but no value in this debug information
+INHIBIT_PACKAGE_DEBUG_SPLIT = "1"

--- a/recipes-containers/firecracker-bin/jailer-bin_1.3.3.bb
+++ b/recipes-containers/firecracker-bin/jailer-bin_1.3.3.bb
@@ -47,3 +47,5 @@ do_install() {
     install -m 0755 ${S}/release-v${PV}-${TARGET_ARCH}/jailer-v${PV}-${TARGET_ARCH} ${D}${bindir}/jailer
 }
 
+# there are sporadic errors when enable debug split, but no value in this debug information
+INHIBIT_PACKAGE_DEBUG_SPLIT = "1"


### PR DESCRIPTION
 there are sporadic errors when enable debug split, but no value in this debug information
INHIBIT_PACKAGE_DEBUG_SPLIT = "1"