### PR TITLE
aws-ec2-x86-64.conf: remove PREFERRED_VERSION_linux-yocto

### DIFF
--- a/conf/machine/aws-ec2-x86-64.conf
+++ b/conf/machine/aws-ec2-x86-64.conf
@@ -8,7 +8,6 @@ DEFAULTTUNE ?= "core2-64"
 require conf/machine/include/x86/tune-core2.inc
 include conf/machine/include/x86/x86-base.inc
 
-PREFERRED_VERSION_linux-yocto ?= "5.15%"
 PREFERRED_PROVIDER_virtual/kernel ?= "linux-yocto"
 
 MACHINE_EXTRA_RRECOMMENDS += "kernel-modules linux-firmware"


### PR DESCRIPTION
Thanks to @gportay for this suggestion.

Going with removing the line.

https://github.com/aws4embeddedlinux/meta-aws/pull/10624