### PR TITLE
greengrass set jvm java 11default

### DIFF
--- a/recipes-iot/aws-iot-greengrass/greengrass-bin_2.12.6.bb
+++ b/recipes-iot/aws-iot-greengrass/greengrass-bin_2.12.6.bb
@@ -54,7 +54,7 @@ FILES:${PN} += "\
 
 RDEPENDS:${PN} += "\
     ca-certificates \
-    java-17 \
+    java-11 \
     python3-core \
     python3-json \
     python3-numbers \


### PR DESCRIPTION
As java 11 is still the default for greengrass and Corretto 11 is under LTS:
https://aws.amazon.com/de/about-aws/whats-new/2020/08/amazon-corretto-8-11-support-extended/

Also helps here: https://github.com/aws4embeddedlinux/meta-aws/commit/cc8ab6c5e3a6ec500a1aa69b74cc0ef3bb5fb0e6#commitcomment-143921769