### PR TITLE
aws-iot-device-sdk-cpp-v2: change to build aws-crt-cpp and aws-c-iot …

### DIFF
--- a/.github/workflows/build-test-recipe.yml
+++ b/.github/workflows/build-test-recipe.yml
@@ -89,7 +89,7 @@ jobs:
           export RECIPES=$( echo "${{ needs.changed.outputs.diff }}" | tr ' ' '\n' | grep '\.bb.*$' | sed 's!.*/!!' | sed 's!.bb!!' | sed 's!_.*!!' | sort | uniq | sed -z $'s/\\\n/ /g')
           if [ "" == "$RECIPES" ]; then
             echo "No changed recipes, adding everything with a ptest to test, build"
-            THINGS_TO_EXCLUDE="! -name aws-lc* ! -name neo-ai-tv* ! -name corretto-17-bin* ! -name corretto-21-bin* ! -name corretto-8-bin* ! -name firecracker-bin* ! -name jailer-bin* ! -name amazon-kvs-producer-sdk-c* ! -name  aws-cli-v2* ! -name aws-iot-device-sdk-cpp-v2-samples-fleet-provisoning* ! -name aws-c-iot* "
+            THINGS_TO_EXCLUDE="! -name aws-lc* ! -name neo-ai-tv* ! -name corretto-17-bin* ! -name corretto-21-bin* ! -name corretto-8-bin* ! -name firecracker-bin* ! -name jailer-bin* ! -name amazon-kvs-producer-sdk-c* ! -name  aws-cli-v2* "
             if [ ${{ matrix.machine }} == "qemuarm" ]; then
               THINGS_TO_EXCLUDE+="! -name amazon-kvs-webrtc-sdk* ! -name amazon-kvs-producer-pic* ! -name amazon-cloudwatch-agent*"
             fi

--- a/recipes-sdk/aws-iot-device-sdk-cpp-v2/aws-iot-device-sdk-cpp-v2-samples.inc
+++ b/recipes-sdk/aws-iot-device-sdk-cpp-v2/aws-iot-device-sdk-cpp-v2-samples.inc
@@ -34,10 +34,3 @@ SOLIBS = "*.so"
 FILES_SOLIBSDEV = ""
 
 BBCLASSEXTEND = "native nativesdk"
-
-# -fsanitize=address does cause this
-# nooelint: oelint.vars.insaneskip:INSANE_SKIP
-INSANE_SKIP += "${@bb.utils.contains('PACKAGECONFIG', 'sanitize', 'buildpaths', '', d)}"
-
-PACKAGECONFIG[sanitize] = ",, gcc-sanitizers"
-OECMAKE_CXX_FLAGS += "${@bb.utils.contains('PACKAGECONFIG', 'sanitize', '-fsanitize=address,undefined -fno-omit-frame-pointer', '', d)}"

--- a/recipes-sdk/aws-iot-device-sdk-cpp-v2/aws-iot-device-sdk-cpp-v2/001-shared-static-crt-libs.patch
+++ b/recipes-sdk/aws-iot-device-sdk-cpp-v2/aws-iot-device-sdk-cpp-v2/001-shared-static-crt-libs.patch
@@ -1,0 +1,32 @@
+This disable the shared libs build for aws-crt-cpp and aws-c-iot,
+cause they will conflict with already exising versions on a system.
+Therefor they are static linked into the cpp libs to not conflict.
+
+Upstream-Status: Inappropriate [oe specific]
+
+
+Index: git/crt/aws-crt-cpp/CMakeLists.txt
+===================================================================
+--- git.orig/crt/aws-crt-cpp/CMakeLists.txt
++++ git/crt/aws-crt-cpp/CMakeLists.txt
+@@ -1,5 +1,7 @@
+ cmake_minimum_required(VERSION 3.9...3.31)
+
++set(BUILD_SHARED_LIBS OFF)
++
+ option(BUILD_DEPS "Builds aws common runtime dependencies as part of build. Turn off if you want to control your dependency chain." ON)
+ option(BYO_CRYPTO "Don't build a tls implementation or link against a crypto interface. This feature is only for unix builds currently" OFF)
+ option(USE_OPENSSL "Set this if you want to use your system's OpenSSL 1.0.2/1.1.1 compatible libcrypto" OFF)
+Index: git/crt/aws-c-iot/CMakeLists.txt
+===================================================================
+--- git.orig/crt/aws-c-iot/CMakeLists.txt
++++ git/crt/aws-c-iot/CMakeLists.txt
+@@ -1,6 +1,8 @@
+ cmake_minimum_required(VERSION 3.9...3.31)
+ project(aws-c-iot C)
+
++set(BUILD_SHARED_LIBS OFF)
++
+ option(USE_EXTERNAL_DEPS_SOURCES "Use dependencies provided by add_subdirectory command" OFF)
+
+ if (USE_EXTERNAL_DEPS_SOURCES)

--- a/recipes-sdk/aws-iot-device-sdk-cpp-v2/aws-iot-device-sdk-cpp-v2_1.35.1.bb
+++ b/recipes-sdk/aws-iot-device-sdk-cpp-v2/aws-iot-device-sdk-cpp-v2_1.35.1.bb
@@ -14,6 +14,7 @@ require aws-iot-device-sdk-cpp-v2-version.inc
 SRC_URI:append = " \
     file://run-ptest \
     file://openssl_suppressions.txt \
+    ${@bb.utils.contains('PACKAGECONFIG', 'static', '', 'file://001-shared-static-crt-libs.patch', d)} \
     "
 
 S = "${WORKDIR}/git"
@@ -46,28 +47,7 @@ PACKAGECONFIG ??= "\
     build-deps \
     "
 
-PACKAGECONFIG:append:x86-64 = " ${@bb.utils.contains('PTEST_ENABLED', '1', 'sanitize', '', d)}"
-
 FILES:${PN} += "${@bb.utils.contains('PACKAGECONFIG', 'build-deps', '/usr/lib/*', '', d)}"
-FILES:${PN}-dev += "\
-    ${libdir}/*/cmake \
-    ${libdir}/pkgconfig/*.pc \
-    ${libdir}/libaws-c-common.so \
-    ${libdir}/libs2n.so \
-    ${libdir}/libaws-c-sdkutils.so \
-    ${libdir}/libaws-c-io.so \
-    ${libdir}/libaws-c-cal.so \
-    ${libdir}/libaws-c-compression.so \
-    ${libdir}/libaws-c-http.so \
-    ${libdir}/libaws-c-auth.so \
-    ${libdir}/libaws-c-mqtt.so \
-    ${libdir}/libaws-checksums.so \
-    ${libdir}/libaws-c-event-stream.so \
-    ${libdir}/libaws-c-s3.so \
-    ${libdir}/libaws-c-iot.so \
-"
-
-RCONFLICTS:${PN} = "${@bb.utils.contains('PACKAGECONFIG', 'build-deps', 'aws-c-iot', '', d)}"
 
 # nooelint: oelint.vars.insaneskip:INSANE_SKIP
 INSANE_SKIP += "${@bb.utils.contains('PACKAGECONFIG', 'build-deps', 'ldflags', '', d)}"
@@ -79,16 +59,3 @@ RDEPENDS:${PN}-ptest:prepend = "\
 BBCLASSEXTEND = "native nativesdk"
 
 EXTRA_OECMAKE:append = " -DCMAKE_BUILD_TYPE=RelWithDebInfo"
-
-# -fsanitize=address does cause this
-# nooelint: oelint.vars.insaneskip:INSANE_SKIP
-INSANE_SKIP += "${@bb.utils.contains('PACKAGECONFIG', 'sanitize', 'buildpaths', '', d)}"
-
-PACKAGECONFIG[sanitize] = ",, gcc-sanitizers"
-OECMAKE_CXX_FLAGS += "${@bb.utils.contains('PACKAGECONFIG', 'sanitize', '-fsanitize=address,undefined -fno-omit-frame-pointer', '', d)}"
-
-do_install_ptest:append() {
-    install -d ${D}${PTEST_PATH}/tests
-
-    install ${UNPACKDIR}/openssl_suppressions.txt ${D}${PTEST_PATH}/
-}


### PR DESCRIPTION
…static

This disable the shared libs build for aws-crt-cpp and aws-c-iot, cause they will conflict with already exising versions on a system. Therefor they are static linked into the cpp libs to not conflict.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
