### PR TITLE
build-test-recipe.yml: disable parselogs for kirkstone

### DIFF
--- a/.github/workflows/build-test-recipe.yml
+++ b/.github/workflows/build-test-recipe.yml
@@ -121,7 +121,7 @@ jobs:
              echo DISTRO = \"poky-altcfg\" >> conf/local.conf
              # this will specify what test should run when running testimage cmd - oeqa layer tests + ptests:
              # Ping and SSH are not required, but do help in debugging. ptest will discover all ptest packages.
-             echo TEST_SUITES = \" ping ssh ptest parselogs\" >> conf/local.conf
+             echo TEST_SUITES = \" ping ssh ptest\" >> conf/local.conf
              # this will allow - running testimage cmd: bitbake core-image-minimal -c testimage
              echo IMAGE_CLASSES += \"testimage\" >> conf/local.conf
              cat conf/local.conf


### PR DESCRIPTION
As there are issues with this feature in kirkstone. Like: 
...vmap allocation for size 1052672 failed: use vmalloc=<size> to increase size\n[    3.926648] pci-host-generic 3f000000.pcie: ECAM ioremap failed\n[    3.927917] pci-host-generic: probe of 3f000000.pcie failed with error -12\n[    3.957702] printk: console [hvc0] enabled\n[    3.987493] brd: module loaded\n[    3.999732] virtio_blk virtio1: [vda] 981384 512-byte logical blocks (502 MB/479 MiB)\n

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
