### PR TITLE
aws-iot-device-sdk-cpp-v2: use libdir to avoid do_package error

### DIFF
--- a/recipes-sdk/aws-iot-device-sdk-cpp-v2/aws-iot-device-sdk-cpp-v2_1.35.1.bb
+++ b/recipes-sdk/aws-iot-device-sdk-cpp-v2/aws-iot-device-sdk-cpp-v2_1.35.1.bb
@@ -47,7 +47,7 @@ PACKAGECONFIG ??= "\
     build-deps \
     "
 
-FILES:${PN} += "${@bb.utils.contains('PACKAGECONFIG', 'build-deps', '/usr/lib/*', '', d)}"
+FILES:${PN} += "${@bb.utils.contains('PACKAGECONFIG', 'build-deps', '${libdir}/*', '', d)}"
 
 # nooelint: oelint.vars.insaneskip:INSANE_SKIP
 INSANE_SKIP += "${@bb.utils.contains('PACKAGECONFIG', 'build-deps', 'ldflags', '', d)}"


### PR DESCRIPTION
If multilib is enabled, libdir is /usr/lib64, and this will cause do_package error about installed-not-shipped issue.

Use ${libdir} to avoid such issue.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
