### PR TITLE
aws-iot-client: add secure tunnel back in

### DIFF
--- a/recipes-iot/aws-iot-device-client/aws-iot-device-client_1.9.bb
+++ b/recipes-iot/aws-iot-device-client/aws-iot-device-client_1.9.bb
@@ -54,8 +54,7 @@ EXTRA_OECMAKE += "\
 
 CXXFLAGS += "-Wno-ignored-attributes"
 
-# enable all modules by default, except st because of: https://github.com/awslabs/aws-iot-device-client/issues/411
-PACKAGECONFIG ??= " dsn dsc ds fp dd pubsub samples jobs"
+PACKAGECONFIG ??= " dsn dsc ds st fp dd pubsub samples jobs"
 
 # enable PACKAGECONFIG = "static" to build static instead of shared
 PACKAGECONFIG[static] = "-DBUILD_SHARED_LIBS=OFF,-DBUILD_SHARED_LIBS=ON,,"


### PR DESCRIPTION
*Issue #, if available:*

Related to issue https://github.com/awslabs/aws-iot-device-client/issues/411

*Description of changes:*
Based on comments in https://github.com/awslabs/aws-iot-device-client/issues/411#issuecomment-1867735644 issues with secure tunneling in https://github.com/awslabs/aws-iot-device-client/issues/411 were resolved in 1.19, however the "st" package config wasn't added back in with https://github.com/aws4embeddedlinux/meta-aws/commit/80c74bfdeafef4fb8a32604b72c347a592469e46.

I've verified this configuration works with secure tunneling using the kas config at https://github.com/Trellis-Logic/meta-aws-iot-demo/blob/main/conf/kas/rpi-rauc-aws-master.yml as well as the kirkstone branch at https://github.com/Trellis-Logic/meta-aws-iot-demo/blob/main/conf/kas/rpi-rauc-aws.yml and I'd ultimately like this backported to kirkstone, let me know if you'd like a PR for kirkstone-next, assuming this is the correct change to make.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
