### PR TITLE
aws-crt-python: disable test_websocket.py unit test

### DIFF
--- a/recipes-sdk/aws-crt-python/files/run-ptest
+++ b/recipes-sdk/aws-crt-python/files/run-ptest
@@ -20,12 +20,10 @@ test/test_mqtt.py \
 test/test_mqtt5.py \
 test/test_proxy.py \
 test/test_s3.py \
-test/test_websocket.py \
 "
 
 for TEST in $TESTS
 do
-    cd tests
     python3 -m unittest $TEST
     RETVAL=$?
     if [ $RETVAL -eq 0 ] ; then
@@ -38,3 +36,6 @@ done
 ### removed tests ####
 # ./test/test_http_client.py
 # ./test/test_mqtt5_canary.py
+
+# a expected exception is thrown causing ptest to fail
+# ./test/test_websocket.py 


### PR DESCRIPTION
This test is failing a expected exception is thrown causing ptest to fail

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
