### PR TITLE
greengrass-bin_2.9.6.bb: replace ptest RDEPENDS greengrass-bin-demo

### DIFF
--- a/recipes-iot/aws-iot-greengrass/greengrass-bin_2.9.6.bb
+++ b/recipes-iot/aws-iot-greengrass/greengrass-bin_2.9.6.bb
@@ -141,5 +141,5 @@ GROUP_MEMS_PARAM:${PN} = ""
 INSANE_SKIP:${PN} += "already-stripped ldflags file-rdeps"
 
 RDEPENDS:${PN}-ptest += "\
-    greengrass-bin-demo \
+    greengrass-bin \
     "


### PR DESCRIPTION
by greengrass-bin, cause greengrass-bin-demo was causing issues when an image contained greengrass-bin and an SDK was built.