### PR TITLE
aws-iot-device-client: readd, upgrade 1.8. -> 1.9.

### DIFF
--- a/recipes-iot/aws-iot-device-client/aws-iot-device-client_1.9.bb
+++ b/recipes-iot/aws-iot-device-client/aws-iot-device-client_1.9.bb
@@ -6,9 +6,11 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=3eb31626add6ada64ff9ac772bd3c653"
 
 DEPENDS = "\
     aws-iot-device-sdk-cpp-v2 \
-    googletest \
     openssl \
     "
+# disabled googletest because of: https://github.com/awslabs/aws-iot-device-client/issues/404
+# use a older and build by this package version, will be downloaded in the do_configure step
+do_configure[network] = "1"
 
 PROVIDES = "aws/aws-iot-device-client"
 
@@ -21,12 +23,11 @@ SRC_URI = "\
     file://ptest_result.py \
     "
 
-SRCREV = "95db8c94d96758f974e88716cc8b2e2bd849a6d2"
+SRCREV = "da10323c3d2a4221baaf7d786ee3172d243faa60"
 
 S = "${WORKDIR}/git"
 
-inherit cmake ptest systemd
-
+inherit cmake systemd ptest
 do_compile_ptest()  {
     cmake_runcmake_build --target test-aws-iot-device-client
 }
@@ -45,8 +46,7 @@ do_install() {
 
 EXTRA_OECMAKE += "\
     -DBUILD_SDK=OFF \
-    -DBUILD_TEST_DEPS=OFF \
-    -DBUILD_TESTING=OFF \
+    -DBUILD_TEST_DEPS=ON \
     -DCMAKE_BUILD_TYPE=RelWithDebInfo \
     -DCMAKE_VERBOSE_MAKEFILE=ON \
     -DCMAKE_CXX_FLAGS_RELEASE=-s \
@@ -55,7 +55,7 @@ EXTRA_OECMAKE += "\
 CXXFLAGS += "-Wno-ignored-attributes"
 
 # enable all modules by default, except st because of: https://github.com/awslabs/aws-iot-device-client/issues/411
-PACKAGECONFIG ??= " dsn dsc ds fp dd pubsub samples jobs "
+PACKAGECONFIG ??= " dsn dsc ds fp dd pubsub samples jobs"
 
 # enable PACKAGECONFIG = "static" to build static instead of shared
 PACKAGECONFIG[static] = "-DBUILD_SHARED_LIBS=OFF,-DBUILD_SHARED_LIBS=ON,,"
@@ -93,4 +93,9 @@ do_install_ptest() {
     cp -r ${B}/test/test-aws-iot-device-client ${D}${PTEST_PATH}/
 
     install -m 0755 ${WORKDIR}/ptest_result.py ${D}${PTEST_PATH}/
+
+    install -d ${D}/${libdir}
+    install -m 755 ${B}/lib/libgtest.so.1.11.0 ${D}/${libdir}
+    install -m 755 ${B}/lib/libgmock.so.1.11.0 ${D}/${libdir}
+    install -m 755 ${B}/lib/libgmock_main.so.1.11.0 ${D}/${libdir}
 }


### PR DESCRIPTION
fixed: https://github.com/awslabs/aws-iot-device-client/issues/411