### PR TITLE
aws-iot-fleetwise-edge: remove setting of cxx-standard

### DIFF
--- a/recipes-iot/aws-iot-fleetwise/aws-iot-fleetwise-edge_1.1.0.bb
+++ b/recipes-iot/aws-iot-fleetwise/aws-iot-fleetwise-edge_1.1.0.bb
@@ -18,6 +18,7 @@ DEPENDS = "\
 # nooelint: oelint.file.patchsignedoff
 SRC_URI = "\
            git://github.com/aws/aws-iot-fleetwise-edge.git;protocol=https;branch=main \
+           file://remove-cxx-standard.patch \
            file://run-ptest \
            "
 
@@ -70,7 +71,7 @@ do_configure:append() {
         --persistency-path ${PERSISTENCY_PATH}  \
         --topic-prefix ${TOPIC_PREFIX} \
         --log-level ${LOG_LEVEL} \
-        --log-color ${LOG_COLOR} 
+        --log-color ${LOG_COLOR}
 }
 
 do_install() {

--- a/recipes-iot/aws-iot-fleetwise/files/remove-cxx-standard.patch
+++ b/recipes-iot/aws-iot-fleetwise/files/remove-cxx-standard.patch
@@ -1,0 +1,16 @@
+Index: git/CMakeLists.txt
+===================================================================
+--- git.orig/CMakeLists.txt
++++ git/CMakeLists.txt
+@@ -4,11 +4,6 @@ cmake_minimum_required(VERSION 3.10.2)
+ 
+ project(iotfleetwise VERSION 1.1.0)
+ 
+-# FWE uses C++14 for compatibility reasons with Automotive middlewares (Adaptive AUTOSAR, ROS2)
+-# Note: When built with FWE_FEATURE_ROS2, colcon will override these settings
+-set(CMAKE_CXX_STANDARD 14)
+-set(CMAKE_CXX_STANDARD_REQUIRED True)
+-
+ # Print out the compile commands which is useful for IDEs
+ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+ 


### PR DESCRIPTION
This is because abseil is compiled with default cxx-standard of the compiler, and needs to be the same.