### PR TITLE
python3-botocore: use nobranch=1 to reflect the latest repo status

### DIFF
--- a/recipes-devtools/python/python3-botocore_1.34.157.bb
+++ b/recipes-devtools/python/python3-botocore_1.34.157.bb
@@ -5,7 +5,7 @@ LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=2ee41112a44fe7014dce33e26468ba93"
 
 SRC_URI = "\
-    git://github.com/boto/botocore.git;protocol=https;branch=master \
+    git://github.com/boto/botocore.git;protocol=https;nobranch=1 \
     file://run-ptest \
     "
 


### PR DESCRIPTION
The rev is a valid tag but not in any branch. This is the current status of botocore repo. So use nobranch=1 to reflect such status. This fixes do_fetch error.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
