### PR TITLE
aws-crt-python: use submodule dependencies instead of package depende…

### DIFF
--- a/recipes-sdk/aws-crt-python/aws-crt-python_0.23.2.bb
+++ b/recipes-sdk/aws-crt-python/aws-crt-python_0.23.2.bb
@@ -6,24 +6,12 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
 DEPENDS += "\
         ${PYTHON_PN}-setuptools-native \
-        aws-c-auth \
-        aws-c-cal \
-        aws-c-common \
-        aws-c-compression \
-        aws-c-event-stream \
-        aws-c-http \
-        aws-c-io \
-        aws-c-mqtt \
-        aws-c-s3 \
-        aws-c-sdkutils \
-        aws-checksums \
-        s2n \
         "
 
 BRANCH ?= "main"
 # nooelint: oelint.file.patchsignedoff
 SRC_URI = "\
-           git://github.com/awslabs/aws-crt-python.git;protocol=https;branch=${BRANCH} \
+           gitsm://github.com/awslabs/aws-crt-python.git;protocol=https;branch=${BRANCH} \
            file://fix-shared-linking.patch \
            file://run-ptest \
            "
@@ -51,8 +39,10 @@ RDEPENDS:${PN}-ptest += "\
 "
 
 do_install_ptest() {
-        install -d ${D}${PTEST_PATH}/tests
-        cp -rf ${S}/* ${D}${PTEST_PATH}/tests/
+        cp -rf ${S}/test ${D}${PTEST_PATH}/
 }
 
 BBCLASSEXTEND = "native nativesdk"
+
+# nooelint: oelint.vars.insaneskip:INSANE_SKIP
+INSANE_SKIP:${PN}-dbg += "buildpaths"

--- a/recipes-sdk/aws-crt-python/files/run-ptest
+++ b/recipes-sdk/aws-crt-python/files/run-ptest
@@ -2,12 +2,9 @@
 
 echo nameserver 8.8.4.4 >> /etc/resolv.conf 
 
-cd tests/
-
 # known good tests
 TESTS="\
 test/test_appexit.py \
-test/test_auth.py \
 test/test_checksums.py \
 test/test_common.py \
 test/test_crypto.py \
@@ -34,8 +31,9 @@ do
 done
 
 ### removed tests ####
-# ./test/test_http_client.py
-# ./test/test_mqtt5_canary.py
+# test_auth.py
+# test_http_client.py
+# test_mqtt5_canary.py
 
 # a expected exception is thrown causing ptest to fail
-# ./test/test_websocket.py 
+# test_websocket.py 


### PR DESCRIPTION
…ncies

As stated here: https://github.com/awslabs/aws-crt-python/issues/604#issuecomment-2422849389 it is not save to assume the work together.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
