### PR TITLE
aws-sdk-cpp: disable sanitizers

### DIFF
--- a/recipes-sdk/aws-sdk-cpp/aws-sdk-cpp_1.11.506.bb
+++ b/recipes-sdk/aws-sdk-cpp/aws-sdk-cpp_1.11.506.bb
@@ -30,8 +30,6 @@ PACKAGECONFIG ?= "\
     ${@bb.utils.contains('PTEST_ENABLED', '1', 'with-tests', '', d)} \
     "
 
-PACKAGECONFIG:append:x86-64 = " ${@bb.utils.contains('PTEST_ENABLED', '1', 'sanitize', '', d)}"
-
 PACKAGECONFIG[pulseaudio] = "-DPULSEAUDIO=TRUE, -DPULSEAUDIO=FALSE, pulseaudio"
 
 # CMAKE_CROSSCOMPILING=OFF will enable build of unit tests


### PR DESCRIPTION
Done because of compile issues in kirkstone branch. Like this:
| {standard input}: Assembler messages:
| {standard input}:6107201: Warning: end of file not at end of a line; newline inserted | {standard input}:6108273: Error: unknown pseudo-op: `.lbe1711249' | {standard input}: Error: open CFI at the end of file; missing .cfi_endproc directive | x86_64-poky-linux-g++: fatal error: Killed signal terminated program cc1plus | compilation terminated.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
