### PR TITLE
build-test-all-branches.yml: wait up to 5h

### DIFF
--- a/.github/workflows/build-test-all-branches.yml
+++ b/.github/workflows/build-test-all-branches.yml
@@ -86,7 +86,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           IFS=' ' read -ra run_ids <<< "${{ env.run_ids }}"
-          max_attempts=180  # Maximum 180 min exec time
+          max_attempts=300  # Maximum 300 min exec time
 
           for attempt in $(seq 1 $max_attempts); do
             all_completed=true


### PR DESCRIPTION
Since activating sanitizers tests run longer.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
