### PR TITLE
aws-sdk-cpp: upgrade 1.11.291 -> 1.11.299, cmake-qemu

### DIFF
--- a/recipes-sdk/aws-sdk-cpp/aws-sdk-cpp_1.11.299.bb
+++ b/recipes-sdk/aws-sdk-cpp/aws-sdk-cpp_1.11.299.bb
@@ -20,11 +20,11 @@ SRC_URI = "\
     file://ptest_result.py \
     "
 
-SRCREV = "1f4fc882a8765b10ce893dfaf2e08a7fb6220887"
+SRCREV = "d79ece080eba11212b10a857ae551a4b8423fe00"
 
 S = "${WORKDIR}/git"
 
-inherit cmake ptest pkgconfig
+inherit cmake-qemu ptest pkgconfig
 
 PACKAGECONFIG ??= "\
     ${@bb.utils.filter('DISTRO_FEATURES', 'pulseaudio', d)} \


### PR DESCRIPTION
Introduced by: https://github.com/aws/aws-sdk-cpp/commit/6caa146a3dcbee72111fc81e6c48473d4836e280
```
include(GoogleTest)
gtest_discover_tests(${PROJECT_NAME})
```
leads to
GoogleTestAddTests.cmake
| .../build/tests/aws-cpp-sdk-s3-unit-tests/aws-cpp-sdk-s3-unit-tests: error while loading shared libraries: libaws-crt-cpp.so: cannot open shared object file: No such file or directory

-> fix is to use cmake-qemu class instead of cmake

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
