### PR TITLE
aws-iot-device-sdk-cpp-v2: add PIC

### DIFF
--- a/recipes-sdk/aws-iot-device-sdk-cpp-v2/aws-iot-device-sdk-cpp-v2_1.35.1.bb
+++ b/recipes-sdk/aws-iot-device-sdk-cpp-v2/aws-iot-device-sdk-cpp-v2_1.35.1.bb
@@ -23,7 +23,8 @@ inherit cmake pkgconfig ptest
 
 UPSTREAM_CHECK_GITTAGREGEX = "v(?P<pver>\d+\.\d+(\.\d+)*)"
 
-CFLAGS:append = " -Wl,-Bsymbolic"
+CXXFLAGS:append = " -fPIC"
+LDFLAGS:append = " -Wl,-Bsymbolic"
 
 EXTRA_OECMAKE += "\
     -DCMAKE_MODULE_PATH=${STAGING_LIBDIR}/cmake \


### PR DESCRIPTION
to fix textrel error on arm32 in styhead.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
