### PR TITLE
build-test-recipe.yml: set 4GB for qemu

### DIFF
--- a/.github/workflows/build-test-recipe.yml
+++ b/.github/workflows/build-test-recipe.yml
@@ -111,8 +111,7 @@ jobs:
              cd  ${{ github.workspace }}
              source poky/oe-init-build-env build
              echo QEMU_USE_KVM = \"\" >> conf/local.conf
-             # set to the same as core-image-ptest
-             echo QB_MEM = \"-m 2G\" >> conf/local.conf
+             echo QB_MEM = \"-m 4G\" >> conf/local.conf
              # use slirp networking instead of TAP interface (require root rights)
              echo QEMU_USE_SLIRP = \"1\" >> conf/local.conf
              echo TEST_RUNQEMUPARAMS += \"slirp\" >> conf/local.conf


### PR DESCRIPTION
As aws-sdk-cpp tests start to fail with memory related error message.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
