### PR TITLE
firecracker-bin: Update to match OE-Core virtual provider changes

### DIFF
--- a/recipes-containers/firecracker-bin/firecracker-bin_1.10.1.bb
+++ b/recipes-containers/firecracker-bin/firecracker-bin_1.10.1.bb
@@ -46,4 +46,4 @@ do_install() {
 }
 
 # https://bugzilla.yoctoproject.org/show_bug.cgi?id=15227
-PACKAGE_DEPENDS:append:class-target = " virtual/${TARGET_PREFIX}binutils"
+PACKAGE_DEPENDS:append:class-target = " virtual/cross-binutils"

--- a/recipes-containers/firecracker-bin/jailer-bin_1.10.1.bb
+++ b/recipes-containers/firecracker-bin/jailer-bin_1.10.1.bb
@@ -49,4 +49,4 @@ do_install() {
 }
 
 # https://bugzilla.yoctoproject.org/show_bug.cgi?id=15227
-PACKAGE_DEPENDS:append:class-target = " virtual/${TARGET_PREFIX}binutils"
+PACKAGE_DEPENDS:append:class-target = " virtual/cross-binutils"


### PR DESCRIPTION
OE-Core changed to to use virtual/cross-binutils to replace the older more complex cross providers. Update the recipes to match.

This fixes check layer failures on the autobuilder.
