### PR TITLE
aws-crt-cpp: change to build-deps as default

### DIFF
--- a/recipes-sdk/aws-crt-cpp/aws-crt-cpp/001-shared-static-crt-libs.patch
+++ b/recipes-sdk/aws-crt-cpp/aws-crt-cpp/001-shared-static-crt-libs.patch
@@ -1,0 +1,26 @@
+This disable the shared libs build for aws-crt-cpp and aws-c-iot,
+cause they will conflict with already exising versions on a system.
+Therefor they are static linked into the cpp libs to not conflict.
+
+Upstream-Status: Inappropriate [oe specific]
+
+Index: 0.32.5/CMakeLists.txt
+===================================================================
+--- 0.32.5.orig/CMakeLists.txt
++++ 0.32.5/CMakeLists.txt
+@@ -45,6 +45,7 @@ set(GENERATED_CONFIG_HEADER "${GENERATED
+ configure_file(include/aws/crt/Config.h.in ${GENERATED_CONFIG_HEADER} @ONLY)
+
+ if(BUILD_DEPS)
++    set(BUILD_SHARED_LIBS OFF)
+     list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/crt/aws-c-common/cmake")
+
+     include(AwsFindPackage)
+@@ -103,6 +104,7 @@ if(BUILD_DEPS)
+     add_subdirectory(crt/aws-c-event-stream)
+     add_subdirectory(crt/aws-c-s3)
+     set(BUILD_TESTING ${BUILD_TESTING_PREV})
++    set(BUILD_SHARED_LIBS ON)
+ else()
+     # this is required so we can use aws-c-common's CMake modules
+     find_package(aws-c-common REQUIRED)

--- a/recipes-sdk/aws-crt-cpp/aws-crt-cpp_0.32.5.bb
+++ b/recipes-sdk/aws-crt-cpp/aws-crt-cpp_0.32.5.bb
@@ -5,7 +5,7 @@ HOMEPAGE = "https://github.com/awslabs/aws-crt-cpp"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
-DEPENDS += "\
+DEPENDS += "${@bb.utils.contains('PACKAGECONFIG', 'build-deps', 'openssl', '\
     aws-c-auth \
     aws-c-common \
     aws-c-event-stream \
@@ -15,14 +15,15 @@ DEPENDS += "\
     aws-c-s3 \
     aws-checksums \
     s2n \
-    "
+', d)}"
 
 PROVIDES += "aws/crt-cpp"
 
 BRANCH ?= "main"
 
 SRC_URI = "\
-    git://github.com/awslabs/aws-crt-cpp.git;protocol=https;branch=${BRANCH} \
+    gitsm://github.com/awslabs/aws-crt-cpp.git;protocol=https;branch=${BRANCH} \
+    ${@bb.utils.contains('PACKAGECONFIG', 'static', '', 'file://001-shared-static-crt-libs.patch', d)} \
     file://run-ptest \
     "
 
@@ -37,13 +38,18 @@ CFLAGS:append = " -Wl,-Bsymbolic"
 EXTRA_OECMAKE += "\
     -DCMAKE_MODULE_PATH=${STAGING_LIBDIR}/cmake \
     -DCMAKE_PREFIX_PATH="${STAGING_LIBDIR}/cmake;${STAGING_LIBDIR}" \
-    -DBUILD_DEPS=OFF \
+    -DUSE_OPENSSL=ON \
     "
 
 # for generating Makefiles to run tests
 OECMAKE_GENERATOR = "Unix Makefiles"
 
-PACKAGECONFIG ?= "\
+# build-deps is enabled by default to use the crt versions that comes as a git submodule,
+# this also means that it conflicts with the other standalone versions as it installs the same library if installed separate.
+PACKAGECONFIG[build-deps] = "-DBUILD_DEPS=ON,-DBUILD_DEPS=OFF"
+
+PACKAGECONFIG ??= "\
+    build-deps \
     ${@bb.utils.contains('PTEST_ENABLED', '1', 'with-tests', '', d)} \
     "
 
@@ -56,6 +62,8 @@ PACKAGECONFIG[static] = "-DBUILD_SHARED_LIBS=OFF,-DBUILD_SHARED_LIBS=ON"
 
 # CMAKE_CROSSCOMPILING=ON will disable building the tests
 PACKAGECONFIG[with-tests] = "-DBUILD_TESTING=ON -DCMAKE_CROSSCOMPILING=OFF,-DBUILD_TESTING=OFF,"
+
+FILES:${PN} += "${@bb.utils.contains('PACKAGECONFIG', 'build-deps', '${libdir}/*', '', d)}"
 
 FILES:${PN} += "${libdir}/libaws-crt-cpp.so"
 FILES:${PN}-dev += "\


### PR DESCRIPTION
As it is not guarnteed that depending libs if they are build separate are fully compatible.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
