### PR TITLE
s2n: disable ptest s2n_stacktrace_test as it is not running in container

### DIFF
--- a/recipes-sdk/s2n/s2n/run-ptest
+++ b/recipes-sdk/s2n/s2n/run-ptest
@@ -221,7 +221,6 @@ TESTS="\
 ./s2n_tls_prf_test \
 ./s2n_x509_validator_certificate_signatures_test \
 ./s2n_x509_validator_test \
-./s2n_stacktrace_test \
 "
 
 for TEST in $TESTS


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
