### PR TITLE
build-test-recipe.yml: make QB_MEM 8GB default

### DIFF
--- a/.github/workflows/build-test-recipe.yml
+++ b/.github/workflows/build-test-recipe.yml
@@ -112,7 +112,8 @@ jobs:
              source poky/oe-init-build-env build
              echo QEMU_USE_KVM = \"\" >> conf/local.conf
              # set to max for arm32
-             echo QB_MEM = \"-m 3G\" >> conf/local.conf
+             echo QB_MEM:arm = \"-m 3G\" >> conf/local.conf
+             echo QB_MEM = \"-m 8G\" >> conf/local.conf
              # use slirp networking instead of TAP interface (require root rights)
              echo QEMU_USE_SLIRP = \"1\" >> conf/local.conf
              echo TEST_RUNQEMUPARAMS += \"slirp\" >> conf/local.conf


### PR DESCRIPTION
As there a some "not enough memory for the allocation" errors.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
