### PR TITLE
aws-sdk-cpp: use cmake instead of cmake-qemu

### DIFF
--- a/recipes-sdk/aws-sdk-cpp/aws-sdk-cpp_1.11.319.bb
+++ b/recipes-sdk/aws-sdk-cpp/aws-sdk-cpp_1.11.319.bb
@@ -24,7 +24,7 @@ SRCREV = "a5cab0adf90cf8e85c771e1de58534e0abd41fdd"
 
 S = "${WORKDIR}/git"
 
-inherit cmake-qemu ptest pkgconfig
+inherit cmake ptest pkgconfig
 
 PACKAGECONFIG ??= "\
     ${@bb.utils.filter('DISTRO_FEATURES', 'pulseaudio', d)} \


### PR DESCRIPTION
This is possible by this commit:
https://github.com/aws/aws-sdk-cpp/commit/c359cb6f2b659ce4c3f212d991e1f1b05dd92302

Will allow backports to kirkstone again.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
