### PR TITLE
aws-iot-securetunneling-localproxy: fix DSO missing from command line

### DIFF
--- a/recipes-iot/aws-iot-securetunneling-localproxy/aws-iot-securetunneling-localproxy_git.bb
+++ b/recipes-iot/aws-iot-securetunneling-localproxy/aws-iot-securetunneling-localproxy_git.bb
@@ -49,3 +49,6 @@ do_install_ptest() {
   install -d ${D}${bindir}
   install -m 0755 ${B}/bin/localproxytest ${D}${bindir}/localproxytest
 }
+
+# fix DSO missing from command line
+LDFLAGS += "-Wl,--copy-dt-needed-entries"


### PR DESCRIPTION
add LDFLAGS += "-Wl,--copy-dt-needed-entries"