### PR TITLE
aws-sdk-cpp: fix parse error

### DIFF
--- a/recipes-sdk/aws-sdk-cpp/aws-sdk-cpp_1.11.291.bb
+++ b/recipes-sdk/aws-sdk-cpp/aws-sdk-cpp_1.11.291.bb
@@ -426,4 +426,4 @@ xray;'\
 ### with arm64 and x86-64 they work
 # ec2;\
 # s3-encryption;\
-# identity-management;\
+# identity-management;


### PR DESCRIPTION
It fails to parse aws-sdk-cpp with bitbake commit:

* 6bd8367aa9 bitbake: BBHandler: Handle unclosed functions correctly

ERROR: ParseError at meta-aws/recipes-sdk/aws-sdk-cpp/aws-sdk-cpp_1.11.291.bb:430:
  Unparsed lines meta-aws/recipes-sdk/aws-sdk-cpp/aws-sdk-cpp_1.11.291.bb:
  ['# ec2;', '# s3-encryption;', '# identity-management;']
ERROR: Parsing halted due to errors, see error messages above

Remove the trailing backslash to fix it.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
