### PR TITLE
amazon-kvs-webrtc-sdk: remove INSANE_SKIP expanded-d

### DIFF
--- a/recipes-sdk/amazon-kvs-webrtc-sdk/amazon-kvs-webrtc-sdk_1.11.0.bb
+++ b/recipes-sdk/amazon-kvs-webrtc-sdk/amazon-kvs-webrtc-sdk_1.11.0.bb
@@ -84,9 +84,6 @@ do_install_ptest () {
 }
 
 # nooelint: oelint.vars.insaneskip:INSANE_SKIP
-INSANE_SKIP:${PN}-ptest += "expanded-d"
-
-# nooelint: oelint.vars.insaneskip:INSANE_SKIP
 INSANE_SKIP:${PN}-ptest += "buildpaths"
 
 # nooelint: oelint.vars.insaneskip:INSANE_SKIP


### PR DESCRIPTION
INSANE_SKIP:${PN}-ptest += "expanded-d" seems to be obsolete.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
