### PR TITLE
revert UNPACKDIR to WORKDIR as this is breaking nightly updates

### DIFF
--- a/.github/workflows/oelint-adv.yml
+++ b/.github/workflows/oelint-adv.yml
@@ -8,24 +8,24 @@ on:
 jobs:
   oelint-adv:
     runs-on: ubuntu-22.04
-      
+
     steps:
       - name: install required packages to run oelint_adv
-        run: | 
+        run: |
           sudo apt-get -y install python3-pip
           sudo pip3 install oelint_adv
-          
+
       - name: checkout meta-aws branch to test
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
- 
+
       - name: get changed bb files
-        id: changes       
-        run: |          
-          echo "::set-output name=bb::$(git diff --name-only --diff-filter=ACMRT ${{ github.event.pull_request.base.sha }} ${{ github.sha }} | grep .bb | xargs)"          
-          
-      - name: run oelint_adv      
+        id: changes
+        run: |
+          echo "::set-output name=bb::$(git diff --name-only --diff-filter=ACMRT ${{ github.event.pull_request.base.sha }} ${{ github.sha }} | grep .bb | xargs)"
+
+      - name: run oelint_adv
         if: ${{steps.changes.outputs.bb}}
         run: |
-          oelint-adv --nowarn --noinfo ${{steps.changes.outputs.bb}}
+          oelint-adv --suppress oelint.vars.unpackdir --nowarn --noinfo ${{steps.changes.outputs.bb}}

--- a/recipes-cloud/amazon-cloudwatch-agent/amazon-cloudwatch-agent_1.300054.0.bb
+++ b/recipes-cloud/amazon-cloudwatch-agent/amazon-cloudwatch-agent_1.300054.0.bb
@@ -19,7 +19,7 @@ SRC_URI = "\
 
 SRCREV = "01b3fbdbe2d2234a44b1219d4f71d11335b771f2"
 
-S = "${UNPACKDIR}/git/src/${GO_IMPORT}"
+S = "${WORKDIR}/git/src/${GO_IMPORT}"
 
 do_compile[network] = "1"
 
@@ -29,7 +29,7 @@ do_compile:prepend() {
     export BUILDTAGS="static_build"
     export GO_BUILD_FLAGS="-trimpath"
     export GOARCH="${TARGET_GOARCH}"
-    export GOPATH="${UNPACKDIR}/git/:${S}/src/import/.gopath:${S}/src/import/vendor:${STAGING_DIR_TARGET}/${prefix}/local/go:${WORKDIR}/git/"
+    export GOPATH="${WORKDIR}/git/:${S}/src/import/.gopath:${S}/src/import/vendor:${STAGING_DIR_TARGET}/${prefix}/local/go:${WORKDIR}/git/"
 }
 
 # nooelint: oelint.task.dash

--- a/recipes-cloud/amazon-cloudwatch-publisher/amazon-cloudwatch-publisher_1.2.4.bb
+++ b/recipes-cloud/amazon-cloudwatch-publisher/amazon-cloudwatch-publisher_1.2.4.bb
@@ -12,7 +12,7 @@ SRC_URI = "\
     file://run-ptest \
     "
 SRCREV = "9feebfa9facb6bfddade737de7a90bfbfd65cf6e"
-S = "${UNPACKDIR}/git"
+S = "${WORKDIR}/git"
 
 inherit systemd ptest
 

--- a/recipes-containers/firecracker-bin/firecracker-bin_1.10.1.bb
+++ b/recipes-containers/firecracker-bin/firecracker-bin_1.10.1.bb
@@ -27,7 +27,7 @@ SRC_URI:append = " \
     file://run-ptest \
 "
 
-S = "${UNPACKDIR}/release-v${PV}-${TARGET_ARCH}"
+S = "${WORKDIR}/release-v${PV}-${TARGET_ARCH}"
 
 inherit bin_package ptest
 

--- a/recipes-containers/firecracker-bin/jailer-bin_1.10.1.bb
+++ b/recipes-containers/firecracker-bin/jailer-bin_1.10.1.bb
@@ -27,7 +27,7 @@ SRC_URI:append = " \
     file://run-ptest \
 "
 
-S = "${UNPACKDIR}/release-v${PV}-${TARGET_ARCH}"
+S = "${WORKDIR}/release-v${PV}-${TARGET_ARCH}"
 
 inherit bin_package ptest
 

--- a/recipes-devtools/python/python3-boto3_1.37.38.bb
+++ b/recipes-devtools/python/python3-boto3_1.37.38.bb
@@ -9,7 +9,7 @@ SRC_URI = "\
     file://run-ptest"
 
 SRCREV = "3f98cd0ed5dc41957e2303a3473b1249b8f4a7c4"
-S = "${UNPACKDIR}/git"
+S = "${WORKDIR}/git"
 
 inherit setuptools3 ptest
 

--- a/recipes-devtools/python/python3-botocore_1.37.38.bb
+++ b/recipes-devtools/python/python3-botocore_1.37.38.bb
@@ -10,7 +10,7 @@ SRC_URI = "\
     "
 
 SRCREV = "2a882881e2f02f8959df7b551978005854f8f5dd"
-S = "${UNPACKDIR}/git"
+S = "${WORKDIR}/git"
 
 inherit setuptools3 ptest
 

--- a/recipes-devtools/python/python3-s3transfer_0.11.5.bb
+++ b/recipes-devtools/python/python3-s3transfer_0.11.5.bb
@@ -10,7 +10,7 @@ SRC_URI = "\
     "
 SRCREV = "314ab603fae915e5b240fc0ee58897c8f3abfcf1"
 
-S = "${UNPACKDIR}/git"
+S = "${WORKDIR}/git"
 
 inherit setuptools3 ptest
 

--- a/recipes-iot/aws-iot-device-client/aws-iot-device-client_1.10.0.bb
+++ b/recipes-iot/aws-iot-device-client/aws-iot-device-client_1.10.0.bb
@@ -27,7 +27,7 @@ SRC_URI = "\
 
 SRCREV = "af44d1508fb683d69dc1b62f9e81709ccaa429aa"
 
-S = "${UNPACKDIR}/git"
+S = "${WORKDIR}/git"
 
 inherit cmake systemd ptest
 

--- a/recipes-iot/aws-iot-fleetwise/aws-iot-fleetwise-edge_1.3.0.bb
+++ b/recipes-iot/aws-iot-fleetwise/aws-iot-fleetwise-edge_1.3.0.bb
@@ -24,7 +24,7 @@ SRC_URI = "\
 
 SRCREV = "a5dacc79945ac33c19dce3924b1162a14526314e"
 
-S = "${UNPACKDIR}/git"
+S = "${WORKDIR}/git"
 
 inherit cmake systemd ptest pkgconfig
 
@@ -70,7 +70,7 @@ do_configure:append() {
     # Execute the script with arguments to generate the file
     ${S}/tools/configure-fwe.sh \
         --input-config-file ${S}/configuration/static-config.json \
-        --output-config-file ${UNPACKDIR}/config-0.json \
+        --output-config-file ${WORKDIR}/config-0.json \
         --connection-type ${CONNECTION_TYPE} \
         --vehicle-name ${VEHICLE_NAME} \
         --endpoint-url ${ENDPOINT_URL} \
@@ -92,7 +92,7 @@ do_install() {
     install -d ${D}${systemd_system_unitdir}
     install -m 0755 ${S}/tools/deploy/fwe@.service ${D}${systemd_system_unitdir}
     install -d ${D}${sysconfdir}/aws-iot-fleetwise
-    install -m 0755 ${UNPACKDIR}/config-0.json ${D}${sysconfdir}/aws-iot-fleetwise
+    install -m 0755 ${WORKDIR}/config-0.json ${D}${sysconfdir}/aws-iot-fleetwise
     install -d ${D}${localstatedir}/aws-iot-fleetwise
 }
 

--- a/recipes-iot/aws-iot-greengrass/greengrass-bin_2.14.1.bb
+++ b/recipes-iot/aws-iot-greengrass/greengrass-bin_2.14.1.bb
@@ -9,7 +9,7 @@ GG_ROOT = "${D}/${GG_BASENAME}"
 GGV2_FLEETPROVISIONING_VERSION ?= "1.2.2"
 GGV2_FLEET_PROVISIONING_TEMPLATE_NAME ?= "GreengrassFleetProvisioningTemplate"
 
-LIC_FILES_CHKSUM = "file://${UNPACKDIR}/greengrass-bin/LICENSE;md5=34400b68072d710fecd0a2940a0d1658"
+LIC_FILES_CHKSUM = "file://${WORKDIR}/greengrass-bin/LICENSE;md5=34400b68072d710fecd0a2940a0d1658"
 
 DEPENDS += "gettext-native"
 
@@ -46,7 +46,7 @@ GG_USESYSTEMD = "${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'yes', 'no',
 
 inherit systemd useradd ptest pkgconfig
 
-S = "${UNPACKDIR}/greengrass-bin"
+S = "${WORKDIR}/greengrass-bin"
 
 FILES:${PN} += "\
     /${GG_BASENAME} \
@@ -76,7 +76,7 @@ do_install() {
     ln -s /${GG_BASENAME}/packages/artifacts-unarchived/aws.greengrass.Nucleus/${PV}/aws.greengrass.nucleus ${GG_ROOT}/alts/init/distro
 
     install -m 0440 ${S}/LICENSE                         ${GG_ROOT}
-    install -m 0640 ${S}/../greengrassv2-init.yaml          ${GG_ROOT}/config/config.yaml.clean
+    install -m 0640 ${UNPACKDIR}/greengrassv2-init.yaml          ${GG_ROOT}/config/config.yaml.clean
     install -m 0640 ${S}/bin/greengrass.service.template ${GG_ROOT}/packages/artifacts-unarchived/aws.greengrass.Nucleus/${PV}/aws.greengrass.nucleus/bin/greengrass.service.template
     install -m 0750 ${S}/bin/loader                      ${GG_ROOT}/packages/artifacts-unarchived/aws.greengrass.Nucleus/${PV}/aws.greengrass.nucleus/bin/loader
     install -m 0640 ${S}/conf/recipe.yaml                ${GG_ROOT}/packages/artifacts-unarchived/aws.greengrass.Nucleus/${PV}/aws.greengrass.nucleus/conf/recipe.yaml

--- a/recipes-iot/aws-iot-securetunneling-localproxy/aws-iot-securetunneling-localproxy_git.bb
+++ b/recipes-iot/aws-iot-securetunneling-localproxy/aws-iot-securetunneling-localproxy_git.bb
@@ -29,7 +29,7 @@ SRCREV = "8557d5faf5fe21fbf8ddbc82e96840d8fe985cef"
 
 UPSTREAM_CHECK_COMMITS = "1"
 
-S = "${UNPACKDIR}/git"
+S = "${WORKDIR}/git"
 
 inherit cmake ptest pkgconfig
 

--- a/recipes-sdk/amazon-kvs-producer-sdk/amazon-kvs-producer-pic_1.1.0.bb
+++ b/recipes-sdk/amazon-kvs-producer-sdk/amazon-kvs-producer-pic_1.1.0.bb
@@ -20,7 +20,7 @@ UPSTREAM_CHECK_GITTAGREGEX = "git_invalid_tag_regex"
 # https://github.com/awslabs/amazon-kinesis-video-streams-producer-c/blob/master/CMake/Dependencies/libkvspic-CMakeLists.txt
 SRCREV = "65e38dac9b30523d43a57bc009d679e627b58d9a"
 
-S = "${UNPACKDIR}/git"
+S = "${WORKDIR}/git"
 
 inherit cmake pkgconfig ptest
 
@@ -68,7 +68,7 @@ RDEPENDS:${PN}-ptest += "\
 
 do_install_ptest () {
    install -d ${D}${PTEST_PATH}/tests
-   install -m 0755 ${UNPACKDIR}/ptest_result.py ${D}${PTEST_PATH}/
+   install -m 0755 ${WORKDIR}/ptest_result.py ${D}${PTEST_PATH}/
    cp -r ${B}/tst/kvspic_test ${D}${PTEST_PATH}/tests/
 }
 

--- a/recipes-sdk/amazon-kvs-producer-sdk/amazon-kvs-producer-sdk-cpp_3.4.2.bb
+++ b/recipes-sdk/amazon-kvs-producer-sdk/amazon-kvs-producer-sdk-cpp_3.4.2.bb
@@ -72,31 +72,31 @@ do_install() {
     install -d ${D}${includedir}/com/amazonaws/kinesis/video/producer/credential-providers
     install -d ${D}${includedir}/com/amazonaws/kinesis/video/producer/gstreamer
 
-    install -m 0640 ${WORKDIR}/git/src/CachingEndpointOnlyCallbackProvider.h ${D}${includedir}/com/amazonaws/kinesis/video/producer/CachingEndpointOnlyCallbackProvider.h
-    install -m 0640 ${WORKDIR}/git/src/ThreadSafeMap.h ${D}${includedir}/com/amazonaws/kinesis/video/producer/ThreadSafeMap.h
-    install -m 0640 ${WORKDIR}/git/src/DefaultCallbackProvider.h ${D}${includedir}/com/amazonaws/kinesis/video/producer/DefaultCallbackProvider.h
-    install -m 0640 ${WORKDIR}/git/src/StreamCallbackProvider.h ${D}${includedir}/com/amazonaws/kinesis/video/producer/StreamCallbackProvider.h
-    install -m 0640 ${WORKDIR}/git/src/KinesisVideoProducer.h ${D}${includedir}/com/amazonaws/kinesis/video/producer/KinesisVideoProducer.h
-    install -m 0640 ${WORKDIR}/git/src/DefaultDeviceInfoProvider.h ${D}${includedir}/com/amazonaws/kinesis/video/producer/DefaultDeviceInfoProvider.h
-    install -m 0640 ${WORKDIR}/git/src/CallbackProvider.h ${D}${includedir}/com/amazonaws/kinesis/video/producer/CallbackProvider.h
-    install -m 0640 ${WORKDIR}/git/src/StreamTags.h ${D}${includedir}/com/amazonaws/kinesis/video/producer/StreamTags.h
-    install -m 0640 ${WORKDIR}/git/src/Logger.h ${D}${includedir}/com/amazonaws/kinesis/video/producer/Logger.h
-    install -m 0640 ${WORKDIR}/git/src/KinesisVideoStream.h ${D}${includedir}/com/amazonaws/kinesis/video/producer/KinesisVideoStream.h
-    install -m 0640 ${WORKDIR}/git/src/ClientCallbackProvider.h ${D}${includedir}/com/amazonaws/kinesis/video/producer/ClientCallbackProvider.h
+    install -m 0640 ${UNPACKDIR}/git/src/CachingEndpointOnlyCallbackProvider.h ${D}${includedir}/com/amazonaws/kinesis/video/producer/CachingEndpointOnlyCallbackProvider.h
+    install -m 0640 ${UNPACKDIR}/git/src/ThreadSafeMap.h ${D}${includedir}/com/amazonaws/kinesis/video/producer/ThreadSafeMap.h
+    install -m 0640 ${UNPACKDIR}/git/src/DefaultCallbackProvider.h ${D}${includedir}/com/amazonaws/kinesis/video/producer/DefaultCallbackProvider.h
+    install -m 0640 ${UNPACKDIR}/git/src/StreamCallbackProvider.h ${D}${includedir}/com/amazonaws/kinesis/video/producer/StreamCallbackProvider.h
+    install -m 0640 ${UNPACKDIR}/git/src/KinesisVideoProducer.h ${D}${includedir}/com/amazonaws/kinesis/video/producer/KinesisVideoProducer.h
+    install -m 0640 ${UNPACKDIR}/git/src/DefaultDeviceInfoProvider.h ${D}${includedir}/com/amazonaws/kinesis/video/producer/DefaultDeviceInfoProvider.h
+    install -m 0640 ${UNPACKDIR}/git/src/CallbackProvider.h ${D}${includedir}/com/amazonaws/kinesis/video/producer/CallbackProvider.h
+    install -m 0640 ${UNPACKDIR}/git/src/StreamTags.h ${D}${includedir}/com/amazonaws/kinesis/video/producer/StreamTags.h
+    install -m 0640 ${UNPACKDIR}/git/src/Logger.h ${D}${includedir}/com/amazonaws/kinesis/video/producer/Logger.h
+    install -m 0640 ${UNPACKDIR}/git/src/KinesisVideoStream.h ${D}${includedir}/com/amazonaws/kinesis/video/producer/KinesisVideoStream.h
+    install -m 0640 ${UNPACKDIR}/git/src/ClientCallbackProvider.h ${D}${includedir}/com/amazonaws/kinesis/video/producer/ClientCallbackProvider.h
 
-    install -m 0640 ${WORKDIR}/git/src/JNI/include/com/amazonaws/kinesis/video/producer/jni/KinesisVideoClientWrapper.h ${D}${includedir}/com/amazonaws/kinesis/video/producer/jni/KinesisVideoClientWrapper.h
-    install -m 0640 ${WORKDIR}/git/src/JNI/include/com/amazonaws/kinesis/video/producer/jni/SyncMutex.h ${D}${includedir}/com/amazonaws/kinesis/video/producer/jni/SyncMutex.h
-    install -m 0640 ${WORKDIR}/git/src/JNI/include/com/amazonaws/kinesis/video/producer/jni/JNICommon.h ${D}${includedir}/com/amazonaws/kinesis/video/producer/jni/JNICommon.h
-    install -m 0640 ${WORKDIR}/git/src/JNI/include/com/amazonaws/kinesis/video/producer/jni/Parameters.h ${D}${includedir}/com/amazonaws/kinesis/video/producer/jni/Parameters.h
-    install -m 0640 ${WORKDIR}/git/src/JNI/include/com/amazonaws/kinesis/video/producer/jni/com_amazonaws_kinesisvideo_internal_producer_jni_NativeKinesisVideoProducerJni.h ${D}${includedir}/com/amazonaws/kinesis/video/producer/jni/com_amazonaws_kinesisvideo_internal_producer_jni_NativeKinesisVideoProducerJni.h
-    install -m 0640 ${WORKDIR}/git/src/JNI/include/com/amazonaws/kinesis/video/producer/jni/TimedSemaphore.h ${D}${includedir}/com/amazonaws/kinesis/video/producer/jni/TimedSemaphore.h
+    install -m 0640 ${UNPACKDIR}/git/src/JNI/include/com/amazonaws/kinesis/video/producer/jni/KinesisVideoClientWrapper.h ${D}${includedir}/com/amazonaws/kinesis/video/producer/jni/KinesisVideoClientWrapper.h
+    install -m 0640 ${UNPACKDIR}/git/src/JNI/include/com/amazonaws/kinesis/video/producer/jni/SyncMutex.h ${D}${includedir}/com/amazonaws/kinesis/video/producer/jni/SyncMutex.h
+    install -m 0640 ${UNPACKDIR}/git/src/JNI/include/com/amazonaws/kinesis/video/producer/jni/JNICommon.h ${D}${includedir}/com/amazonaws/kinesis/video/producer/jni/JNICommon.h
+    install -m 0640 ${UNPACKDIR}/git/src/JNI/include/com/amazonaws/kinesis/video/producer/jni/Parameters.h ${D}${includedir}/com/amazonaws/kinesis/video/producer/jni/Parameters.h
+    install -m 0640 ${UNPACKDIR}/git/src/JNI/include/com/amazonaws/kinesis/video/producer/jni/com_amazonaws_kinesisvideo_internal_producer_jni_NativeKinesisVideoProducerJni.h ${D}${includedir}/com/amazonaws/kinesis/video/producer/jni/com_amazonaws_kinesisvideo_internal_producer_jni_NativeKinesisVideoProducerJni.h
+    install -m 0640 ${UNPACKDIR}/git/src/JNI/include/com/amazonaws/kinesis/video/producer/jni/TimedSemaphore.h ${D}${includedir}/com/amazonaws/kinesis/video/producer/jni/TimedSemaphore.h
 
-    install -m 0640 ${WORKDIR}/git/src/credential-providers/RotatingCredentialProvider.h ${D}${includedir}/com/amazonaws/kinesis/video/producer/credential-providers/RotatingCredentialProvider.h
-    install -m 0640 ${WORKDIR}/git/src/credential-providers/IotCertCredentialProvider.h ${D}${includedir}/com/amazonaws/kinesis/video/producer/credential-providers/IotCertCredentialProvider.h
+    install -m 0640 ${UNPACKDIR}/git/src/credential-providers/RotatingCredentialProvider.h ${D}${includedir}/com/amazonaws/kinesis/video/producer/credential-providers/RotatingCredentialProvider.h
+    install -m 0640 ${UNPACKDIR}/git/src/credential-providers/IotCertCredentialProvider.h ${D}${includedir}/com/amazonaws/kinesis/video/producer/credential-providers/IotCertCredentialProvider.h
 
-    install -m 0640 ${WORKDIR}/git/src/gstreamer/KvsSinkStreamCallbackProvider.h ${D}${includedir}/com/amazonaws/kinesis/video/producer/KvsSinkStreamCallbackProvider.h
-    install -m 0640 ${WORKDIR}/git/src/gstreamer/KvsSinkDeviceInfoProvider.h ${D}${includedir}/com/amazonaws/kinesis/video/producer/credential-providers/KvsSinkDeviceInfoProvider.h
-    install -m 0640 ${WORKDIR}/git/src/gstreamer/gstkvssink.h ${D}${includedir}/com/amazonaws/kinesis/video/producer/credential-providers/gstkvssink.h
+    install -m 0640 ${UNPACKDIR}/git/src/gstreamer/KvsSinkStreamCallbackProvider.h ${D}${includedir}/com/amazonaws/kinesis/video/producer/KvsSinkStreamCallbackProvider.h
+    install -m 0640 ${UNPACKDIR}/git/src/gstreamer/KvsSinkDeviceInfoProvider.h ${D}${includedir}/com/amazonaws/kinesis/video/producer/credential-providers/KvsSinkDeviceInfoProvider.h
+    install -m 0640 ${UNPACKDIR}/git/src/gstreamer/gstkvssink.h ${D}${includedir}/com/amazonaws/kinesis/video/producer/credential-providers/gstkvssink.h
 
     install -m 0755 ${B}/libKinesisVideoProducer.so ${D}${libdir}/
 

--- a/recipes-sdk/amazon-kvs-webrtc-sdk/amazon-kvs-webrtc-sdk_1.12.1.bb
+++ b/recipes-sdk/amazon-kvs-webrtc-sdk/amazon-kvs-webrtc-sdk_1.12.1.bb
@@ -80,7 +80,7 @@ EXTRA_OECMAKE += "-DCMAKE_SKIP_RPATH=1"
 
 do_install_ptest () {
     cp -r ${B}/tst/webrtc_client_test ${D}${PTEST_PATH}/
-    install -m 0755 ${UNPACKDIR}/ptest_result.py ${D}${PTEST_PATH}/
+    install -m 0755 ${WORKDIR}/ptest_result.py ${D}${PTEST_PATH}/
 }
 
 # nooelint: oelint.vars.insaneskip:INSANE_SKIP

--- a/recipes-sdk/aws-c-auth/aws-c-auth_0.9.0.bb
+++ b/recipes-sdk/aws-c-auth/aws-c-auth_0.9.0.bb
@@ -25,7 +25,7 @@ SRC_URI = "\
     "
 SRCREV = "cd9d6afcd42035d49bb2d0d3bef24b9faed57773"
 
-S = "${UNPACKDIR}/git"
+S = "${WORKDIR}/git"
 
 inherit cmake ptest pkgconfig
 

--- a/recipes-sdk/aws-c-cal/aws-c-cal_0.9.0.bb
+++ b/recipes-sdk/aws-c-cal/aws-c-cal_0.9.0.bb
@@ -22,7 +22,7 @@ SRC_URI = "\
 
 SRCREV = "fa108de5280afd71018e0a0534edb36b33f030f6"
 
-S = "${UNPACKDIR}/git"
+S = "${WORKDIR}/git"
 
 inherit cmake ptest pkgconfig
 

--- a/recipes-sdk/aws-c-common/aws-c-common_0.12.2.bb
+++ b/recipes-sdk/aws-c-common/aws-c-common_0.12.2.bb
@@ -18,7 +18,7 @@ SRCREV = "8ae8f48ebddb0ee2624d643952ac33afa5e8859e"
 # will match only x.x.x for auto upgrades, because: https://github.com/awslabs/aws-c-common/issues/1025
 UPSTREAM_CHECK_GITTAGREGEX = "(?P<pver>\d\.\d+(\.\d+)+)"
 
-S = "${UNPACKDIR}/git"
+S = "${WORKDIR}/git"
 
 inherit cmake ptest
 

--- a/recipes-sdk/aws-c-compression/aws-c-compression_0.3.1.bb
+++ b/recipes-sdk/aws-c-compression/aws-c-compression_0.3.1.bb
@@ -24,7 +24,7 @@ SRC_URI = "\
 
 SRCREV = "f951ab2b819fc6993b6e5e6cfef64b1a1554bfc8"
 
-S = "${UNPACKDIR}/git"
+S = "${WORKDIR}/git"
 
 inherit cmake ptest pkgconfig
 

--- a/recipes-sdk/aws-c-event-stream/aws-c-event-stream_0.5.4.bb
+++ b/recipes-sdk/aws-c-event-stream/aws-c-event-stream_0.5.4.bb
@@ -22,7 +22,7 @@ SRC_URI = "\
     "
 SRCREV = "9312b052583183b98526aaeb91e5c72ec3db9627"
 
-S = "${UNPACKDIR}/git"
+S = "${WORKDIR}/git"
 
 inherit cmake ptest pkgconfig
 

--- a/recipes-sdk/aws-c-http/aws-c-http_0.9.7.bb
+++ b/recipes-sdk/aws-c-http/aws-c-http_0.9.7.bb
@@ -25,7 +25,7 @@ SRC_URI = "\
 
 SRCREV = "6586c80edc09a07d3e6db6bf82c4b53aefdfe895"
 
-S = "${UNPACKDIR}/git"
+S = "${WORKDIR}/git"
 
 inherit cmake ptest pkgconfig
 

--- a/recipes-sdk/aws-c-io/aws-c-io_0.18.1.bb
+++ b/recipes-sdk/aws-c-io/aws-c-io_0.18.1.bb
@@ -24,7 +24,7 @@ SRC_URI = "\
     "
 SRCREV = "31d7361dd7517c54e697316fec6ded2ebe89fee9"
 
-S = "${UNPACKDIR}/git"
+S = "${WORKDIR}/git"
 
 inherit cmake ptest pkgconfig
 

--- a/recipes-sdk/aws-c-iot/aws-c-iot_0.2.1.bb
+++ b/recipes-sdk/aws-c-iot/aws-c-iot_0.2.1.bb
@@ -31,7 +31,7 @@ SRC_URI = "\
 
 SRCREV = "9f0c152ed76af1a45d99fb98286707aa23c728af"
 
-S = "${UNPACKDIR}/git"
+S = "${WORKDIR}/git"
 
 inherit cmake ptest pkgconfig
 

--- a/recipes-sdk/aws-c-mqtt/aws-c-mqtt_0.12.3.bb
+++ b/recipes-sdk/aws-c-mqtt/aws-c-mqtt_0.12.3.bb
@@ -25,7 +25,7 @@ SRC_URI = "\
 
 SRCREV = "fb651a4a59f28384fdb4938524192433492dead0"
 
-S = "${UNPACKDIR}/git"
+S = "${WORKDIR}/git"
 
 inherit cmake ptest
 

--- a/recipes-sdk/aws-c-s3/aws-c-s3_0.7.15.bb
+++ b/recipes-sdk/aws-c-s3/aws-c-s3_0.7.15.bb
@@ -21,7 +21,7 @@ SRC_URI = "\
     "
 SRCREV = "0770d353ce2d04af0f2b1ee3680a8f827f28263f"
 
-S = "${UNPACKDIR}/git"
+S = "${WORKDIR}/git"
 
 inherit cmake ptest pkgconfig
 

--- a/recipes-sdk/aws-c-sdkutils/aws-c-sdkutils_0.2.3.bb
+++ b/recipes-sdk/aws-c-sdkutils/aws-c-sdkutils_0.2.3.bb
@@ -16,7 +16,7 @@ SRC_URI = "\
     "
 SRCREV = "ba6a28fab7ed5d7f1b3b1d12eb672088be093824"
 
-S = "${UNPACKDIR}/git"
+S = "${WORKDIR}/git"
 
 inherit cmake ptest pkgconfig
 

--- a/recipes-sdk/aws-checksums/aws-checksums_0.2.7.bb
+++ b/recipes-sdk/aws-checksums/aws-checksums_0.2.7.bb
@@ -21,7 +21,7 @@ SRC_URI = "\
 
 SRCREV = "9978ba2c33a7a259c1a6bd0f62abe26827d03b85"
 
-S = "${UNPACKDIR}/git"
+S = "${WORKDIR}/git"
 
 inherit cmake ptest pkgconfig
 

--- a/recipes-sdk/aws-crt-cpp/aws-crt-cpp_0.32.4.bb
+++ b/recipes-sdk/aws-crt-cpp/aws-crt-cpp_0.32.4.bb
@@ -28,7 +28,7 @@ SRC_URI = "\
 
 SRCREV = "f8437df651af0795e024f02a944bd464319220ee"
 
-S = "${UNPACKDIR}/git"
+S = "${WORKDIR}/git"
 
 inherit cmake pkgconfig ptest
 

--- a/recipes-sdk/aws-crt-python/aws-crt-python_0.26.1.bb
+++ b/recipes-sdk/aws-crt-python/aws-crt-python_0.26.1.bb
@@ -30,7 +30,7 @@ SRC_URI = "\
 SRCREV = "e31ff4a78ab1226aeb2f1686ccdc5fb0a634c313"
 UPSTREAM_CHECK_GITTAGREGEX = "v(?P<pver>.*)"
 
-S = "${UNPACKDIR}/git"
+S = "${WORKDIR}/git"
 
 inherit setuptools3_legacy ptest
 

--- a/recipes-sdk/aws-iot-device-sdk-cpp-v2/aws-iot-device-sdk-cpp-v2_1.35.1.bb
+++ b/recipes-sdk/aws-iot-device-sdk-cpp-v2/aws-iot-device-sdk-cpp-v2_1.35.1.bb
@@ -16,7 +16,7 @@ SRC_URI:append = " \
     ${@bb.utils.contains('PACKAGECONFIG', 'static', '', 'file://001-shared-static-crt-libs.patch', d)} \
     "
 
-S = "${UNPACKDIR}/git"
+S = "${WORKDIR}/git"
 
 inherit cmake pkgconfig ptest
 

--- a/recipes-sdk/aws-iot-device-sdk-embedded-c/aws-iot-device-sdk-embedded-c_202412.00.bb
+++ b/recipes-sdk/aws-iot-device-sdk-embedded-c/aws-iot-device-sdk-embedded-c_202412.00.bb
@@ -17,7 +17,7 @@ DEPENDS = "\
     ${@bb.utils.contains('PACKAGECONFIG', 'with-tests', 'ruby-native', '', d)} \
     "
 
-S = "${UNPACKDIR}/git"
+S = "${WORKDIR}/git"
 
 inherit cmake ptest pkgconfig
 

--- a/recipes-sdk/aws-iot-device-sdk-python-v2/aws-iot-device-sdk-python-v2_1.22.2.bb
+++ b/recipes-sdk/aws-iot-device-sdk-python-v2/aws-iot-device-sdk-python-v2_1.22.2.bb
@@ -10,7 +10,7 @@ SRC_URI = "\
         "
 SRCREV = "9518299b90b5979bae2140ed69123c809fdd1609"
 
-S = "${UNPACKDIR}/git"
+S = "${WORKDIR}/git"
 
 inherit setuptools3 ptest
 

--- a/recipes-sdk/aws-lc/aws-lc_1.49.1.bb
+++ b/recipes-sdk/aws-lc/aws-lc_1.49.1.bb
@@ -17,7 +17,7 @@ SRC_URI = "\
 SRCREV = "b1420f27a7c95762cd11b249ece3d049f530d9e6"
 UPSTREAM_CHECK_GITTAGREGEX = "v(?P<pver>.*)"
 
-S = "${UNPACKDIR}/git"
+S = "${WORKDIR}/git"
 
 inherit cmake ptest pkgconfig
 

--- a/recipes-sdk/aws-sdk-cpp/aws-sdk-cpp_1.11.551.bb
+++ b/recipes-sdk/aws-sdk-cpp/aws-sdk-cpp_1.11.551.bb
@@ -21,7 +21,7 @@ SRC_URI = "\
 
 SRCREV = "66a96132b3b74ddf4ca77fa0556aa4fffd660180"
 
-S = "${UNPACKDIR}/git"
+S = "${WORKDIR}/git"
 
 inherit cmake ptest pkgconfig
 

--- a/recipes-sdk/s2n/s2n_1.5.17.bb
+++ b/recipes-sdk/s2n/s2n_1.5.17.bb
@@ -20,7 +20,7 @@ SRC_URI = "\
 SRCREV = "eb4167f148ccdb21a8fa22bf07cb91044ba2d7f0"
 UPSTREAM_CHECK_GITTAGREGEX = "v(?P<pver>.*)"
 
-S = "${UNPACKDIR}/git"
+S = "${WORKDIR}/git"
 
 inherit cmake ptest pkgconfig
 

--- a/recipes-support/amazon-ssm-agent/amazon-ssm-agent_3.3.2299.0.bb
+++ b/recipes-support/amazon-ssm-agent/amazon-ssm-agent_3.3.2299.0.bb
@@ -15,7 +15,7 @@ SRC_URI = "\
 
 SRCREV = "aa5415fc89797c8769e949ae78522a2a06b550e3"
 
-S = "${UNPACKDIR}/git"
+S = "${WORKDIR}/git"
 
 GO_IMPORT = ""
 
@@ -38,7 +38,7 @@ python go_do_unpack() {
                 s_dirname = os.path.basename(d.getVar('S'))
 #                fetcher.ud[url].parm['destsuffix'] = os.path.join(s_dirname, 'src', d.getVar('GO_IMPORT')) + '/'
                 fetcher.ud[url].parm['destsuffix'] = os.path.join(s_dirname, '', d.getVar('GO_IMPORT')) + '/'
-    fetcher.unpack(d.getVar('UNPACKDIR'))
+    fetcher.unpack(d.getVar('WORKDIR'))
 }
 
 # src folder will break devtool upgrade

--- a/recipes-support/aws-cli-v2/aws-cli-v2_2.27.0.bb
+++ b/recipes-support/aws-cli-v2/aws-cli-v2_2.27.0.bb
@@ -60,7 +60,7 @@ inherit python_pep517 python3native python3-dir setuptools3-base ptest
 
 export CRYPTOGRAPHY_OPENSSL_NO_LEGACY = "true"
 
-S = "${UNPACKDIR}/git"
+S = "${WORKDIR}/git"
 
 # this package also contains aws help
 PACKAGES += "${PN}-examples"

--- a/recipes-support/aws-cli/aws-cli_1.38.38.bb
+++ b/recipes-support/aws-cli/aws-cli_1.38.38.bb
@@ -14,7 +14,7 @@ SRCREV = "b6b3318948fa779c83ad116e5347cfc85978d941"
 # version 2.x has got library link issues - so stick to version 1.x for now
 UPSTREAM_CHECK_GITTAGREGEX = "(?P<pver>1\.\d+(\.\d+)+)"
 
-S = "${UNPACKDIR}/git"
+S = "${WORKDIR}/git"
 
 inherit setuptools3 ptest
 


### PR DESCRIPTION
devtool is used in a nightly GH workflow to perform checks if new versions of recipe software is available, this is broken if UNPACKDIR is used. See more here: https://lists.openembedded.org/g/openembedded-core/topic/112431116#msg215739

Plan is not to backport this to release branches for now. Just for master to enable auto updates again.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
