### PR TITLE
Revert "aws-iot-securetunneling-localproxy: upgrade git -> new"

### DIFF
--- a/recipes-iot/aws-iot-securetunneling-localproxy/aws-iot-securetunneling-localproxy_git.bb
+++ b/recipes-iot/aws-iot-securetunneling-localproxy/aws-iot-securetunneling-localproxy_git.bb
@@ -23,7 +23,7 @@ SRC_URI = "\
   file://gcc13.patch \
   file://run-ptest \
   "
-SRCREV = "f63f8fd6c7be216e484b066a8330df415a8600cf"
+SRCREV = "d3150e0ebc4ef022939deb1ab43de005254f5751"
 
 UPSTREAM_CHECK_COMMITS = "1"
 

--- a/recipes-iot/aws-iot-securetunneling-localproxy/files/boost-support-any.patch
+++ b/recipes-iot/aws-iot-securetunneling-localproxy/files/boost-support-any.patch
@@ -1,4 +1,4 @@
-From a9a8b254b363862f54d585c6e2d707e73d13ad98 Mon Sep 17 00:00:00 2001
+From aa17740b66d7a33d9259719cb143c1b97327b202 Mon Sep 17 00:00:00 2001
 From: Thomas Roos <throos@amazon.de>
 Date: Fri, 10 Mar 2023 12:46:05 +0000
 Subject: [PATCH] aws-iot-securetunneling-localproxy: support any boost version

--- a/recipes-iot/aws-iot-securetunneling-localproxy/files/gcc13.patch
+++ b/recipes-iot/aws-iot-securetunneling-localproxy/files/gcc13.patch
@@ -1,7 +1,35 @@
-From cb510583d502c7b48c8ad6b3b7f175882cacb8eb Mon Sep 17 00:00:00 2001
+From f6ba73eaede61841534623cdb01b69d793124f4b Mon Sep 17 00:00:00 2001
+From: tro <throos@amazon.de>
+Date: Tue, 30 May 2023 12:02:24 +0200
+Subject: [PATCH 1/2] Url.h: #include <cstdint>
+
+Upstream-Status: Pending [https://github.com/aws-samples/aws-iot-securetunneling-localproxy/pull/136]
+
+fix GCC 13 issue "'uint16_t' is defined in header '<cstdint>'; did you forget to '#include <cstdint>'? "
+---
+ src/Url.h | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/Url.h b/src/Url.h
+index 81fc932..fa084d3 100644
+--- a/src/Url.h
++++ b/src/Url.h
+@@ -3,6 +3,7 @@
+ #pragma once
+ 
+ #include <string>
++#include <cstdint>
+ namespace aws {
+     namespace iot {
+         namespace securedtunneling {
+-- 
+2.34.1
+
+
+From de8779630d14e4f4969c9b171d826acfa847822b Mon Sep 17 00:00:00 2001
 From: tro <throos@amazon.de>
 Date: Tue, 30 May 2023 12:10:36 +0200
-Subject: [PATCH] ProxySettings.h: add #include <cstdint>
+Subject: [PATCH 2/2] ProxySettings.h: add #include <cstdint>
 
 Upstream-Status: Pending -> https://github.com/aws-samples/aws-iot-securetunneling-localproxy/pull/136
 
@@ -21,3 +49,6 @@ index 9dc4e10..de3098a 100644
  #include <boost/property_tree/ptree.hpp>
  namespace aws { namespace iot { namespace securedtunneling { namespace settings {
      using boost::property_tree::ptree;
+-- 
+2.34.1
+


### PR DESCRIPTION
This reverts commit 2027a50c986b279bf52bfa366e3c9fc66b390378.

This release needs a patch for missing declarations