### PR TITLE
corretto-8,11,17,21-bin: add alternate name, fix ptest

### DIFF
--- a/recipes-devtools/amazon-corretto/corretto-11-bin/run-ptest
+++ b/recipes-devtools/amazon-corretto/corretto-11-bin/run-ptest
@@ -1,7 +1,14 @@
 #!/bin/sh
 set -euxo pipefail
 
-java --version
+FILE=/usr/bin/java.corretto-11-bin
+if [ -f "$FILE" ]; then
+    echo "$FILE exists. Using alternate java name to test."
+    $FILE --version
+else
+    echo "$FILE does not exist. Using default java to test."
+    java --version
+fi
 
 RETVAL=$?
 if [ $RETVAL -eq 0 ] ; then

--- a/recipes-devtools/amazon-corretto/corretto-11-bin_11.0.21.9.1.bb
+++ b/recipes-devtools/amazon-corretto/corretto-11-bin_11.0.21.9.1.bb
@@ -30,6 +30,8 @@ UPSTREAM_CHECK_REGEX ?= "releases/tag/v?(?P<pver>\d+(\.\d+)+)"
 
 UPSTREAM_CHECK_URI = "https://github.com/corretto/corretto-11/tags"
 
+ALTERNATIVE_PRIORITY = "60"
+
 # nooelint: oelint.file.underscores
 require corretto-bin-common.inc
 
@@ -39,3 +41,6 @@ INSANE_SKIP:${PN} += "ldflags"
 RDEPENDS:${PN}-ptest:prepend = "\
     greengrass-bin \
     "
+
+# this is used by meta-aws-tests to find this recipe for ptests, so it should stay in this file instead of moving into corretto-bin-common
+inherit ptest

--- a/recipes-devtools/amazon-corretto/corretto-17-bin/run-ptest
+++ b/recipes-devtools/amazon-corretto/corretto-17-bin/run-ptest
@@ -1,7 +1,14 @@
 #!/bin/sh
 set -euxo pipefail
 
-java --version
+FILE=/usr/bin/java.corretto-17-bin
+if [ -f "$FILE" ]; then
+    echo "$FILE exists. Using alternate java name to test."
+    $FILE --version
+else
+    echo "$FILE does not exist. Using default java to test."
+    java --version
+fi
 
 RETVAL=$?
 if [ $RETVAL -eq 0 ] ; then

--- a/recipes-devtools/amazon-corretto/corretto-17-bin_17.0.9.8.1.bb
+++ b/recipes-devtools/amazon-corretto/corretto-17-bin_17.0.9.8.1.bb
@@ -16,5 +16,10 @@ UPSTREAM_CHECK_REGEX ?= "releases/tag/v?(?P<pver>\d+(\.\d+)+)"
 
 UPSTREAM_CHECK_URI = "https://github.com/corretto/corretto-17/tags"
 
+ALTERNATIVE_PRIORITY = "70"
+
 # nooelint: oelint.file.underscores
 require corretto-bin-common.inc
+
+# this is used by meta-aws-tests to find this recipe for ptests, so it should stay in this file instead of moving into corretto-bin-common
+inherit ptest

--- a/recipes-devtools/amazon-corretto/corretto-21-bin/run-ptest
+++ b/recipes-devtools/amazon-corretto/corretto-21-bin/run-ptest
@@ -1,7 +1,14 @@
 #!/bin/sh
 set -euxo pipefail
 
-java --version
+FILE=/usr/bin/java.corretto-21-bin
+if [ -f "$FILE" ]; then
+    echo "$FILE exists. Using alternate java name to test."
+    $FILE --version
+else
+    echo "$FILE does not exist. Using default java to test."
+    java --version
+fi
 
 RETVAL=$?
 if [ $RETVAL -eq 0 ] ; then

--- a/recipes-devtools/amazon-corretto/corretto-21-bin_21.0.1.12.1.bb
+++ b/recipes-devtools/amazon-corretto/corretto-21-bin_21.0.1.12.1.bb
@@ -16,5 +16,10 @@ UPSTREAM_CHECK_REGEX ?= "releases/tag/v?(?P<pver>\d+(\.\d+)+)"
 
 UPSTREAM_CHECK_URI = "https://github.com/corretto/corretto-21/tags"
 
+ALTERNATIVE_PRIORITY = "80"
+
 # nooelint: oelint.file.underscores
 require corretto-bin-common.inc
+
+# this is used by meta-aws-tests to find this recipe for ptests, so it should stay in this file instead of moving into corretto-bin-common
+inherit ptest

--- a/recipes-devtools/amazon-corretto/corretto-8-bin/run-ptest
+++ b/recipes-devtools/amazon-corretto/corretto-8-bin/run-ptest
@@ -1,7 +1,14 @@
 #!/bin/sh
 set -euxo pipefail
 
-java -version
+FILE=/usr/bin/java.corretto-8-bin
+if [ -f "$FILE" ]; then
+    echo "$FILE exists. Using alternate java name to test."
+    $FILE -version
+else
+    echo "$FILE does not exist. Using default java to test."
+    java -version
+fi
 
 RETVAL=$?
 if [ $RETVAL -eq 0 ] ; then

--- a/recipes-devtools/amazon-corretto/corretto-8-bin_8.392.08.1.bb
+++ b/recipes-devtools/amazon-corretto/corretto-8-bin_8.392.08.1.bb
@@ -13,6 +13,30 @@ SRC_URI[aarch64.sha256sum] = "25f2bf6103c97cc44371d888b649449178baeaa4033d1867a3
 
 UPSTREAM_CHECK_URI = "https://github.com/corretto/corretto-8/tags"
 
+ALTERNATIVE_PRIORITY = "50"
+
+ALTERNATIVE_NAMES = "\
+    jar \
+    jarsigner \
+    java \
+    javac \
+    javadoc \
+    javap \
+    jcmd \
+    jconsole \
+    jdb \
+    jdeps \
+    jfr \
+    jinfo \
+    jmap \
+    jps \
+    jrunscript \
+    jstack \
+    jstat \
+    jstatd \
+    serialver \
+"
+
 # nooelint: oelint.file.underscores
 require corretto-bin-common.inc
 
@@ -26,3 +50,6 @@ RDEPENDS:${PN} += "\
     libgl \
     pango \
 "
+
+# this is used by meta-aws-tests to find this recipe for ptests, so it should stay in this file instead of moving into corretto-bin-common
+inherit ptest

--- a/recipes-devtools/amazon-corretto/corretto-bin-common.inc
+++ b/recipes-devtools/amazon-corretto/corretto-bin-common.inc
@@ -19,8 +19,6 @@ SRC_URI:append = " file://run-ptest"
 
 S = "${WORKDIR}/${BASE}"
 
-inherit ptest
-
 FILES:${PN} += "\
     /usr/lib/${SHR} \
     /usr/bin \
@@ -31,39 +29,10 @@ do_install() {
     install -d ${D}${libdir}/${SHR}
     cp -r ${WORKDIR}/${BASE}/* ${D}${libdir}/${SHR}/
     cd ${D}${bindir}
-    ln -s ../lib/${SHR}/bin/jaotc
-    ln -s ../lib/${SHR}/bin/jarsigner
-    ln -s ../lib/${SHR}/bin/javac
-    ln -s ../lib/${SHR}/bin/javap
-    ln -s ../lib/${SHR}/bin/jconsole
-    ln -s ../lib/${SHR}/bin/jdeprscan
-    ln -s ../lib/${SHR}/bin/jfr
-    ln -s ../lib/${SHR}/bin/jimage
-    ln -s ../lib/${SHR}/bin/jjs
-    ln -s ../lib/${SHR}/bin/jmap
-    ln -s ../lib/${SHR}/bin/jps
-    ln -s ../lib/${SHR}/bin/jshell
-    ln -s ../lib/${SHR}/bin/jstat
-    ln -s ../lib/${SHR}/bin/keytool
-    ln -s ../lib/${SHR}/bin/rmic
-    ln -s ../lib/${SHR}/bin/rmiregistry
-    ln -s ../lib/${SHR}/bin/unpack200
-    ln -s ../lib/${SHR}/bin/jar
-    ln -s ../lib/${SHR}/bin/java
-    ln -s ../lib/${SHR}/bin/javadoc
-    ln -s ../lib/${SHR}/bin/jcmd
-    ln -s ../lib/${SHR}/bin/jdb
-    ln -s ../lib/${SHR}/bin/jdeps
-    ln -s ../lib/${SHR}/bin/jhsdb
-    ln -s ../lib/${SHR}/bin/jinfo
-    ln -s ../lib/${SHR}/bin/jlink
-    ln -s ../lib/${SHR}/bin/jmod
-    ln -s ../lib/${SHR}/bin/jrunscript
-    ln -s ../lib/${SHR}/bin/jstack
-    ln -s ../lib/${SHR}/bin/jstatd
-    ln -s ../lib/${SHR}/bin/pack200
-    ln -s ../lib/${SHR}/bin/rmid
-    ln -s ../lib/${SHR}/bin/serialver
+
+    for alt_name in ${ALTERNATIVE_NAMES}; do
+        ln -s ../lib/${SHR}/bin/${alt_name}
+    done
 }
 
 do_install:append:x86-64() {
@@ -97,3 +66,44 @@ do_install:append() {
         rm ${D}${libdir}/${SHR}/lib/libjsound.so
     fi
 }
+
+inherit update-alternatives
+
+ALTERNATIVE_NAMES ?= "\
+    jar \
+    jarsigner \
+    java \
+    javac \
+    javadoc \
+    javap \
+    jcmd \
+    jconsole \
+    jdb \
+    jdeprscan \
+    jdeps \
+    jfr \
+    jhsdb \
+    jimage \
+    jinfo \
+    jlink \
+    jmap \
+    jmod \
+    jps \
+    jrunscript \
+    jshell \
+    jstack \
+    jstat \
+    jstatd \
+    serialver \
+"
+
+python do_package:prepend () {
+    prio = d.getVar('ALTERNATIVE_PRIORITY')
+    alt_names = d.getVar('ALTERNATIVE_NAMES')
+
+    for alt_name in alt_names.split():
+        d.appendVar("ALTERNATIVE_PRIORITY_VARDEPS", ' ' + alt_name + ':' + prio)
+}
+
+
+ALTERNATIVE:${PN} = "${ALTERNATIVE_NAMES}"


### PR DESCRIPTION
meta-aws-test is searching for ptest in bb file to find recipes to test, therefor move inherit ptest into recipe

running ptest in testimage require all recipes to install in parallel, so ALTERNATE mechanism is added