### PR TITLE
Fix issue 10914: changed loader mode from 640 to 750

### DIFF
--- a/recipes-iot/aws-iot-greengrass/greengrass-bin_2.14.0.bb
+++ b/recipes-iot/aws-iot-greengrass/greengrass-bin_2.14.0.bb
@@ -79,7 +79,7 @@ do_install() {
     install -m 0440 ${S}/LICENSE                         ${GG_ROOT}
     install -m 0640 ${S}/greengrassv2-init.yaml          ${GG_ROOT}/config/config.yaml.clean
     install -m 0640 ${S}/bin/greengrass.service.template ${GG_ROOT}/packages/artifacts-unarchived/aws.greengrass.Nucleus/${PV}/aws.greengrass.nucleus/bin/greengrass.service.template
-    install -m 0640 ${S}/bin/loader                      ${GG_ROOT}/packages/artifacts-unarchived/aws.greengrass.Nucleus/${PV}/aws.greengrass.nucleus/bin/loader
+    install -m 0750 ${S}/bin/loader                      ${GG_ROOT}/packages/artifacts-unarchived/aws.greengrass.Nucleus/${PV}/aws.greengrass.nucleus/bin/loader
     install -m 0640 ${S}/conf/recipe.yaml                ${GG_ROOT}/packages/artifacts-unarchived/aws.greengrass.Nucleus/${PV}/aws.greengrass.nucleus/conf/recipe.yaml
     install -m 0740 ${S}/lib/Greengrass.jar              ${GG_ROOT}/packages/artifacts-unarchived/aws.greengrass.Nucleus/${PV}/aws.greengrass.nucleus/lib/Greengrass.jar
 


### PR DESCRIPTION
*Issue #, if available:* 10914

*Description of changes:* Changes mode of 'loader' from 640 to 750 so that it can be executed in Greengrass bin

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
