### PR TITLE
greengrass-lite: fix ptest for greengrass-bin

### DIFF
--- a/recipes-iot/aws-iot-greengrass/greengrass-lite/run-ptest
+++ b/recipes-iot/aws-iot-greengrass/greengrass-lite/run-ptest
@@ -1,6 +1,13 @@
 #!/bin/sh
 set -euxo pipefail
 
+# this has been disabled cause this has issues with greengrass-bin
+systemctl enable ggl.gg-ipc.socket.socket
+systemctl start greengrass-lite.target
+
+# settle time
+sleep 10
+
 /usr/bin/configtest
 
 RETVAL=$?

--- a/recipes-iot/aws-iot-greengrass/greengrass-lite_2.0.0.bb
+++ b/recipes-iot/aws-iot-greengrass/greengrass-lite_2.0.0.bb
@@ -122,6 +122,10 @@ do_install:append() {
     chown ${gg_user}:${gg_group} ${D}/${gg_workingdir}
 }
 
+# disable automatic startup of gg-lite, cause this will use the same port as greengrass-bin, conflicting.
+SYSTEMD_SERVICE:${PN}-ptest:remove = "greengrass-lite.target"
+SYSTEMD_SERVICE:${PN}-ptest:remove = "ggl.gg-ipc.socket.socket"
+
 USERADD_PACKAGES = "${PN}"
 GROUPADD_PARAM:${PN} = "-r ${gg_group}; -r ${ggc_group}"
 USERADD_PARAM:${PN} = "-r -M -N -g  ${gg_group} -s /bin/false ${gg_user}; -r -M -N -g  ${ggc_group} -s /bin/false ${ggc_user}"


### PR DESCRIPTION
Disable automatic startup of gg-lite, cause this will use the same port as greengrass-bin, conflicting.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
