### PR TITLE
EC2-AMI feature: fix race, get var

### DIFF
--- a/conf/machine/aws-ec2-arm64.conf
+++ b/conf/machine/aws-ec2-arm64.conf
@@ -16,6 +16,8 @@ MACHINE_EXTRA_RRECOMMENDS += "kernel-modules linux-firmware"
 
 EFI_PROVIDER ?= "${@bb.utils.contains("DISTRO_FEATURES", "systemd", "systemd-boot", "grub-efi", d)}"
 
+WKS_FILE_DEPENDS_BOOTLOADERS:aarch64 += "systemd-boot"
+
 WKS_FILE ?= "efi-disk.wks.in"
 
 MACHINE_FEATURES:append = " efi rtc"

--- a/scripts/ec2-ami/create-ec2-ami.sh
+++ b/scripts/ec2-ami/create-ec2-ami.sh
@@ -15,7 +15,7 @@ IMAGE_NAME=$3
 MACHINE_NAME=$4
 
 
-IMG_DIR="build/tmp/deploy/images/${MACHINE_NAME}"
+IMG_DIR=$(bitbake-getvar --value -q  DEPLOY_DIR_IMAGE)
 
 TESTDATA_JSON="${IMG_DIR}/${IMAGE_NAME}-${MACHINE_NAME}.rootfs.testdata.json"
 
@@ -28,7 +28,7 @@ TARGET_ARCH=$(jq -r '.TARGET_ARCH' $TESTDATA_JSON)
 IMAGE_NAME=$(jq -r '.IMAGE_NAME' $TESTDATA_JSON)
 IMAGE_ROOTFS_SIZE=$(jq -r '.IMAGE_ROOTFS_SIZE' $TESTDATA_JSON)
 
-
+echo IMG_DIR=$IMG_DIR
 echo DISTRO=$DISTRO
 echo DISTRO_CODENAME=$DISTRO_CODENAME
 echo DISTRO_NAME=$DISTRO_NAME
@@ -120,4 +120,3 @@ AMI_ID=$(aws ec2 register-image --name ${AMI_NAME} --cli-input-json="file://regi
 echo "AMI name: $AMI_NAME"
 echo "AMI ID: $AMI_ID"
 rm register-ami.json
-


### PR DESCRIPTION
Based on suggestions from Jan-Simon Moeller.
- Fixing a potential race by adding, that caused bootloader not in place, when generating the image.

WKS_FILE_DEPENDS_BOOTLOADERS:aarch64 += "systemd-boot"

- Using bitbake-getvar to get DEPLOY_DIR_IMAGE cause build and tmp dir can have various names.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
