### PR TITLE
aws-sdk-cpp: fix the ParseError

### DIFF
--- a/recipes-sdk/aws-sdk-cpp/aws-sdk-cpp_1.11.291.bb
+++ b/recipes-sdk/aws-sdk-cpp/aws-sdk-cpp_1.11.291.bb
@@ -427,3 +427,4 @@ xray;'\
 # ec2;\
 # s3-encryption;\
 # identity-management;\
+###


### PR DESCRIPTION
Add '###' to close the commented lines. Fixes the bitbake parsing error caused by the trailing backslash:

ERROR: ParseError at meta-aws/recipes-sdk/aws-sdk-cpp/aws-sdk-cpp_1.11.291.bb:430:
Unparsed lines: ['# ec2;', '# s3-encryption;', '# identity-management;']
ERROR: Parsing halted due to errors, see error messages above

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
