### PR TITLE
aws-iot-device-sdk-cpp-v2: fix build with latest CRT

### DIFF
--- a/recipes-sdk/aws-iot-device-sdk-cpp-v2/aws-iot-device-sdk-cpp-v2/001-cmake-aws-module-path.patch
+++ b/recipes-sdk/aws-iot-device-sdk-cpp-v2/aws-iot-device-sdk-cpp-v2/001-cmake-aws-module-path.patch
@@ -1,0 +1,18 @@
+Upstream-Status: Submitted [https://github.com/aws/aws-iot-device-sdk-cpp-v2/issues/776]
+
+Index: git/CMakeLists.txt
+===================================================================
+--- git.orig/CMakeLists.txt
++++ git/CMakeLists.txt
+@@ -37,10 +37,7 @@ if (${CMAKE_INSTALL_LIBDIR} STREQUAL "li
+ endif()
+
+ # This is required in order to append /lib/cmake to each element in CMAKE_PREFIX_PATH
+-set(AWS_MODULE_DIR "/${CMAKE_INSTALL_LIBDIR}/cmake")
+-string(REPLACE ";" "${AWS_MODULE_DIR};" AWS_MODULE_PATH "${CMAKE_PREFIX_PATH}${AWS_MODULE_DIR}")
+-# Append that generated list to the module search path
+-list(APPEND CMAKE_MODULE_PATH ${AWS_MODULE_PATH})
++find_package(aws-c-common REQUIRED)
+
+ if (NOT CMAKE_BUILD_TYPE)
+     if (NOT WIN32)

--- a/recipes-sdk/aws-iot-device-sdk-cpp-v2/aws-iot-device-sdk-cpp-v2_1.34.0.bb
+++ b/recipes-sdk/aws-iot-device-sdk-cpp-v2/aws-iot-device-sdk-cpp-v2_1.34.0.bb
@@ -11,7 +11,10 @@ PROVIDES += "aws/aws-iot-device-sdk-cpp-v2"
 
 require aws-iot-device-sdk-cpp-v2-version.inc
 
-SRC_URI:append = " file://run-ptest"
+SRC_URI:append = " \
+    file://run-ptest \
+    file://001-cmake-aws-module-path.patch \
+    "
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Breaking change in CMAKE file of CRT libs.
https://github.com/aws/aws-iot-device-sdk-cpp-v2/issues/776

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
