### PR TITLE
aws-iot-device-client: disable tests, as the new aws-c-io event loop …

### DIFF
--- a/recipes-iot/aws-iot-device-client/aws-iot-device-client_1.9.5.bb
+++ b/recipes-iot/aws-iot-device-client/aws-iot-device-client_1.9.5.bb
@@ -21,13 +21,17 @@ SRC_URI = "\
     git://github.com/awslabs/aws-iot-device-client.git;protocol=https;branch=${BRANCH} \
     file://run-ptest \
     file://ptest_result.py \
+    file://001-disable-tests.patch \
     "
 
 SRCREV = "faf80330b96681f05a03e9409c0c0dcc67e4e915"
 
 S = "${WORKDIR}/git"
 
-inherit cmake systemd ptest
+inherit cmake systemd
+# disable package tests
+# this is disabled because of this change here, that is used in the tests:
+# https://github.com/awslabs/aws-c-io/commit/b6bff6f557ecf8b92131471d5668e7b90a196fab
 do_compile_ptest()  {
     cmake_runcmake_build --target test-aws-iot-device-client
 }

--- a/recipes-iot/aws-iot-device-client/files/001-disable-tests.patch
+++ b/recipes-iot/aws-iot-device-client/files/001-disable-tests.patch
@@ -1,0 +1,12 @@
+Upstream-Status: Submitted [author]
+
+Index: git/CMakeLists.txt
+===================================================================
+--- git.orig/CMakeLists.txt
++++ git/CMakeLists.txt
+@@ -265,4 +265,4 @@ if (BUILD_TEST_DEPS)
+             ${CMAKE_BINARY_DIR}/googletest-build)
+ endif ()
+
+-add_subdirectory(test)
++# add_subdirectory(test)


### PR DESCRIPTION
…interface changed.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
