### PR TITLE
[Backport scarthgap-next] aws-sdk-cpp: upgrade 1.11.432 -> 1.11.451

### DIFF
--- a/recipes-sdk/aws-sdk-cpp/aws-sdk-cpp_1.11.451.bb
+++ b/recipes-sdk/aws-sdk-cpp/aws-sdk-cpp_1.11.451.bb
@@ -19,7 +19,7 @@ SRC_URI = "\
     file://ptest_result.py \
     "
 
-SRCREV = "2345a84bffedd2ca4eba64be3edc5e9ee2f7b572"
+SRCREV = "09da88b7726e5dea45ca6136c4951cc71d7f5cfa"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
(cherry picked from commit b02f05847d6a396326d71fcb460ab0c7cb5a99d9)

*Issue:*
#10437

*Description of changes:*
Backports recent updates of `aws-sdk-cpp`. The automatic backport mechanism currently appears to be experiencing issues, so this update has been manually cherry-picked.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
