### PR TITLE
greengrass-bin: change subdir structure to fix bbappends

### DIFF
--- a/recipes-iot/aws-iot-greengrass/greengrass-bin_2.14.1.bb
+++ b/recipes-iot/aws-iot-greengrass/greengrass-bin_2.14.1.bb
@@ -9,7 +9,7 @@ GG_ROOT = "${D}/${GG_BASENAME}"
 GGV2_FLEETPROVISIONING_VERSION ?= "1.2.2"
 GGV2_FLEET_PROVISIONING_TEMPLATE_NAME ?= "GreengrassFleetProvisioningTemplate"
 
-LIC_FILES_CHKSUM = "file://${WORKDIR}/greengrass-bin/LICENSE;md5=34400b68072d710fecd0a2940a0d1658"
+LIC_FILES_CHKSUM = "file://${WORKDIR}/LICENSE;md5=34400b68072d710fecd0a2940a0d1658"
 
 DEPENDS += "gettext-native"
 
@@ -20,7 +20,7 @@ PACKAGECONFIG ??= "${@bb.utils.contains('PTEST_ENABLED', '1', 'fleetprovisioning
 PACKAGECONFIG[fleetprovisioning] = ""
 
 SRC_URI = "\
-    https://d2s8p88vqu9w66.cloudfront.net/releases/greengrass-${PV}.zip;subdir=greengrass-bin \
+    https://d2s8p88vqu9w66.cloudfront.net/releases/greengrass-${PV}.zip \
     file://greengrassv2-init.yaml \
     file://run-ptest \
     "
@@ -46,7 +46,7 @@ GG_USESYSTEMD = "${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'yes', 'no',
 
 inherit systemd useradd ptest pkgconfig
 
-S = "${WORKDIR}/greengrass-bin"
+S = "${WORKDIR}"
 
 FILES:${PN} += "\
     /${GG_BASENAME} \
@@ -76,7 +76,7 @@ do_install() {
     ln -s /${GG_BASENAME}/packages/artifacts-unarchived/aws.greengrass.Nucleus/${PV}/aws.greengrass.nucleus ${GG_ROOT}/alts/init/distro
 
     install -m 0440 ${S}/LICENSE                         ${GG_ROOT}
-    install -m 0640 ${S}/../greengrassv2-init.yaml          ${GG_ROOT}/config/config.yaml.clean
+    install -m 0640 ${S}/greengrassv2-init.yaml          ${GG_ROOT}/config/config.yaml.clean
     install -m 0640 ${S}/bin/greengrass.service.template ${GG_ROOT}/packages/artifacts-unarchived/aws.greengrass.Nucleus/${PV}/aws.greengrass.nucleus/bin/greengrass.service.template
     install -m 0750 ${S}/bin/loader                      ${GG_ROOT}/packages/artifacts-unarchived/aws.greengrass.Nucleus/${PV}/aws.greengrass.nucleus/bin/loader
     install -m 0640 ${S}/conf/recipe.yaml                ${GG_ROOT}/packages/artifacts-unarchived/aws.greengrass.Nucleus/${PV}/aws.greengrass.nucleus/conf/recipe.yaml


### PR DESCRIPTION
Without this bbappends like here:
https://github.com/aws4embeddedlinux/meta-aws-demos/blob/fb51b404a23a329f4b0a52fadc47ee7609f9062c/meta-aws-demos/recipes-iot/aws-iot-greengrass/greengrass-bin_%25.bbappend#L5 do not work anymore.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
