### PR TITLE
aws-ec2-x86-64: bump linux-yocto preferred version to 6.10

### DIFF
--- a/conf/machine/aws-ec2-x86-64.conf
+++ b/conf/machine/aws-ec2-x86-64.conf
@@ -8,7 +8,7 @@ DEFAULTTUNE ?= "core2-64"
 require conf/machine/include/x86/tune-core2.inc
 include conf/machine/include/x86/x86-base.inc
 
-PREFERRED_VERSION_linux-yocto ?= "5.15%"
+PREFERRED_VERSION_linux-yocto ?= "6.10%"
 PREFERRED_PROVIDER_virtual/kernel ?= "linux-yocto"
 
 MACHINE_EXTRA_RRECOMMENDS += "kernel-modules linux-firmware"


### PR DESCRIPTION
The support for linux-yocto 5.15 was drop a while ago[1].

This makes linux-yocto 6.10 the preferred kernel for AWS-EC2 x86-64 machine to shut down the warnings below:

	WARNING: preferred version 5.15% of linux-yocto not available (for item virtual/kernel)
	WARNING: versions of linux-yocto available: 6.10.14+git 6.6.59+git

[1]: https://git.yoctoproject.org/poky/commit/?h=deaedea295042df3e956660e43dbc871a8fa42d4

Note: 6.10 is the latest version on the [master](https://git.yoctoproject.org/poky/tree/meta/recipes-kernel/linux) branch. Also, dropping the preferred version appears to be a better alternative to avoid the bump through the versions.