### PR TITLE
aws-crt-cpp: disable rules-engine test

### DIFF
--- a/recipes-sdk/aws-crt-cpp/aws-crt-cpp/run-ptest
+++ b/recipes-sdk/aws-crt-cpp/aws-crt-cpp/run-ptest
@@ -46,7 +46,6 @@ TestCreatingImdsClient \
 ChannelHandlerInterop \
 Mqtt5NewClientMinimal \
 Mqtt5NewClientFull \
-RuleEngine \
 "
 
 for TEST in $TESTS


### PR DESCRIPTION
As this require a cert to run.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
