### PR TITLE
aws-iot-device-sdk-cpp-v2-samples-fleet-provisoning: rename binary

### DIFF
--- a/recipes-sdk/aws-iot-device-sdk-cpp-v2/aws-iot-device-sdk-cpp-v2-samples-fleet-provisoning.bb
+++ b/recipes-sdk/aws-iot-device-sdk-cpp-v2/aws-iot-device-sdk-cpp-v2-samples-fleet-provisoning.bb
@@ -11,7 +11,7 @@ RDEPENDS:${PN}-ptest += "python3 aws-cli"
 
 do_install() {
  install -d ${D}${bindir}
- install ${B}/fleet-provisioning ${D}${bindir}
+ install ${B}/fleet-provisioning ${D}${bindir}/aws-iot-device-sdk-cpp-v2-samples-fleet-provisoning
 }
 
 inherit ptest

--- a/recipes-sdk/aws-iot-device-sdk-cpp-v2/aws-iot-device-sdk-cpp-v2-samples-fleet-provisoning/run-ptest
+++ b/recipes-sdk/aws-iot-device-sdk-cpp-v2/aws-iot-device-sdk-cpp-v2-samples-fleet-provisoning/run-ptest
@@ -39,7 +39,7 @@ aws iot create-provisioning-claim \
     --path ./tmp \
     --filename provision
 
-fleet-provisioning --endpoint $IOT_DATA_ENDPOINT --cert ./tmp/provision.cert.pem --key ./tmp/provision.private.key --template_name $TEMPLATE --template_parameters '{"SerialNumber":"'$DATE'","DeviceLocation":"Seattle"}'
+aws-iot-device-sdk-cpp-v2-samples-fleet-provisoning --endpoint $IOT_DATA_ENDPOINT --cert ./tmp/provision.cert.pem --key ./tmp/provision.private.key --template_name $TEMPLATE --template_parameters '{"SerialNumber":"'$DATE'","DeviceLocation":"Seattle"}'
 
 # this also acts like a (try-) catch block
 if [ $? -eq 0 ] ; then


### PR DESCRIPTION
From fleet-provisioning to aws-iot-device-sdk-cpp-v2-samples-fleet-provisoning, as there is a name conflict with greengrass-bin fleet-provisioning.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
