### PR TITLE
aws-cli-v2: fix warning whitespace missing around assignement

### DIFF
--- a/recipes-support/aws-cli-v2/aws-cli-v2_2.27.0.bb
+++ b/recipes-support/aws-cli-v2/aws-cli-v2_2.27.0.bb
@@ -58,7 +58,7 @@ UPSTREAM_CHECK_GITTAGREGEX = "(?P<pver>2\.\d+(\.\d+)+)"
 
 inherit python_pep517 python3native python3-dir setuptools3-base ptest
 
-export CRYPTOGRAPHY_OPENSSL_NO_LEGACY="true"
+export CRYPTOGRAPHY_OPENSSL_NO_LEGACY = "true"
 
 S = "${UNPACKDIR}/git"
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
