### PR TITLE
Add aws-iot-device-sdk-embedded-c libs as separate recipes

### DIFF
--- a/recipes-sdk/aws-iot-device-sdk-embedded-c/aws-iot-device-sdk-embedded-c-fleet-provisioning-keys-cert/001-transport-interface.patch
+++ b/recipes-sdk/aws-iot-device-sdk-embedded-c/aws-iot-device-sdk-embedded-c-fleet-provisioning-keys-cert/001-transport-interface.patch
@@ -1,0 +1,15 @@
+Upstream-Status: Inappropriate [oe-specific]
+
+Index: aws-iot-device-sdk-embedded-c-fleet-provisioning-keys-cert-git/platform/posix/transport/include/sockets_posix.h
+===================================================================
+--- aws-iot-device-sdk-embedded-c-fleet-provisioning-keys-cert-git.orig/platform/posix/transport/include/sockets_posix.h
++++ aws-iot-device-sdk-embedded-c-fleet-provisioning-keys-cert-git/platform/posix/transport/include/sockets_posix.h
+@@ -55,7 +55,7 @@
+ /* *INDENT-ON* */
+
+ /* Transport interface include. */
+-#include "transport_interface.h"
++#include <core_mqtt/transport_interface.h>
+
+ /**
+  * @brief TCP Connect / Disconnect return status.

--- a/recipes-sdk/aws-iot-device-sdk-embedded-c/aws-iot-device-sdk-embedded-c-fleet-provisioning-keys-cert/002-config.patch
+++ b/recipes-sdk/aws-iot-device-sdk-embedded-c/aws-iot-device-sdk-embedded-c-fleet-provisioning-keys-cert/002-config.patch
@@ -1,0 +1,51 @@
+Upstream-Status: Inappropriate [oe-specific]
+
+Index: aws-iot-device-sdk-embedded-c-fleet-provisioning-keys-cert-git/demos/fleet_provisioning/fleet_provisioning_keys_cert/demo_config.h
+===================================================================
+--- aws-iot-device-sdk-embedded-c-fleet-provisioning-keys-cert-git.orig/demos/fleet_provisioning/fleet_provisioning_keys_cert/demo_config.h
++++ aws-iot-device-sdk-embedded-c-fleet-provisioning-keys-cert-git/demos/fleet_provisioning/fleet_provisioning_keys_cert/demo_config.h
+@@ -188,27 +188,27 @@
+  * The current value is given as an example. Please update for your specific
+  * operating system.
+  */
+-#define OS_NAME                   "Ubuntu"
++//#define OS_NAME                   "Ubuntu"
+
+ /**
+  * @brief The version of the operating system that the application is running
+  * on. The current value is given as an example. Please update for your specific
+  * operating system version.
+  */
+-#define OS_VERSION                "18.04 LTS"
++//#define OS_VERSION                "18.04 LTS"
+
+ /**
+  * @brief The name of the hardware platform the application is running on. The
+  * current value is given as an example. Please update for your specific
+  * hardware platform.
+  */
+-#define HARDWARE_PLATFORM_NAME    "PC"
++//#define HARDWARE_PLATFORM_NAME    "PC"
+
+ /**
+  * @brief The name of the MQTT library used and its version, following an "@"
+  * symbol.
+  */
+-#include "core_mqtt.h"
++#include <core_mqtt/core_mqtt.h>
+ #define MQTT_LIB    "core-mqtt@" MQTT_LIBRARY_VERSION
+
+ #endif /* ifndef DEMO_CONFIG_H_ */
+Index: aws-iot-device-sdk-embedded-c-fleet-provisioning-keys-cert-git/platform/posix/transport/src/openssl_posix.c
+===================================================================
+--- aws-iot-device-sdk-embedded-c-fleet-provisioning-keys-cert-git.orig/platform/posix/transport/src/openssl_posix.c
++++ aws-iot-device-sdk-embedded-c-fleet-provisioning-keys-cert-git/platform/posix/transport/src/openssl_posix.c
+@@ -30,7 +30,7 @@
+ #include <poll.h>
+
+ /* Transport interface include. */
+-#include "transport_interface.h"
++#include <core_mqtt/transport_interface.h>
+
+ #include "openssl_posix.h"
+ #include <openssl/err.h>

--- a/recipes-sdk/aws-iot-device-sdk-embedded-c/aws-iot-device-sdk-embedded-c-fleet-provisioning-keys-cert/003-fix-includes.patch
+++ b/recipes-sdk/aws-iot-device-sdk-embedded-c/aws-iot-device-sdk-embedded-c-fleet-provisioning-keys-cert/003-fix-includes.patch
@@ -1,0 +1,149 @@
+Upstream-Status: Inappropriate [oe-specific]
+
+Index: aws-iot-device-sdk-embedded-c-fleet-provisioning-keys-cert-git/demos/fleet_provisioning/fleet_provisioning_keys_cert/fleet_provisioning_keys_cert_demo.c
+===================================================================
+--- aws-iot-device-sdk-embedded-c-fleet-provisioning-keys-cert-git.orig/demos/fleet_provisioning/fleet_provisioning_keys_cert/fleet_provisioning_keys_cert_demo.c
++++ aws-iot-device-sdk-embedded-c-fleet-provisioning-keys-cert-git/demos/fleet_provisioning/fleet_provisioning_keys_cert/fleet_provisioning_keys_cert_demo.c
+@@ -66,11 +66,11 @@
+ #include "demo_config.h"
+
+ /* corePKCS11 includes. */
+-#include "core_pkcs11.h"
+-#include "core_pkcs11_config.h"
++#include <core_pkcs/core_pkcs11.h>
++#include <core_pkcs/core_pkcs11_config.h>
+
+ /* AWS IoT Fleet Provisioning Library. */
+-#include "fleet_provisioning.h"
++#include <fleetprovisioning/fleet_provisioning.h>
+
+ /* Demo includes. */
+ #include "mqtt_operations.h"
+Index: aws-iot-device-sdk-embedded-c-fleet-provisioning-keys-cert-git/platform/posix/transport/include/openssl_posix.h
+===================================================================
+--- aws-iot-device-sdk-embedded-c-fleet-provisioning-keys-cert-git.orig/platform/posix/transport/include/openssl_posix.h
++++ aws-iot-device-sdk-embedded-c-fleet-provisioning-keys-cert-git/platform/posix/transport/include/openssl_posix.h
+@@ -59,7 +59,7 @@
+ #include <openssl/ssl.h>
+
+ /* Transport includes. */
+-#include "transport_interface.h"
++#include <core_mqtt/transport_interface.h>
+
+ /* Socket include. */
+ #include "sockets_posix.h"
+Index: aws-iot-device-sdk-embedded-c-fleet-provisioning-keys-cert-git/demos/fleet_provisioning/fleet_provisioning_keys_cert/mqtt_operations.h
+===================================================================
+--- aws-iot-device-sdk-embedded-c-fleet-provisioning-keys-cert-git.orig/demos/fleet_provisioning/fleet_provisioning_keys_cert/mqtt_operations.h
++++ aws-iot-device-sdk-embedded-c-fleet-provisioning-keys-cert-git/demos/fleet_provisioning/fleet_provisioning_keys_cert/mqtt_operations.h
+@@ -24,10 +24,10 @@
+ #define MQTT_OPERATIONS_H_
+
+ /* MQTT API header. */
+-#include "core_mqtt.h"
++#include <core_mqtt/core_mqtt.h>
+
+ /* corePKCS11 include. */
+-#include "core_pkcs11.h"
++#include <core_pkcs/core_pkcs11.h>
+
+ /**
+  * @brief Application callback type to handle the incoming publishes.
+Index: aws-iot-device-sdk-embedded-c-fleet-provisioning-keys-cert-git/platform/posix/transport/include/plaintext_posix.h
+===================================================================
+--- aws-iot-device-sdk-embedded-c-fleet-provisioning-keys-cert-git.orig/platform/posix/transport/include/plaintext_posix.h
++++ aws-iot-device-sdk-embedded-c-fleet-provisioning-keys-cert-git/platform/posix/transport/include/plaintext_posix.h
+@@ -56,7 +56,7 @@
+ /* *INDENT-ON* */
+
+ /* Transport includes. */
+-#include "transport_interface.h"
++#include <core_mqtt/transport_interface.h>
+ #include "sockets_posix.h"
+
+ /**
+Index: aws-iot-device-sdk-embedded-c-fleet-provisioning-keys-cert-git/demos/fleet_provisioning/fleet_provisioning_keys_cert/pkcs11_operations.h
+===================================================================
+--- aws-iot-device-sdk-embedded-c-fleet-provisioning-keys-cert-git.orig/demos/fleet_provisioning/fleet_provisioning_keys_cert/pkcs11_operations.h
++++ aws-iot-device-sdk-embedded-c-fleet-provisioning-keys-cert-git/demos/fleet_provisioning/fleet_provisioning_keys_cert/pkcs11_operations.h
+@@ -33,7 +33,7 @@
+ #define MBEDTLS_ALLOW_PRIVATE_ACCESS
+
+ /* corePKCS11 include. */
+-#include "core_pkcs11.h"
++#include <core_pkcs/core_pkcs11.h>
+
+ /**
+  * @brief Loads the claim credentials into the PKCS #11 module. Claim
+
+Index: aws-iot-device-sdk-embedded-c-fleet-provisioning-keys-cert-202412.00/platform/posix/transport/include/mbedtls_pkcs11_posix.h
+===================================================================
+--- aws-iot-device-sdk-embedded-c-fleet-provisioning-keys-cert-202412.00.orig/platform/posix/transport/include/mbedtls_pkcs11_posix.h
++++ aws-iot-device-sdk-embedded-c-fleet-provisioning-keys-cert-202412.00/platform/posix/transport/include/mbedtls_pkcs11_posix.h
+@@ -72,16 +72,16 @@
+ #define MBEDTLS_ALLOW_PRIVATE_ACCESS
+
+ /* MbedTLS includes. */
+-#include "mbedtls/net_sockets.h"
+-#include "mbedtls/ssl.h"
+-#include "mbedtls/pk.h"
+-#include "pk_wrap.h"
++#include <mbedtls/net_sockets.h>
++#include <mbedtls/ssl.h>
++#include <mbedtls/pk.h>
++#include <pk_wrap.h>
+
+ /* Transport interface include. */
+-#include "transport_interface.h"
++#include <transport_interface.h>
+
+ /* PKCS #11 includes. */
+-#include "core_pkcs11.h"
++#include <core_pkcs/core_pkcs11.h>
+
+ /**
+  * @brief Debug logging level to use for MbedTLS.
+Index: aws-iot-device-sdk-embedded-c-fleet-provisioning-keys-cert-202412.00/demos/fleet_provisioning/fleet_provisioning_keys_cert/pkcs11_operations.c
+===================================================================
+--- aws-iot-device-sdk-embedded-c-fleet-provisioning-keys-cert-202412.00.orig/demos/fleet_provisioning/fleet_provisioning_keys_cert/pkcs11_operations.c
++++ aws-iot-device-sdk-embedded-c-fleet-provisioning-keys-cert-202412.00/demos/fleet_provisioning/fleet_provisioning_keys_cert/pkcs11_operations.c
+@@ -34,12 +34,12 @@
+ #include "demo_config.h"
+
+ /* Interface include. */
+-#include "pkcs11_operations.h"
++#include <pkcs11_operations.h>
+
+ /* PKCS #11 include. */
+-#include "core_pkcs11_config.h"
+-#include "core_pki_utils.h"
+-#include "mbedtls_utils.h"
++#include <core_pkcs/core_pkcs11_config.h>
++#include <core_pkcs/core_pki_utils.h>
++#include <core_pkcs/mbedtls_utils.h>
+
+ /* MbedTLS include. */
+ #include "mbedtls/ctr_drbg.h"
+Index: aws-iot-device-sdk-embedded-c-fleet-provisioning-keys-cert-202412.00/platform/posix/transport/src/mbedtls_pkcs11_posix.c
+===================================================================
+--- aws-iot-device-sdk-embedded-c-fleet-provisioning-keys-cert-202412.00.orig/platform/posix/transport/src/mbedtls_pkcs11_posix.c
++++ aws-iot-device-sdk-embedded-c-fleet-provisioning-keys-cert-202412.00/platform/posix/transport/src/mbedtls_pkcs11_posix.c
+@@ -22,8 +22,10 @@
+
+ /* Standard includes. */
+ #include <string.h>
++#include <stdlib.h>
+ #include <assert.h>
+
++
+ /* TLS transport header. */
+ #include "mbedtls_pkcs11_posix.h"
+
+@@ -32,7 +34,7 @@
+ #include "mbedtls/error.h"
+
+ /* PKCS #11 includes. */
+-#include "core_pki_utils.h"
++#include <core_pkcs/core_pki_utils.h>
+
+ /*-----------------------------------------------------------*/

--- a/recipes-sdk/aws-iot-device-sdk-embedded-c/aws-iot-device-sdk-embedded-c-fleet-provisioning-keys-cert/004-convert-pem-to-der.patch
+++ b/recipes-sdk/aws-iot-device-sdk-embedded-c/aws-iot-device-sdk-embedded-c-fleet-provisioning-keys-cert/004-convert-pem-to-der.patch
@@ -1,0 +1,113 @@
+Upstream-Status: Inappropriate [oe-specific]
+
+Index: aws-iot-device-sdk-embedded-c-fleet-provisioning-keys-cert-202412.00/libraries/3rdparty/mbedtls/programs/util/pem2der.c
+===================================================================
+--- aws-iot-device-sdk-embedded-c-fleet-provisioning-keys-cert-202412.00.orig/libraries/3rdparty/mbedtls/programs/util/pem2der.c
++++ aws-iot-device-sdk-embedded-c-fleet-provisioning-keys-cert-202412.00/libraries/3rdparty/mbedtls/programs/util/pem2der.c
+@@ -160,106 +160,4 @@ static int write_file(const char *path,
+     return 0;
+ }
+
+-int main(int argc, char *argv[])
+-{
+-    int ret = 1;
+-    int exit_code = MBEDTLS_EXIT_FAILURE;
+-    unsigned char *pem_buffer = NULL;
+-    unsigned char der_buffer[4096];
+-    char buf[1024];
+-    size_t pem_size, der_size = sizeof(der_buffer);
+-    int i;
+-    char *p, *q;
+-
+-    /*
+-     * Set to sane values
+-     */
+-    memset(buf, 0, sizeof(buf));
+-    memset(der_buffer, 0, sizeof(der_buffer));
+-
+-    if (argc < 2) {
+-usage:
+-        mbedtls_printf(USAGE);
+-        goto exit;
+-    }
+-
+-    opt.filename            = DFL_FILENAME;
+-    opt.output_file         = DFL_OUTPUT_FILENAME;
+-
+-    for (i = 1; i < argc; i++) {
+-
+-        p = argv[i];
+-        if ((q = strchr(p, '=')) == NULL) {
+-            goto usage;
+-        }
+-        *q++ = '\0';
+-
+-        if (strcmp(p, "filename") == 0) {
+-            opt.filename = q;
+-        } else if (strcmp(p, "output_file") == 0) {
+-            opt.output_file = q;
+-        } else {
+-            goto usage;
+-        }
+-    }
+-
+-    /*
+-     * 1.1. Load the PEM file
+-     */
+-    mbedtls_printf("\n  . Loading the PEM file ...");
+-    fflush(stdout);
+-
+-    ret = load_file(opt.filename, &pem_buffer, &pem_size);
+-
+-    if (ret != 0) {
+-#ifdef MBEDTLS_ERROR_C
+-        mbedtls_strerror(ret, buf, 1024);
+-#endif
+-        mbedtls_printf(" failed\n  !  load_file returned %d - %s\n\n", ret, buf);
+-        goto exit;
+-    }
+-
+-    mbedtls_printf(" ok\n");
+-
+-    /*
+-     * 1.2. Convert from PEM to DER
+-     */
+-    mbedtls_printf("  . Converting from PEM to DER ...");
+-    fflush(stdout);
+-
+-    if ((ret = convert_pem_to_der(pem_buffer, pem_size, der_buffer, &der_size)) != 0) {
+-#ifdef MBEDTLS_ERROR_C
+-        mbedtls_strerror(ret, buf, 1024);
+-#endif
+-        mbedtls_printf(" failed\n  !  convert_pem_to_der %d - %s\n\n", ret, buf);
+-        goto exit;
+-    }
+-
+-    mbedtls_printf(" ok\n");
+-
+-    /*
+-     * 1.3. Write the DER file
+-     */
+-    mbedtls_printf("  . Writing the DER file ...");
+-    fflush(stdout);
+-
+-    ret = write_file(opt.output_file, der_buffer, der_size);
+-
+-    if (ret != 0) {
+-#ifdef MBEDTLS_ERROR_C
+-        mbedtls_strerror(ret, buf, 1024);
+-#endif
+-        mbedtls_printf(" failed\n  !  write_file returned %d - %s\n\n", ret, buf);
+-        goto exit;
+-    }
+-
+-    mbedtls_printf(" ok\n");
+-
+-    exit_code = MBEDTLS_EXIT_SUCCESS;
+-
+-exit:
+-    free(pem_buffer);
+-
+-    mbedtls_exit(exit_code);
+-}
+ #endif /* MBEDTLS_BASE64_C && MBEDTLS_FS_IO */

--- a/recipes-sdk/aws-iot-device-sdk-embedded-c/aws-iot-device-sdk-embedded-c-fleet-provisioning-keys-cert/CMakeLists.txt
+++ b/recipes-sdk/aws-iot-device-sdk-embedded-c/aws-iot-device-sdk-embedded-c-fleet-provisioning-keys-cert/CMakeLists.txt
@@ -1,0 +1,96 @@
+cmake_minimum_required(VERSION 3.0)
+set( DEMO_NAME "fleet_provisioning_keys_cert" )
+
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/libraries/3rdparty/mbedtls)
+
+# Find required packages
+find_package(backoffalgorithm REQUIRED)
+
+find_package(core_mqtt REQUIRED)
+
+find_package(core_pkcs REQUIRED)
+
+find_package(fleetprovisioning REQUIRED)
+
+include(${CMAKE_CURRENT_SOURCE_DIR}/demos/logging-stack/logging.cmake)
+
+### tincycbor
+
+add_library(tinycbor STATIC
+    "${CMAKE_CURRENT_SOURCE_DIR}/libraries/3rdparty/tinycbor/src/cborpretty.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/libraries/3rdparty/tinycbor/src/cborpretty_stdio.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/libraries/3rdparty/tinycbor/src/cborencoder.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/libraries/3rdparty/tinycbor/src/cborencoder_close_container_checked.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/libraries/3rdparty/tinycbor/src/cborerrorstrings.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/libraries/3rdparty/tinycbor/src/cborparser.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/libraries/3rdparty/tinycbor/src/cborparser_dup_string.c"
+)
+
+# Use C99 for tinycbor as it is incompatible with C90
+if(CMAKE_C_STANDARD LESS 99)
+    set_target_properties(tinycbor PROPERTIES C_STANDARD 99)
+endif()
+
+target_include_directories(tinycbor PUBLIC
+    "${CMAKE_CURRENT_SOURCE_DIR}/libraries/3rdparty/tinycbor/src"
+)
+
+### DEMO
+
+file( GLOB DEMO_FILE "${DEMO_NAME}.c*" )
+
+# Add source files
+add_executable(${DEMO_NAME}
+    ${CMAKE_CURRENT_SOURCE_DIR}/demos/fleet_provisioning/${DEMO_NAME}/${DEMO_NAME}_demo.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/demos/fleet_provisioning/${DEMO_NAME}/fleet_provisioning_serializer.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/demos/fleet_provisioning/${DEMO_NAME}/pkcs11_operations.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/demos/fleet_provisioning/${DEMO_NAME}/mqtt_operations.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/platform/posix/clock_posix.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/platform/posix/transport/src/plaintext_posix.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/platform/posix/transport/src/sockets_posix.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/platform/posix/transport/src/mbedtls_pkcs11_posix.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/libraries/3rdparty/mbedtls/programs/util/pem2der.c
+)
+
+# Add include directories for platform specific files
+target_include_directories(${DEMO_NAME} PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/demos/fleet_provisioning/${DEMO_NAME}
+    ${CMAKE_CURRENT_SOURCE_DIR}/libraries/3rdparty/mbedtls/include
+    ${CMAKE_CURRENT_SOURCE_DIR}/libraries/3rdparty/mbedtls/library
+    ${CMAKE_CURRENT_SOURCE_DIR}/demos/http/common/include
+    ${CMAKE_CURRENT_SOURCE_DIR}/demos/include
+    ${CMAKE_CURRENT_SOURCE_DIR}/platform/posix/transport/include
+    ${CMAKE_CURRENT_SOURCE_DIR}/platform/include
+    PUBLIC
+        ${CMAKE_CURRENT_LIST_DIR}
+        ${LOGGING_INCLUDE_DIRS}
+)
+
+# Link libraries
+target_link_libraries(${DEMO_NAME}
+    PRIVATE
+       pthread
+       tinycbor
+       mbedtls
+       backoffalgorithm::backoffalgorithm
+       core_mqtt::core_mqtt
+       core_pkcs
+       fleetprovisioning::fleetprovisioning
+)
+
+# Add compile definitions
+target_compile_definitions(${DEMO_NAME} PRIVATE
+    DOWNLOADED_CERT_WRITE_PATH=""
+    DOWNLOADED_PRIVATE_KEY_WRITE_PATH=""
+    AWS_IOT_ENDPOINT=""
+    ROOT_CA_CERT_PATH=""
+    CLAIM_CERT_PATH=""
+    CLAIM_PRIVATE_KEY_PATH=""
+    PROVISIONING_TEMPLATE_NAME=""
+    DEVICE_SERIAL_NUMBER=""
+    CSR_SUBJECT_NAME=""
+    CLIENT_IDENTIFIER=""
+    OS_NAME="Yocto"
+    OS_VERSION="Yocto"
+    HARDWARE_PLATFORM_NAME="Yocto"
+)

--- a/recipes-sdk/aws-iot-device-sdk-embedded-c/aws-iot-device-sdk-embedded-c-fleet-provisioning-keys-cert/CMakeLists.txt_mbedtls
+++ b/recipes-sdk/aws-iot-device-sdk-embedded-c/aws-iot-device-sdk-embedded-c-fleet-provisioning-keys-cert/CMakeLists.txt_mbedtls
@@ -1,0 +1,20 @@
+file(GLOB MBEDTLS_FILES CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/library/*.c")
+
+add_library(mbedtls
+    ${MBEDTLS_FILES}
+)
+
+set_target_properties(mbedtls PROPERTIES
+    ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib
+    POSITION_INDEPENDENT_CODE ON
+)
+
+# Use C99 for mbedtls as v2.26.0 is incompatible with C90
+if(CMAKE_C_STANDARD LESS 99)
+    set_target_properties(mbedtls PROPERTIES C_STANDARD 99)
+endif()
+
+target_include_directories(mbedtls
+    PUBLIC
+        "${CMAKE_CURRENT_SOURCE_DIR}/include"
+)

--- a/recipes-sdk/aws-iot-device-sdk-embedded-c/aws-iot-device-sdk-embedded-c-fleet-provisioning-keys-cert/run-ptest
+++ b/recipes-sdk/aws-iot-device-sdk-embedded-c/aws-iot-device-sdk-embedded-c-fleet-provisioning-keys-cert/run-ptest
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+ fleet_provisioning_keys_cert
+
+RETVAL=$?
+if [ $RETVAL -eq 1 ] ; then
+    echo "PASS: aws-iot-device-sdk-embedded-c-fleet-provisioning-keys-cert: simple test"
+else
+    echo "FAIL: aws-iot-device-sdk-embedded-c-fleet-provisioning-keys-cert: simple test"
+fi

--- a/recipes-sdk/aws-iot-device-sdk-embedded-c/aws-iot-device-sdk-embedded-c-fleet-provisioning-keys-cert_202412.00.bb
+++ b/recipes-sdk/aws-iot-device-sdk-embedded-c/aws-iot-device-sdk-embedded-c-fleet-provisioning-keys-cert_202412.00.bb
@@ -1,0 +1,39 @@
+SUMMARY = "AWS IoT Device SDK for Embedded C - demo fleet_provisioning_keys_cert"
+DESCRIPTION = "SDK for connecting to AWS IoT from a device using embedded C - demo fleet_provisioning_keys_cert build from discrete lib packages instead of self contained libs"
+HOMEPAGE = "https://github.com/aws/aws-iot-device-sdk-embedded-C"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=c8c19afab7f99fb196c9287cbd60a258 "
+
+SRC_URI = "\
+    gitsm://github.com/aws/aws-iot-device-sdk-embedded-C.git;protocol=https;branch=main \
+    file://001-transport-interface.patch \
+    file://002-config.patch \
+    file://003-fix-includes.patch \
+    file://004-convert-pem-to-der.patch \
+    file://CMakeLists.txt_mbedtls \
+    file://CMakeLists.txt \
+    file://run-ptest \
+    "
+
+SRCREV = "da99638ec373c791a45557b0cd91fc20968d492d"
+
+S = "${WORKDIR}/git"
+
+DEPENDS = "\
+    backoffalgorithm \
+    coremqtt \
+    corepkcs11 \
+    fleet-provisioning-for-aws-iot-embedded-sdk \
+    "
+
+inherit cmake ptest
+
+do_configure:prepend () {
+    install ${WORKDIR}/CMakeLists.txt ${S}/
+    install ${WORKDIR}/CMakeLists.txt_mbedtls ${S}/libraries/3rdparty/mbedtls/CMakeLists.txt
+}
+
+do_install () {
+    install -d ${D}${bindir}
+    install -m 0755 ${B}/fleet_provisioning_keys_cert ${D}${bindir}
+}

--- a/recipes-sdk/aws-iot-device-sdk-embedded-c/aws-iot-device-sdk-embedded-c-http-demo-basic-tls/CMakeLists.txt
+++ b/recipes-sdk/aws-iot-device-sdk-embedded-c/aws-iot-device-sdk-embedded-c-http-demo-basic-tls/CMakeLists.txt
@@ -1,0 +1,51 @@
+cmake_minimum_required(VERSION 3.0)
+set( DEMO_NAME "http_demo_basic_tls" )
+
+# Find required packages
+find_package(core_http REQUIRED)
+find_package(OpenSSL REQUIRED)
+find_package(backoffalgorithm REQUIRED)
+
+include(${CMAKE_CURRENT_SOURCE_DIR}/demos/logging-stack/logging.cmake)
+
+file( GLOB DEMO_FILE "${DEMO_NAME}.c*" )
+
+# Add source files
+add_executable(${DEMO_NAME}
+    ${CMAKE_CURRENT_SOURCE_DIR}/platform/posix/clock_posix.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/platform/posix/transport/src/plaintext_posix.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/platform/posix/transport/src/sockets_posix.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/platform/posix/transport/src/openssl_posix.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/demos/http/common/src/http_demo_utils.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/demos/http/common/src/http_demo_url_utils.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/demos/http/${DEMO_NAME}/${DEMO_NAME}.c
+)
+
+# Add include directories for platform specific files
+target_include_directories(${DEMO_NAME} PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/demos/http/${DEMO_NAME}
+    ${CMAKE_CURRENT_SOURCE_DIR}/demos/http/common/include
+    ${CMAKE_CURRENT_SOURCE_DIR}/platform/posix/transport/include
+    ${CMAKE_CURRENT_SOURCE_DIR}/platform/include
+    PUBLIC
+        ${CMAKE_CURRENT_LIST_DIR}
+        ${LOGGING_INCLUDE_DIRS}
+)
+
+
+# Link libraries
+target_link_libraries(${DEMO_NAME}
+    PRIVATE
+        core_http::core_http
+        backoffalgorithm::backoffalgorithm
+        pthread
+        ssl
+        crypto
+)
+
+# Add compile definitions
+target_compile_definitions(${DEMO_NAME} PRIVATE
+    SERVER_HOST="google.com"
+    HTTPS_PORT=443
+    ROOT_CA_CERT_PATH="/etc/ssl/certs/ca-certificates.crt"
+)

--- a/recipes-sdk/aws-iot-device-sdk-embedded-c/aws-iot-device-sdk-embedded-c-http-demo-basic-tls/run-ptest
+++ b/recipes-sdk/aws-iot-device-sdk-embedded-c/aws-iot-device-sdk-embedded-c-http-demo-basic-tls/run-ptest
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+rm -rf tests.log
+timeout 30s http_demo_basic_tls | tee -a tests.log
+grep "Demo completed successfully" tests.log
+RETVAL=$?
+if [ $RETVAL -eq 0 ] ; then
+    echo "PASS: aws-iot-device-sdk-embedded-c: http_demo_basic_tls"
+else
+    echo "FAIL: aws-iot-device-sdk-embedded-c: http_demo_basic_tls"
+fi

--- a/recipes-sdk/aws-iot-device-sdk-embedded-c/aws-iot-device-sdk-embedded-c-http-demo-basic-tls_202412.00.bb
+++ b/recipes-sdk/aws-iot-device-sdk-embedded-c/aws-iot-device-sdk-embedded-c-http-demo-basic-tls_202412.00.bb
@@ -1,0 +1,37 @@
+SUMMARY = "AWS IoT Device SDK for Embedded C - demo http-demo-basic-tls"
+DESCRIPTION = "SDK for connecting to AWS IoT from a device using embedded C - demo http-demo-basic-tls build from discrete lib packages instead of self contained libs"
+HOMEPAGE = "https://github.com/aws/aws-iot-device-sdk-embedded-C"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=c8c19afab7f99fb196c9287cbd60a258"
+
+DEPENDS = "\
+    backoffalgorithm \
+    corehttp \
+    openssl \
+"
+
+SRC_URI = "\
+    git://github.com/aws/aws-iot-device-sdk-embedded-C.git;protocol=https;branch=main \
+    file://CMakeLists.txt \
+    file://run-ptest \
+    "
+
+SRCREV = "da99638ec373c791a45557b0cd91fc20968d492d"
+
+S = "${WORKDIR}/git"
+
+RDEPENDS:${PN} += "\
+    ca-certificates \
+    openssl \
+"
+
+inherit cmake ptest
+
+do_configure:prepend () {
+    cp ${WORKDIR}/CMakeLists.txt ${S}/
+}
+
+do_install () {
+    install -d ${D}${bindir}
+    install -m 0755 ${B}/http_demo_basic_tls ${D}${bindir}
+}

--- a/recipes-sdk/aws-iot-device-sdk-embedded-c/aws-iot-device-sdk-embedded-c-jobs-demo-mosquitto/001-jobs-include.patch
+++ b/recipes-sdk/aws-iot-device-sdk-embedded-c/aws-iot-device-sdk-embedded-c-jobs-demo-mosquitto/001-jobs-include.patch
@@ -1,0 +1,16 @@
+Upstream-Status: Inappropriate [oe-specific]
+
+Index: aws-iot-device-sdk-embedded-c-jobs-demo-mosquitto-git/demos/jobs/jobs_demo_mosquitto/jobs_demo_mosquitto.c
+===================================================================
+--- aws-iot-device-sdk-embedded-c-jobs-demo-mosquitto-git.orig/demos/jobs/jobs_demo_mosquitto/jobs_demo_mosquitto.c
++++ aws-iot-device-sdk-embedded-c-jobs-demo-mosquitto-git/demos/jobs/jobs_demo_mosquitto/jobs_demo_mosquitto.c
+@@ -55,8 +55,8 @@
+ #endif
+
+ #include "demo_config.h"
+-#include "jobs.h"
+-#include "core_json.h"
++#include <libjobs/jobs.h>
++#include <core_json/core_json.h>
+
+ /*-----------------------------------------------------------*/

--- a/recipes-sdk/aws-iot-device-sdk-embedded-c/aws-iot-device-sdk-embedded-c-jobs-demo-mosquitto/002-string-include.patch
+++ b/recipes-sdk/aws-iot-device-sdk-embedded-c/aws-iot-device-sdk-embedded-c-jobs-demo-mosquitto/002-string-include.patch
@@ -1,0 +1,14 @@
+Upstream-Status: Inappropriate [oe-specific]
+
+Index: aws-iot-device-sdk-embedded-c-jobs-demo-mosquitto-git/demos/http/common/src/http_demo_utils.c
+===================================================================
+--- aws-iot-device-sdk-embedded-c-jobs-demo-mosquitto-git.orig/demos/http/common/src/http_demo_utils.c
++++ aws-iot-device-sdk-embedded-c-jobs-demo-mosquitto-git/demos/http/common/src/http_demo_utils.c
+@@ -24,6 +24,7 @@
+ #include <assert.h>
+ #include <time.h>
+ #include <stdlib.h>
++#include <string.h>
+
+ /* POSIX includes. */
+ #include <unistd.h>

--- a/recipes-sdk/aws-iot-device-sdk-embedded-c/aws-iot-device-sdk-embedded-c-jobs-demo-mosquitto/CMakeLists.txt
+++ b/recipes-sdk/aws-iot-device-sdk-embedded-c/aws-iot-device-sdk-embedded-c-jobs-demo-mosquitto/CMakeLists.txt
@@ -1,0 +1,61 @@
+cmake_minimum_required(VERSION 3.0)
+set( DEMO_NAME "jobs_demo_mosquitto" )
+
+# Find required packages
+find_package(backoffalgorithm REQUIRED)
+find_package(jobs REQUIRED)
+find_package(core_http REQUIRED)
+
+include(${CMAKE_CURRENT_SOURCE_DIR}/demos/logging-stack/logging.cmake)
+
+file( GLOB DEMO_FILE "${DEMO_NAME}.c*" )
+
+# Add source files
+add_executable(${DEMO_NAME}
+    ${CMAKE_CURRENT_SOURCE_DIR}/platform/posix/clock_posix.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/platform/posix/transport/src/plaintext_posix.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/platform/posix/transport/src/sockets_posix.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/platform/posix/transport/src/openssl_posix.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/demos/http/common/src/http_demo_utils.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/demos/http/common/src/http_demo_url_utils.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/demos/jobs/${DEMO_NAME}/${DEMO_NAME}.c
+)
+
+# Add include directories for platform specific files
+target_include_directories(${DEMO_NAME} PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/demos/jobs/${DEMO_NAME}
+    ${CMAKE_CURRENT_SOURCE_DIR}/demos/http/common/include
+    ${CMAKE_CURRENT_SOURCE_DIR}/platform/posix/transport/include
+    ${CMAKE_CURRENT_SOURCE_DIR}/platform/include
+    PUBLIC
+        ${CMAKE_CURRENT_LIST_DIR}
+        ${LOGGING_INCLUDE_DIRS}
+)
+
+
+# Link libraries
+target_link_libraries(${DEMO_NAME}
+    PRIVATE
+        core_http::core_http
+        core_json
+        backoffalgorithm::backoffalgorithm
+        pthread
+        ssl
+        crypto
+        libjobs
+        mosquitto
+)
+
+# Add compile definitions
+target_compile_definitions(${DEMO_NAME} PRIVATE
+    AWS_IOT_ENDPOINT=""
+    ROOT_CA_CERT_PATH="/etc/ssl/certs/ca-certificates.crt"
+    CLIENT_PRIVATE_KEY_PATH=""
+
+)
+
+# Add define to use default config
+target_compile_definitions(${DEMO_NAME}
+    PUBLIC
+        HTTP_DO_NOT_USE_CUSTOM_CONFIG
+)

--- a/recipes-sdk/aws-iot-device-sdk-embedded-c/aws-iot-device-sdk-embedded-c-jobs-demo-mosquitto/run-ptest
+++ b/recipes-sdk/aws-iot-device-sdk-embedded-c/aws-iot-device-sdk-embedded-c-jobs-demo-mosquitto/run-ptest
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+jobs_demo_mosquitto 
+RETVAL=$?
+if [ $RETVAL -eq 0 ] ; then
+    echo "PASS: aws-iot-device-sdk-embedded-c-jobs_demo_mosquitto: simple-test"
+else
+    echo "FAIL: aws-iot-device-sdk-embedded-c-jobs_demo_mosquitto: simple-test"
+fi

--- a/recipes-sdk/aws-iot-device-sdk-embedded-c/aws-iot-device-sdk-embedded-c-jobs-demo-mosquitto_202412.00.bb
+++ b/recipes-sdk/aws-iot-device-sdk-embedded-c/aws-iot-device-sdk-embedded-c-jobs-demo-mosquitto_202412.00.bb
@@ -1,0 +1,41 @@
+SUMMARY = "AWS IoT Device SDK for Embedded C - jobs-demo-mosquitto"
+DESCRIPTION = "SDK for connecting to AWS IoT from a device using embedded C - jobs-demo-mosquitto build from discrete lib packages instead of self contained libs"
+HOMEPAGE = "https://github.com/aws/aws-iot-device-sdk-embedded-C"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=c8c19afab7f99fb196c9287cbd60a258"
+
+DEPENDS = "\
+    backoffalgorithm \
+    corehttp \
+    corejson \
+    jobs-for-aws-iot-embedded-sdk \
+    mosquitto \
+    openssl \
+    "
+
+SRC_URI = "\
+    git://github.com/aws/aws-iot-device-sdk-embedded-C.git;protocol=https;branch=main \
+    file://001-jobs-include.patch \
+    file://002-string-include.patch \
+    file://CMakeLists.txt \
+    file://run-ptest \
+    "
+
+SRCREV = "da99638ec373c791a45557b0cd91fc20968d492d"
+
+S = "${WORKDIR}/git"
+
+RDEPENDS:${PN}-ptest += "\
+    mosquitto \
+    "
+
+inherit cmake ptest
+
+do_configure:prepend () {
+    install ${WORKDIR}/CMakeLists.txt ${S}/
+}
+
+do_install () {
+    install -d ${D}${bindir}
+    install -m 0755 ${B}/jobs_demo_mosquitto ${D}${bindir}
+}

--- a/recipes-sdk/aws-iot-device-sdk-embedded-c/aws-iot-device-sdk-embedded-c-mqtt-demo-plaintext/CMakeLists.txt
+++ b/recipes-sdk/aws-iot-device-sdk-embedded-c/aws-iot-device-sdk-embedded-c-mqtt-demo-plaintext/CMakeLists.txt
@@ -1,0 +1,41 @@
+cmake_minimum_required(VERSION 3.0)
+project(mqtt_demo_plaintext C)
+
+# Find required packages
+find_package(core_mqtt REQUIRED)
+find_package(backoffalgorithm REQUIRED)
+
+include(${CMAKE_CURRENT_SOURCE_DIR}/demos/logging-stack/logging.cmake)
+
+# Add source files
+add_executable(mqtt_demo_plaintext
+    ${CMAKE_CURRENT_SOURCE_DIR}/platform/posix/clock_posix.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/platform/posix/transport/src/plaintext_posix.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/platform/posix/transport/src/sockets_posix.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/demos/mqtt/mqtt_demo_plaintext/mqtt_demo_plaintext.c
+)
+
+# Add include directories for platform specific files
+target_include_directories(mqtt_demo_plaintext PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CMAKE_CURRENT_SOURCE_DIR}/platform/posix/transport/include/
+    ${CMAKE_CURRENT_SOURCE_DIR}/platform/include/
+    PUBLIC
+        ${CMAKE_CURRENT_LIST_DIR}
+        ${LOGGING_INCLUDE_DIRS}
+)
+
+
+# Link libraries
+target_link_libraries(mqtt_demo_plaintext
+    PRIVATE
+        core_mqtt::core_mqtt
+        backoffalgorithm::backoffalgorithm
+        pthread
+)
+
+# Add compile definitions
+target_compile_definitions(mqtt_demo_plaintext PRIVATE
+    BROKER_ENDPOINT="localhost"
+    CLIENT_IDENTIFIER="mqtt_demo_plaintext"
+)

--- a/recipes-sdk/aws-iot-device-sdk-embedded-c/aws-iot-device-sdk-embedded-c-mqtt-demo-plaintext/run-ptest
+++ b/recipes-sdk/aws-iot-device-sdk-embedded-c/aws-iot-device-sdk-embedded-c-mqtt-demo-plaintext/run-ptest
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+rm -rf tests.log
+timeout 30s mqtt_demo_plaintext | tee -a tests.log
+grep "Demo completed successfully" tests.log
+RETVAL=$?
+if [ $RETVAL -eq 0 ] ; then
+    echo "PASS: aws-iot-device-sdk-embedded-c: mqtt_demo_plaintext"
+else
+    echo "FAIL: aws-iot-device-sdk-embedded-c: mqtt_demo_plaintext"
+fi

--- a/recipes-sdk/aws-iot-device-sdk-embedded-c/aws-iot-device-sdk-embedded-c-mqtt-demo-plaintext_202412.00.bb
+++ b/recipes-sdk/aws-iot-device-sdk-embedded-c/aws-iot-device-sdk-embedded-c-mqtt-demo-plaintext_202412.00.bb
@@ -1,0 +1,36 @@
+SUMMARY = "AWS IoT Device SDK for Embedded C - demo mqtt-demo-plaintext"
+DESCRIPTION = "SDK for connecting to AWS IoT from a device using embedded C - demo mqtt-demo-plaintext build from discrete lib packages instead of self contained libs"
+HOMEPAGE = "https://github.com/aws/aws-iot-device-sdk-embedded-C"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=c8c19afab7f99fb196c9287cbd60a258"
+
+DEPENDS = "\
+    backoffalgorithm \
+    coremqtt \
+    "
+
+SRC_URI = "\
+    git://github.com/aws/aws-iot-device-sdk-embedded-C.git;protocol=https;branch=main \
+    file://CMakeLists.txt \
+    file://run-ptest \
+    "
+
+SRCREV = "da99638ec373c791a45557b0cd91fc20968d492d"
+
+S = "${WORKDIR}/git"
+
+RDEPENDS:${PN}-ptest += "\
+    coreutils \
+    mosquitto \
+    "
+
+inherit cmake ptest
+
+do_configure:prepend () {
+    install ${WORKDIR}/CMakeLists.txt ${S}/
+}
+
+do_install () {
+    install -d ${D}${bindir}
+    install -m 0755 ${B}/mqtt_demo_plaintext ${D}${bindir}
+}

--- a/recipes-sdk/aws-iot-device-sdk-embedded-c/aws-iot-device-sdk-embedded-c_202412.00.bb
+++ b/recipes-sdk/aws-iot-device-sdk-embedded-c/aws-iot-device-sdk-embedded-c_202412.00.bb
@@ -1,8 +1,14 @@
-SUMMARY = "AWS IoT Device SDK for Embedded C"
-DESCRIPTION = "SDK for connecting to AWS IoT from a device using embedded C"
+SUMMARY = "AWS IoT Device SDK for Embedded C - reference implentation"
+DESCRIPTION = "SDK for connecting to AWS IoT from a device using embedded C - a reference implentation, using standalone versions of contained libs is the preferred way to consoume it"
 HOMEPAGE = "https://github.com/aws/aws-iot-device-sdk-embedded-C"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=c8c19afab7f99fb196c9287cbd60a258 "
+
+DEPENDS = "\
+    ${@bb.utils.contains('PACKAGECONFIG', 'with-demos', 'mosquitto', '', d)} \
+    ${@bb.utils.contains('PACKAGECONFIG', 'with-demos', 'openssl', '', d)} \
+    ${@bb.utils.contains('PACKAGECONFIG', 'with-tests', 'ruby-native', '', d)} \
+    "
 
 SRC_URI = "\
     gitsm://github.com/aws/aws-iot-device-sdk-embedded-C.git;protocol=https;branch=main \
@@ -11,19 +17,13 @@ SRC_URI = "\
 
 SRCREV = "da99638ec373c791a45557b0cd91fc20968d492d"
 
-DEPENDS = "\
-    ${@bb.utils.contains('PACKAGECONFIG', 'with-demos', 'mosquitto', '', d)} \
-    ${@bb.utils.contains('PACKAGECONFIG', 'with-demos', 'openssl', '', d)} \
-    ${@bb.utils.contains('PACKAGECONFIG', 'with-tests', 'ruby-native', '', d)} \
-    "
-
 S = "${WORKDIR}/git"
 
 inherit cmake ptest pkgconfig
 
 PACKAGECONFIG ??= "\
+    with-demos \
     ${@bb.utils.contains('PTEST_ENABLED', '1', 'with-tests','', d)} \
-    ${@bb.utils.contains('PTEST_ENABLED', '1', 'with-demos','', d)} \
     "
 
 EXTRA_OECMAKE += "\
@@ -33,6 +33,7 @@ EXTRA_OECMAKE += "\
     -DCLIENT_PRIVATE_KEY_PATH=${CLIENT_PRIVATE_KEY_PATH} \
     -DINSTALL_TO_SYSTEM=1 \
     -DROOT_CA_CERT_PATH=${ROOT_CA_CERT_PATH} \
+    -DSERVER_HOST=${SERVER_HOST} \
     -DTHING_NAME=${THING_NAME} \
     "
 
@@ -70,5 +71,6 @@ AWS_IOT_ENDPOINT ?= "your-iot-endpoint"
 BROKER_ENDPOINT ?= "localhost"
 CLIENT_CERT_PATH ?= "${sysconfdir}"
 CLIENT_PRIVATE_KEY_PATH ?= "${sysconfdir}"
-ROOT_CA_CERT_PATH ?= "${sysconfdir}"
+ROOT_CA_CERT_PATH ?= "${sysconfdir}/ssl/certs/ca-certificates.crt"
+SERVER_HOST ?= "google.com"
 THING_NAME ?= "your-registered-thing-name"

--- a/recipes-sdk/backoffalgorithm/backoffalgorithm_1.4.1.bb
+++ b/recipes-sdk/backoffalgorithm/backoffalgorithm_1.4.1.bb
@@ -1,0 +1,37 @@
+SUMMARY = "Algorithm for calculating exponential backoff"
+DESCRIPTION = "Algorithm for calculating exponential backoff with jitter for network retry attempts."
+HOMEPAGE = "https://github.com/FreeRTOS/backoffAlgorithm"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=7ae2be7fb1637141840314b51970a9f7"
+
+SRC_URI = "gitsm://github.com/FreeRTOS/backoffAlgorithm.git;protocol=https;branch=main \
+    file://CMakeLists.txt \
+    file://Findbackoffalgorithm.cmake \
+"
+
+SRCREV = "50e30d7d0aa0aa74e85134088a86f91978267d41"
+
+S = "${WORKDIR}/git"
+
+inherit cmake
+
+EXTRA_OECMAKE:append = " \
+    -DLIB_VERSION=${PV} \
+    -DLIB_SOVERSION=${@d.getVar('PV').split('.')[0]} \
+"
+
+do_configure:prepend() {
+    cp ${WORKDIR}/CMakeLists.txt ${S}/
+}
+
+do_install:append() {
+    install -d ${D}${datadir}/cmake/Modules
+    install -m 0644 ${WORKDIR}/Findbackoffalgorithm.cmake ${D}${datadir}/cmake/Modules/
+}
+
+FILES:${PN} += "${libdir}/libbackoffalgorithm.so.*"
+FILES:${PN}-dev += "\
+    ${libdir}/libbackoffalgorithm.so \
+    ${includedir}/backoffalgorithm/* \
+    ${datadir}/cmake/Modules/Findbackoffalgorithm.cmake \
+"

--- a/recipes-sdk/backoffalgorithm/files/CMakeLists.txt
+++ b/recipes-sdk/backoffalgorithm/files/CMakeLists.txt
@@ -1,0 +1,38 @@
+set( LIB_NAME "backoffalgorithm" )
+cmake_minimum_required(VERSION 3.0)
+
+# Include the file containing source definitions
+include(${CMAKE_CURRENT_SOURCE_DIR}/backoffAlgorithmFilePaths.cmake)
+
+# Option to build shared libraries
+option(BUILD_SHARED_LIBS "Build shared libraries" ON)
+
+add_library(${LIB_NAME}
+    ${BACKOFF_ALGORITHM_SOURCES}
+)
+
+set_target_properties(${LIB_NAME} PROPERTIES
+    VERSION ${LIB_VERSION}
+    SOVERSION ${LIB_SOVERSION}
+)
+
+# Set include directories using the paths from backoffAlgorithmFilePaths.cmake
+target_include_directories(${LIB_NAME}
+    PUBLIC
+        ${BACKOFF_ALGORITHM_INCLUDE_PUBLIC_DIRS}
+)
+
+# Installation rules
+include(GNUInstallDirs)
+
+# Install the library and headers
+install(TARGETS ${LIB_NAME}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${LIB_NAME}
+)
+
+# Install header files
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/source/include/
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${LIB_NAME}
+    FILES_MATCHING PATTERN "*.h"
+)

--- a/recipes-sdk/backoffalgorithm/files/Findbackoffalgorithm.cmake
+++ b/recipes-sdk/backoffalgorithm/files/Findbackoffalgorithm.cmake
@@ -1,0 +1,20 @@
+find_path(BACKOFFALGORITHM_INCLUDE_DIR backoff_algorithm.h
+          PATHS ${CMAKE_INSTALL_PREFIX}/include
+          PATH_SUFFIXES backoffalgorithm)
+
+find_library(BACKOFFALGORITHM_LIBRARY
+             NAMES backoffalgorithm
+             PATHS ${CMAKE_INSTALL_PREFIX}/lib)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(backoffalgorithm DEFAULT_MSG
+                                  BACKOFFALGORITHM_LIBRARY BACKOFFALGORITHM_INCLUDE_DIR)
+
+mark_as_advanced(BACKOFFALGORITHM_INCLUDE_DIR BACKOFFALGORITHM_LIBRARY)
+
+if(backoffalgorithm_FOUND AND NOT TARGET backoffalgorithm::backoffalgorithm)
+  add_library(backoffalgorithm::backoffalgorithm UNKNOWN IMPORTED)
+  set_target_properties(backoffalgorithm::backoffalgorithm PROPERTIES
+    IMPORTED_LOCATION "${BACKOFFALGORITHM_LIBRARY}"
+    INTERFACE_INCLUDE_DIRECTORIES "${BACKOFFALGORITHM_INCLUDE_DIR}")
+endif()

--- a/recipes-sdk/corehttp/corehttp_3.1.1.bb
+++ b/recipes-sdk/corehttp/corehttp_3.1.1.bb
@@ -1,0 +1,45 @@
+SUMMARY = "Client implementation of a subset of HTTP 1.1 protocol"
+DESCRIPTION = "Client implementation of a subset of HTTP 1.1 protocol designed for embedded devices."
+HOMEPAGE = "https://github.com/FreeRTOS/coreHTTP"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=7ae2be7fb1637141840314b51970a9f7 \
+                    file://source/dependency/3rdparty/llhttp/LICENSE-MIT;md5=f5e274d60596dd59be0a1d1b19af7978"
+
+SRC_URI = "\
+    gitsm://github.com/FreeRTOS/coreHTTP.git;protocol=https;branch=main \
+    file://CMakeLists.txt \
+    file://Findcore_http.cmake \
+"
+
+SRCREV = "169c2879589dee06fce4a4f9803924f76131f483"
+
+S = "${WORKDIR}/git"
+
+inherit cmake
+
+EXTRA_OECMAKE:append = " \
+    -DCMAKE_C_FLAGS=-DHTTP_DO_NOT_USE_CUSTOM_CONFIG=ON \
+    -DLIB_VERSION=${PV} \
+    -DLIB_SOVERSION=${@d.getVar('PV').split('.')[0]} \
+"
+
+do_configure:prepend() {
+    cp ${WORKDIR}/CMakeLists.txt ${S}/
+}
+
+do_install:append() {
+    install -d ${D}${datadir}/cmake/Modules
+    install -m 0644 ${WORKDIR}/Findcore_http.cmake ${D}${datadir}/cmake/Modules/
+    install ${S}/source/interface/transport_interface.h ${D}${includedir}/core_http/
+}
+
+FILES:${PN} += "${libdir}/libcore_http.so.*"
+
+FILES:${PN}-dev += "\
+    ${libdir}/libcore_http.so \
+    ${includedir}/core_http/* \
+    ${datadir}/cmake/Modules/Findcore_http.cmake \
+"
+
+# nooelint: oelint.vars.insaneskip:INSANE_SKIP
+INSANE_SKIP:${PN} += "buildpaths"

--- a/recipes-sdk/corehttp/files/CMakeLists.txt
+++ b/recipes-sdk/corehttp/files/CMakeLists.txt
@@ -1,0 +1,39 @@
+set( LIB_NAME "core_http" )
+
+cmake_minimum_required(VERSION 3.0)
+
+# Include the file containing source definitions
+include(${CMAKE_CURRENT_SOURCE_DIR}/httpFilePaths.cmake)
+
+# Option to build shared libraries
+option(BUILD_SHARED_LIBS "Build shared libraries" ON)
+
+add_library(${LIB_NAME}
+    ${HTTP_SOURCES}
+)
+
+set_target_properties(${LIB_NAME} PROPERTIES
+    VERSION ${LIB_VERSION}
+    SOVERSION ${LIB_SOVERSION}
+)
+
+# Set include directories using the paths from httpFilePaths.cmake
+target_include_directories(${LIB_NAME}
+    PUBLIC
+        ${HTTP_INCLUDE_PUBLIC_DIRS}
+)
+
+# Installation rules
+include(GNUInstallDirs)
+
+# Install the library and headers
+install(TARGETS ${LIB_NAME}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${LIB_NAME}
+)
+
+# Install header files
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/source/include/
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${LIB_NAME}
+    FILES_MATCHING PATTERN "*.h"
+)

--- a/recipes-sdk/corehttp/files/Findcore_http.cmake
+++ b/recipes-sdk/corehttp/files/Findcore_http.cmake
@@ -1,0 +1,20 @@
+find_path(HTTP_INCLUDE_PUBLIC_DIRS core_http_client.h
+          PATHS ${CMAKE_INSTALL_PREFIX}/include
+          PATH_SUFFIXES core_http)
+
+find_library(CORE_HTTP_LIBRARY
+             NAMES core_http
+             PATHS ${CMAKE_INSTALL_PREFIX}/lib)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(core_http DEFAULT_MSG
+                                  CORE_HTTP_LIBRARY HTTP_INCLUDE_PUBLIC_DIRS)
+
+mark_as_advanced(HTTP_INCLUDE_PUBLIC_DIRS CORE_HTTP_LIBRARY)
+
+if(core_http_FOUND AND NOT TARGET core_http::core_http)
+  add_library(core_http::core_http UNKNOWN IMPORTED)
+  set_target_properties(core_http::core_http PROPERTIES
+    IMPORTED_LOCATION "${CORE_HTTP_LIBRARY}"
+    INTERFACE_INCLUDE_DIRECTORIES "${HTTP_INCLUDE_PUBLIC_DIRS}")
+endif()

--- a/recipes-sdk/corejson/corejson_3.0.0.bb
+++ b/recipes-sdk/corejson/corejson_3.0.0.bb
@@ -1,0 +1,38 @@
+SUMMARY = "A parser strictly enforcing the ECMA-404 JSON standard."
+DESCRIPTION = "A parser strictly enforcing the ECMA-404 JSON standard, suitable for microcontrollers."
+HOMEPAGE = "https://github.com/FreeRTOS/coreJSON"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=7ae2be7fb1637141840314b51970a9f7"
+
+SRC_URI = "\
+    gitsm://github.com/FreeRTOS/coreJSON.git;protocol=https;branch=main \
+    file://CMakeLists.txt \
+    file://Findcore_json.cmake \
+"
+
+SRCREV = "03a463f23ead5240974c663477baf03fe82fc530"
+
+S = "${WORKDIR}/git"
+
+inherit cmake
+
+EXTRA_OECMAKE:append = " \
+    -DLIB_VERSION=${PV} \
+    -DLIB_SOVERSION=${@d.getVar('PV').split('.')[0]} \
+"
+
+do_configure:prepend() {
+    cp ${WORKDIR}/CMakeLists.txt ${S}/
+}
+
+do_install:append() {
+    install -d ${D}${datadir}/cmake/Modules
+    install -m 0644 ${WORKDIR}/Findcore_json.cmake ${D}${datadir}/cmake/Modules/
+}
+
+FILES:${PN} += "${libdir}/libcore_json.so.*"
+FILES:${PN}-dev += "\
+    ${libdir}/libcore_json.so \
+    ${includedir}/libcore_json/* \
+    ${datadir}/cmake/Modules/Findcore_json.cmake \
+"

--- a/recipes-sdk/corejson/files/CMakeLists.txt
+++ b/recipes-sdk/corejson/files/CMakeLists.txt
@@ -1,0 +1,37 @@
+set( LIB_NAME "core_json" )
+
+cmake_minimum_required(VERSION 3.0)
+
+# Include the file containing source definitions
+include(${CMAKE_CURRENT_SOURCE_DIR}/jsonFilePaths.cmake)
+
+option(BUILD_SHARED_LIBS "Build shared libraries" ON)
+
+add_library(${LIB_NAME}
+    ${JSON_SOURCES}
+)
+
+set_target_properties(${LIB_NAME} PROPERTIES
+    VERSION ${LIB_VERSION}
+    SOVERSION ${LIB_SOVERSION}
+)
+
+target_include_directories(${LIB_NAME}
+    PUBLIC
+        ${JSON_INCLUDE_PUBLIC_DIRS}
+)
+
+# Installation rules
+include(GNUInstallDirs)
+
+# Install the library and headers
+install(TARGETS ${LIB_NAME}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${LIB_NAME}
+)
+
+# Install header files
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/source/include/
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${LIB_NAME}
+    FILES_MATCHING PATTERN "*.h"
+)

--- a/recipes-sdk/corejson/files/Findcore_json.cmake
+++ b/recipes-sdk/corejson/files/Findcore_json.cmake
@@ -1,0 +1,20 @@
+find_path(JSON_INCLUDE_PUBLIC_DIRS core_json.h
+          PATHS ${CMAKE_INSTALL_PREFIX}/include
+          PATH_SUFFIXES core_json)
+
+find_library(JSON_LIBRARY
+             NAMES core_json
+             PATHS ${CMAKE_INSTALL_PREFIX}/lib)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(core_json DEFAULT_MSG
+                                  JSON_LIBRARY JSON_INCLUDE_PUBLIC_DIRS)
+
+mark_as_advanced(JSON_INCLUDE_PUBLIC_DIRS JSON_LIBRARY)
+
+if(json_FOUND AND NOT TARGET json::json)
+  add_library(json::json UNKNOWN IMPORTED)
+  set_target_properties(json::json PROPERTIES
+    IMPORTED_LOCATION "${JSON_LIBRARY}"
+    INTERFACE_INCLUDE_DIRECTORIES "${JSON_INCLUDE_PUBLIC_DIRS}")
+endif()

--- a/recipes-sdk/coremqtt/coremqtt_2.3.1.bb
+++ b/recipes-sdk/coremqtt/coremqtt_2.3.1.bb
@@ -1,0 +1,42 @@
+SUMMARY = "Client implementation of the MQTT 3.1.1 specification"
+DESCRIPTION = "Client implementation of the MQTT 3.1.1 specification for embedded devices"
+HOMEPAGE = "https://github.com/FreeRTOS/coreMQTT"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=7ae2be7fb1637141840314b51970a9f7"
+
+SRC_URI = "gitsm://github.com/FreeRTOS/coreMQTT.git;protocol=https;branch=main \
+    file://CMakeLists.txt \
+    file://Findcore_mqtt.cmake \
+"
+
+SRCREV = "d7b04a13002496994d737eebaf56dbe1e56aaefb"
+
+S = "${WORKDIR}/git"
+
+inherit cmake
+
+EXTRA_OECMAKE:append = " \
+    -DCMAKE_C_FLAGS=-DMQTT_DO_NOT_USE_CUSTOM_CONFIG=ON \
+    -DLIB_VERSION=${PV} \
+    -DLIB_SOVERSION=${@d.getVar('PV').split('.')[0]} \
+"
+
+do_configure:prepend() {
+    cp ${WORKDIR}/CMakeLists.txt ${S}/
+}
+
+do_install:append() {
+    install -d ${D}${datadir}/cmake/Modules
+    install -m 0644 ${WORKDIR}/Findcore_mqtt.cmake ${D}${datadir}/cmake/Modules/
+    install ${S}/source/interface/transport_interface.h ${D}${includedir}/core_mqtt/
+}
+
+FILES:${PN} += "${libdir}/libcore_mqtt.so.*"
+
+FILES:${PN}-dev += "\
+    ${libdir}/libcore_mqtt.so \
+    ${includedir}/core_mqtt/* \
+    ${datadir}/cmake/Modules/Findcore_mqtt.cmake \
+"
+# nooelint: oelint.vars.insaneskip:INSANE_SKIP
+INSANE_SKIP:${PN} += "buildpaths"

--- a/recipes-sdk/coremqtt/files/CMakeLists.txt
+++ b/recipes-sdk/coremqtt/files/CMakeLists.txt
@@ -1,0 +1,35 @@
+set( LIB_NAME "core_mqtt" )
+
+cmake_minimum_required(VERSION 3.0)
+
+# Include the file containing source definitions
+include(${CMAKE_CURRENT_SOURCE_DIR}/mqttFilePaths.cmake)
+
+option(BUILD_SHARED_LIBS "Build shared libraries" ON)
+
+add_library(${LIB_NAME}
+    ${MQTT_SOURCES}
+    ${MQTT_SERIALIZER_SOURCES}
+)
+
+set_target_properties(${LIB_NAME} PROPERTIES
+    VERSION ${LIB_VERSION}
+    SOVERSION ${LIB_SOVERSION}
+)
+
+target_include_directories(${LIB_NAME}
+    PUBLIC
+        ${MQTT_INCLUDE_PUBLIC_DIRS}
+)
+
+include(GNUInstallDirs)
+
+install(TARGETS ${LIB_NAME}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${LIB_NAME}
+)
+
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/source/include/
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${LIB_NAME}
+    FILES_MATCHING PATTERN "*.h"
+)

--- a/recipes-sdk/coremqtt/files/Findcore_mqtt.cmake
+++ b/recipes-sdk/coremqtt/files/Findcore_mqtt.cmake
@@ -1,0 +1,20 @@
+find_path(CORE_MQTT_INCLUDE_DIR core_mqtt.h
+          PATHS ${CMAKE_INSTALL_PREFIX}/include
+          PATH_SUFFIXES core_mqtt)
+
+find_library(CORE_MQTT_LIBRARY
+             NAMES core_mqtt
+             PATHS ${CMAKE_INSTALL_PREFIX}/lib)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(core_mqtt DEFAULT_MSG
+                                  CORE_MQTT_LIBRARY CORE_MQTT_INCLUDE_DIR)
+
+mark_as_advanced(CORE_MQTT_INCLUDE_DIR CORE_MQTT_LIBRARY)
+
+if(core_mqtt_FOUND AND NOT TARGET core_mqtt::core_mqtt)
+  add_library(core_mqtt::core_mqtt UNKNOWN IMPORTED)
+  set_target_properties(core_mqtt::core_mqtt PROPERTIES
+    IMPORTED_LOCATION "${CORE_MQTT_LIBRARY}"
+    INTERFACE_INCLUDE_DIRECTORIES "${CORE_MQTT_INCLUDE_DIR}")
+endif()

--- a/recipes-sdk/corepkcs11/corepkcs11_3.6.3.bb
+++ b/recipes-sdk/corepkcs11/corepkcs11_3.6.3.bb
@@ -1,0 +1,71 @@
+SUMMARY = "implementation of the PKCS #11 standard"
+DESCRIPTION = "Software implementation of the PKCS #11 standard."
+HOMEPAGE = "https://github.com/FreeRTOS/corePKCS11"
+LICENSE = "MIT & OASIS & Apache-2.0"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=7ae2be7fb1637141840314b51970a9f7 \
+                    file://source/dependency/3rdparty/pkcs11/LICENSE.md;md5=636524f005338d77b2c83f6b111f87cd \
+                    file://source/dependency/3rdparty/mbedtls/LICENSE;md5=379d5819937a6c2f1ef1630d341e026d"
+
+NO_GENERIC_LICENSE[OASIS] = "source/dependency/3rdparty/pkcs11/LICENSE.md"
+
+SRC_URI = "\
+    gitsm://github.com/FreeRTOS/corePKCS11.git;protocol=https;branch=main;name=corepkscs11 \
+    git://github.com/Mbed-TLS/mbedtls.git;protocol=https;branch=mbedtls-2.28;name=mbedtls;destsuffix=${S}/source/dependency/3rdparty/mbedtls \
+    file://core_pkcs11_config.h \
+    file://logging_levels.h \
+    file://logging_stack.h \
+    file://CMakeLists.txt \
+    file://Findcore_pkcs.cmake \
+    file://corepkcs11_mbedtls_config.h \
+    file://CMakeLists.txt_mbedtls \
+    "
+
+SRCREV_corepkscs11 = "0a5fb6c9dd6233d5a869ab9970440be594d2a1c8"
+
+S = "${WORKDIR}/git"
+
+MBEDTLS_2_VERSION = "2.28.10"
+SRCREV_mbedtls = "2fc8413bfcb51354c8e679141b17b3f1a5942561"
+
+SRCREV_FORMAT .= "_corepkscs11_mbedtls"
+
+EXTRA_OECMAKE:append = " \
+    -DFETCHCONTENT_SOURCE_DIR_MBEDTLS=${S}/source/dependency/3rdparty/mbedtls \
+    -DCMAKE_C_FLAGS=-DPKCS_DO_NOT_USE_CUSTOM_CONFIG=ON \
+    -DLIB_VERSION=${PV} \
+    -DLIB_SOVERSION=${@d.getVar('PV').split('.')[0]} \
+"
+
+LDFLAGS += "-Wl,--copy-dt-needed-entries"
+
+inherit cmake
+
+do_configure:prepend() {
+    # verify that all dependencies have correct version
+    grep -q ${MBEDTLS_2_VERSION} ${S}/tools/mbedtls.cmake || bbfatal "ERROR: dependency version mismatch, please update 'SRCREV_mbedtls + MBEDTLS_2_VERSION'!"
+    install ${WORKDIR}/CMakeLists.txt ${S}/
+    install ${WORKDIR}/corepkcs11_mbedtls_config.h ${S}/source/dependency/3rdparty/mbedtls/include/mbedtls/mbedtls_config.h
+    install ${WORKDIR}/CMakeLists.txt_mbedtls ${S}/source/dependency/3rdparty/mbedtls/CMakeLists.txt
+    install ${WORKDIR}/core_pkcs11_config.h ${S}/source/include/
+    install ${WORKDIR}/logging_levels.h ${S}/source/include/
+    install ${WORKDIR}/logging_stack.h ${S}/source/include/
+}
+
+do_install:append() {
+    install -d ${D}${datadir}/cmake/Modules
+    install -m 0644 ${WORKDIR}/Findcore_pkcs.cmake ${D}${datadir}/cmake/Modules/
+    install ${S}/source/dependency/3rdparty/pkcs11/published/2-40-errata-1/* ${D}/${includedir}/core_pkcs/
+    install ${S}/source/dependency/3rdparty/mbedtls_utils/mbedtls_utils.h ${D}/${includedir}/core_pkcs/
+}
+
+FILES:${PN} = "${libdir}/lib*.so.*"
+FILES:${PN}-dev += "\
+    ${libdir}/lib*.so \
+    ${includedir}/core_pkcs/* \
+    ${datadir}/cmake/Modules/Findcore_pkcs.cmake \
+"
+
+EXTRA_OECMAKE += "-DPKCS11_PLATFORM=posix"
+
+# nooelint: oelint.vars.insaneskip:INSANE_SKIP
+INSANE_SKIP:${PN} += "buildpaths"

--- a/recipes-sdk/corepkcs11/files/CMakeLists.txt
+++ b/recipes-sdk/corepkcs11/files/CMakeLists.txt
@@ -1,0 +1,63 @@
+set( LIB_NAME core_pkcs )
+
+cmake_minimum_required(VERSION 3.0)
+
+# set(BUILD_SHARED_LIBS OFF)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/source/dependency/3rdparty/mbedtls)
+
+# For your library (force shared only)
+set(BUILD_SHARED_LIBS ON)
+
+# Include the file containing source definitions
+include(${CMAKE_CURRENT_SOURCE_DIR}/pkcsFilePaths.cmake)
+
+# Create PKCS core library
+add_library(${LIB_NAME}
+    ${PKCS_SOURCES}
+    ${PKCS_PAL_POSIX_SOURCES}
+    ${CMAKE_CURRENT_SOURCE_DIR}/source/portable/mbedtls/core_pkcs11_mbedtls.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/source/dependency/3rdparty/mbedtls/library/threading.c
+)
+
+set_target_properties(${LIB_NAME} PROPERTIES
+    VERSION ${LIB_VERSION}
+    SOVERSION ${LIB_SOVERSION}
+)
+
+# Add define to use default config
+target_compile_definitions(${LIB_NAME}
+    PUBLIC
+        MBEDTLS_CONFIG_FILE="${CMAKE_CURRENT_SOURCE_DIR}/source/dependency/3rdparty/mbedtls/include/mbedtls/mbedtls_config.h"
+)
+
+# Set include directories using the paths from pkcsFilePaths.cmake
+target_include_directories(${LIB_NAME}
+    PUBLIC
+        ${PKCS_INCLUDE_PUBLIC_DIRS}
+        ${PKCS_PAL_INCLUDE_PUBLIC_DIRS}
+        "${CMAKE_CURRENT_LIST_DIR}/source/test/include"
+        "${CMAKE_CURRENT_SOURCE_DIR}/source/dependency/3rdparty/mbedtls/include"
+)
+
+# Installation rules
+include(GNUInstallDirs)
+
+# Install the library and headers
+install(TARGETS ${LIB_NAME}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${LIB_NAME}
+)
+
+# Install header files
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/source/include/
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${LIB_NAME}
+    FILES_MATCHING PATTERN "*.h"
+)
+
+# Link against mbedtls lib
+target_link_libraries(${LIB_NAME}
+    PRIVATE
+#        mbedcrypto
+#        mbedx509
+        mbedtls
+)

--- a/recipes-sdk/corepkcs11/files/CMakeLists.txt_mbedtls
+++ b/recipes-sdk/corepkcs11/files/CMakeLists.txt_mbedtls
@@ -1,0 +1,23 @@
+file(GLOB MBEDTLS_FILES CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/library/*.c")
+
+# Option to build static libraries
+option(BUILD_SHARED_LIBS "Build shared libraries" OFF)
+
+add_library(mbedtls
+    ${MBEDTLS_FILES}
+)
+
+set_target_properties(mbedtls PROPERTIES
+    ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib
+    POSITION_INDEPENDENT_CODE ON
+)
+
+# Use C99 for mbedtls as v2.26.0 is incompatible with C90
+if(CMAKE_C_STANDARD LESS 99)
+    set_target_properties(mbedtls PROPERTIES C_STANDARD 99)
+endif()
+
+target_include_directories(mbedtls
+    PRIVATE
+        "${CMAKE_CURRENT_SOURCE_DIR}/include"
+)

--- a/recipes-sdk/corepkcs11/files/Findcore_pkcs.cmake
+++ b/recipes-sdk/corepkcs11/files/Findcore_pkcs.cmake
@@ -1,0 +1,20 @@
+find_path(CORE_PKCS_INCLUDE_DIR core_pkcs11.h
+          PATHS ${CMAKE_INSTALL_PREFIX}/include
+          PATH_SUFFIXES core_pkcs)
+
+find_library(CORE_PKCS_LIBRARY
+             NAMES core_pkcs
+             PATHS ${CMAKE_INSTALL_PREFIX}/lib)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(core_pkcs DEFAULT_MSG
+                                  CORE_PKCS_LIBRARY CORE_PKCS_INCLUDE_DIR)
+
+mark_as_advanced(CORE_PKCS_INCLUDE_DIR CORE_PKCS_LIBRARY)
+
+if(core_pkcs_FOUND AND NOT TARGET core_pkcs::core_pkcs)
+  add_library(core_pkcs::core_pkcs UNKNOWN IMPORTED)
+  set_target_properties(core_pkcs::core_pkcs PROPERTIES
+    IMPORTED_LOCATION "${CORE_PKCS_LIBRARY}"
+    INTERFACE_INCLUDE_DIRECTORIES "${CORE_PKCS_INCLUDE_DIR}")
+endif()

--- a/recipes-sdk/corepkcs11/files/core_pkcs11_config.h
+++ b/recipes-sdk/corepkcs11/files/core_pkcs11_config.h
@@ -1,0 +1,190 @@
+/*
+ * AWS IoT Device SDK for Embedded C 202412.00
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * @file core_pkcs11_config.h
+ * @brief PCKS#11 config options.
+ */
+#ifndef _CORE_PKCS11_CONFIG_H_
+#define _CORE_PKCS11_CONFIG_H_
+
+/**************************************************/
+/******* DO NOT CHANGE the following order ********/
+/**************************************************/
+
+/* Include logging header files and define logging macros in the following order:
+ * 1. Include the header file "logging_levels.h".
+ * 2. Define the LIBRARY_LOG_NAME and LIBRARY_LOG_LEVEL macros depending on
+ * the logging configuration for PKCS #11.
+ * 3. Include the header file "logging_stack.h", if logging is enabled for PKCS #11.
+ */
+
+#include "logging_levels.h"
+
+/* Logging configuration for the PKCS #11 library. */
+#ifndef LIBRARY_LOG_NAME
+    #define LIBRARY_LOG_NAME    "PKCS11"
+#endif
+
+#ifndef LIBRARY_LOG_LEVEL
+    #define LIBRARY_LOG_LEVEL    LOG_INFO
+#endif
+
+#include "logging_stack.h"
+
+/************ End of logging configuration ****************/
+
+#include <stdlib.h>
+
+/**
+ * @brief Malloc API used by core_pkcs11.h
+ */
+#define pkcs11configPKCS11_MALLOC                          malloc
+
+/**
+ * @brief Free API used by core_pkcs11.h
+ */
+#define pkcs11configPKCS11_FREE                            free
+
+/**
+ * @brief PKCS #11 default user PIN.
+ *
+ * The PKCS #11 standard specifies the presence of a user PIN. That feature is
+ * sensible for applications that have an interactive user interface and memory
+ * protections. However, since typical microcontroller applications lack one or
+ * both of those, the user PIN is assumed to be used herein for interoperability
+ * purposes only, and not as a security feature.
+ *
+ * Note: Do not cast this to a pointer! The library calls sizeof to get the length
+ * of this string.
+ */
+#define pkcs11configPKCS11_DEFAULT_USER_PIN                "0000"
+
+/**
+ * @brief Maximum length (in characters) for a PKCS #11 CKA_LABEL
+ * attribute.
+ */
+#define pkcs11configMAX_LABEL_LENGTH                       32UL
+
+/**
+ * @brief Maximum number of token objects that can be stored
+ * by the PKCS #11 module.
+ */
+#define pkcs11configMAX_NUM_OBJECTS                        6
+
+/**
+ * @brief Maximum number of sessions that can be stored
+ * by the PKCS #11 module.
+ */
+#define pkcs11configMAX_SESSIONS                           10
+
+/**
+ * @brief Set to 1 if a PAL destroy object is implemented.
+ *
+ * If set to 0, no PAL destroy object is implemented, and this functionality
+ * is implemented in the common PKCS #11 layer.
+ */
+#define pkcs11configPAL_DESTROY_SUPPORTED                  0
+
+/**
+ * @brief Set to 1 if OTA image verification via PKCS #11 module is supported.
+ *
+ * If set to 0, OTA code signing certificate is built in via
+ * aws_ota_codesigner_certificate.h.
+ */
+#define pkcs11configOTA_SUPPORTED                          0
+
+/**
+ * @brief Set to 1 if PAL supports storage for JITP certificate,
+ * code verify certificate, and trusted server root certificate.
+ *
+ * If set to 0, PAL does not support storage mechanism for these, and
+ * they are accessed via headers compiled into the code.
+ */
+#define pkcs11configJITP_CODEVERIFY_ROOT_CERT_SUPPORTED    0
+
+/**
+ * @brief The PKCS #11 label for device private key.
+ *
+ * Private key for connection to AWS IoT endpoint.  The corresponding
+ * public key should be registered with the AWS IoT endpoint.
+ */
+#define pkcs11configLABEL_DEVICE_PRIVATE_KEY_FOR_TLS       "Device Priv TLS Key"
+
+/**
+ * @brief The PKCS #11 label for device public key.
+ *
+ * The public key corresponding to pkcs11configLABEL_DEVICE_PRIVATE_KEY_FOR_TLS.
+ */
+#define pkcs11configLABEL_DEVICE_PUBLIC_KEY_FOR_TLS        "Device Pub TLS Key"
+
+/**
+ * @brief The PKCS #11 label for the device certificate.
+ *
+ * Device certificate corresponding to pkcs11configLABEL_DEVICE_PRIVATE_KEY_FOR_TLS.
+ */
+#define pkcs11configLABEL_DEVICE_CERTIFICATE_FOR_TLS       "Device Cert"
+
+/**
+ * @brief The PKCS #11 label for the object to be used for HMAC operations.
+ */
+#define pkcs11configLABEL_HMAC_KEY                         "HMAC Key"
+
+/**
+ * @brief The PKCS #11 label for the object to be used for CMAC operations.
+ */
+#define pkcs11configLABEL_CMAC_KEY                         "CMAC Key"
+
+/**
+ * @brief The PKCS #11 label for the object to be used for code verification.
+ *
+ * Used by over-the-air update code to verify an incoming signed image.
+ */
+#define pkcs11configLABEL_CODE_VERIFICATION_KEY            "Code Verify Key"
+
+/**
+ * @brief The PKCS #11 label for the claim certificate for Fleet Provisioning.
+ */
+#define pkcs11configLABEL_CLAIM_CERTIFICATE                "Claim Cert"
+
+/**
+ * @brief The PKCS #11 label for the claim private key for Fleet Provisioning.
+ */
+#define pkcs11configLABEL_CLAIM_PRIVATE_KEY                "Claim Key"
+
+/**
+ * @brief The PKCS #11 label for Just-In-Time-Provisioning.
+ *
+ * The certificate corresponding to the issuer of the device certificate
+ * (pkcs11configLABEL_DEVICE_CERTIFICATE_FOR_TLS) when using the JITR or
+ * JITP flow.
+ */
+#define pkcs11configLABEL_JITP_CERTIFICATE                 "JITP Cert"
+
+/**
+ * @brief The PKCS #11 label for the AWS Trusted Root Certificate.
+ *
+ * @see aws_default_root_certificates.h
+ */
+#define pkcs11configLABEL_ROOT_CERTIFICATE                 "Root Cert"
+
+#endif /* _CORE_PKCS11_CONFIG_H_ */

--- a/recipes-sdk/corepkcs11/files/corepkcs11_mbedtls_config.h
+++ b/recipes-sdk/corepkcs11/files/corepkcs11_mbedtls_config.h
@@ -1,0 +1,120 @@
+/*
+ * AWS IoT Device SDK for Embedded C 202412.00
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/* This file configures MbedTLS for the CSDK transport interface and demos. */
+
+#ifndef MBEDTLS_CONFIG_H_
+#define MBEDTLS_CONFIG_H_
+
+#include <stddef.h>
+
+/* Generate errors if deprecated functions are used. */
+#define MBEDTLS_DEPRECATED_REMOVED
+
+/* Place AES tables in ROM. */
+#define MBEDTLS_AES_ROM_TABLES
+
+/* Enable the following cipher modes. */
+#define MBEDTLS_CIPHER_MODE_CBC
+#define MBEDTLS_CIPHER_MODE_CFB
+#define MBEDTLS_CIPHER_MODE_CTR
+
+/* Enable the following cipher padding modes. */
+#define MBEDTLS_CIPHER_PADDING_PKCS7
+#define MBEDTLS_CIPHER_PADDING_ONE_AND_ZEROS
+#define MBEDTLS_CIPHER_PADDING_ZEROS_AND_LEN
+#define MBEDTLS_CIPHER_PADDING_ZEROS
+
+/* Cipher suite configuration. */
+#define MBEDTLS_REMOVE_ARC4_CIPHERSUITES
+#define MBEDTLS_ECP_DP_SECP256R1_ENABLED
+#define MBEDTLS_ECP_NIST_OPTIM
+#define MBEDTLS_KEY_EXCHANGE_ECDHE_RSA_ENABLED
+#define MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED
+
+/* Enable all SSL alert messages. */
+#define MBEDTLS_SSL_ALL_ALERT_MESSAGES
+
+/* Enable the following SSL features. */
+#define MBEDTLS_SSL_ENCRYPT_THEN_MAC
+#define MBEDTLS_SSL_EXTENDED_MASTER_SECRET
+#define MBEDTLS_SSL_MAX_FRAGMENT_LENGTH
+#define MBEDTLS_SSL_PROTO_TLS1_2
+#define MBEDTLS_SSL_ALPN
+#define MBEDTLS_SSL_SERVER_NAME_INDICATION
+
+/* Check certificate key usage. */
+#define MBEDTLS_X509_CHECK_KEY_USAGE
+#define MBEDTLS_X509_CHECK_EXTENDED_KEY_USAGE
+
+/* Enable PKCS11 features */
+#define MBEDTLS_PK_RSA_ALT_SUPPORT
+#define MBEDTLS_GENPRIME
+
+/* Enable the following MbedTLS features. */
+#define MBEDTLS_AES_C
+#define MBEDTLS_ASN1_PARSE_C
+#define MBEDTLS_ASN1_WRITE_C
+#define MBEDTLS_BASE64_C
+#define MBEDTLS_BIGNUM_C
+#define MBEDTLS_CIPHER_C
+#define MBEDTLS_CMAC_C
+#define MBEDTLS_CTR_DRBG_C
+#define MBEDTLS_DEBUG_C
+#define MBEDTLS_ECDH_C
+#define MBEDTLS_CAN_ECDH
+#define MBEDTLS_ECDSA_C
+#define MBEDTLS_PK_CAN_ECDSA_SIGN
+#define MBEDTLS_ECP_C
+#define MBEDTLS_ENTROPY_C
+#define MBEDTLS_ERROR_C
+#define MBEDTLS_GCM_C
+#define MBEDTLS_MD_C
+#define MBEDTLS_OID_C
+#define MBEDTLS_PEM_PARSE_C
+#define MBEDTLS_PEM_WRITE_C
+#define MBEDTLS_PK_C
+#define MBEDTLS_PK_PARSE_C
+#define MBEDTLS_PK_WRITE_C
+#define MBEDTLS_PKCS1_V15
+#define MBEDTLS_PLATFORM_C
+#define MBEDTLS_RSA_C
+#define MBEDTLS_SHA1_C
+#define MBEDTLS_SHA256_C
+#define MBEDTLS_SSL_CLI_C
+#define MBEDTLS_SSL_TLS_C
+#define MBEDTLS_THREADING_PTHREAD
+#define MBEDTLS_THREADING_C
+#define MBEDTLS_X509_USE_C
+#define MBEDTLS_X509_CREATE_C
+#define MBEDTLS_X509_CRT_PARSE_C
+#define MBEDTLS_X509_CSR_WRITE_C
+#define MBEDTLS_NET_C
+#define MBEDTLS_TIMING_C
+
+#define MBEDTLS_ENTROPY_PLATFORM
+#define MBEDTLS_FS_IO
+#define MBEDTLS_HAVE_TIME_DATE
+#define MBEDTLS_HAVE_TIME
+
+#include "mbedtls/check_config.h"
+#endif /* ifndef MBEDTLS_CONFIG_H_ */

--- a/recipes-sdk/corepkcs11/files/logging_levels.h
+++ b/recipes-sdk/corepkcs11/files/logging_levels.h
@@ -1,0 +1,105 @@
+/*
+ * AWS IoT Device SDK for Embedded C 202412.00
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * @file logging_levels.h
+ * @brief Defines the logging level macros.
+ */
+
+#ifndef LOGGING_LEVELS_H_
+#define LOGGING_LEVELS_H_
+
+/**
+ * @brief No log messages.
+ *
+ * When @ref LIBRARY_LOG_LEVEL is #LOG_NONE, logging is disabled and no
+ * logging messages are printed.
+ */
+#define LOG_NONE     0
+
+/**
+ * @brief Represents erroneous application state or event.
+ *
+ * These messages describe the situations when a library encounters an error from
+ * which it cannot recover.
+ *
+ * These messages are printed when @ref LIBRARY_LOG_LEVEL is defined as either
+ * of #LOG_ERROR, #LOG_WARN, #LOG_INFO or #LOG_DEBUG.
+ */
+#define LOG_ERROR    1
+
+/**
+ * @brief Message about an abnormal event.
+ *
+ * These messages describe the situations when a library encounters
+ * abnormal event that may be indicative of an error. Libraries continue
+ * execution after logging a warning.
+ *
+ * These messages are printed when @ref LIBRARY_LOG_LEVEL is defined as either
+ * of #LOG_WARN, #LOG_INFO or #LOG_DEBUG.
+ */
+#define LOG_WARN     2
+
+/**
+ * @brief A helpful, informational message.
+ *
+ * These messages describe normal execution of a library. They provide
+ * the progress of the program at a coarse-grained level.
+ *
+ * These messages are printed when @ref LIBRARY_LOG_LEVEL is defined as either
+ * of #LOG_INFO or #LOG_DEBUG.
+ */
+#define LOG_INFO     3
+
+/**
+ * @brief Detailed and excessive debug information.
+ *
+ * Debug log messages are used to provide the
+ * progress of the program at a fine-grained level. These are mostly used
+ * for debugging and may contain excessive information such as internal
+ * variables, buffers, or other specific information.
+ *
+ * These messages are only printed when @ref LIBRARY_LOG_LEVEL is defined as
+ * #LOG_DEBUG.
+ */
+#define LOG_DEBUG    4
+
+/* The macro definition for LIBRARY_LOG_LEVEL is for Doxygen
+ * documentation only. This macro is typically defined in only the
+ * <library>_config.h file or the demo_config.h file. */
+
+/**
+ * @brief The logging level verbosity configuration of log messages from library.
+ *
+ * The logging verbosity levels are one of #LOG_DEBUG, #LOG_INFO, #LOG_WARN,
+ * and #LOG_ERROR.
+ * - With level #LOG_NONE, logging will be disabled.
+ * - With level #LOG_DEBUG, all log messages will print.
+ * - With level #LOG_INFO, all log messages, except level #LOG_DEBUG, will print.
+ * - With level #LOG_WARN, only messages this level and #LOG_ERROR level will print.
+ * - With level #LOG_ERROR, only messages at this level will print.
+ */
+#ifdef DOXYGEN
+    #define LIBRARY_LOG_LEVEL    LOG_ERROR
+#endif
+
+#endif /* ifndef LOGGING_LEVELS_H_ */

--- a/recipes-sdk/corepkcs11/files/logging_stack.h
+++ b/recipes-sdk/corepkcs11/files/logging_stack.h
@@ -1,0 +1,182 @@
+/*
+ * AWS IoT Device SDK for Embedded C 202412.00
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * @file logging_stack.h
+ * @brief Reference implementation of Logging stack as a header-only library.
+ */
+
+#ifndef LOGGING_STACK_H_
+#define LOGGING_STACK_H_
+
+/* Include header for logging level macros. */
+#include "logging_levels.h"
+
+/* Standard Include. */
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+
+/* The macro definition for LIBRARY_LOG_NAME is for Doxygen
+ * documentation only. This macro is typically defined in only the
+ * <library>_config.h file or the demo_config.h file. */
+
+/**
+ * @brief The name of the library or demo to add as metadata in log messages
+ * from the library or demo.
+ *
+ * This metadata aids in identifying the module source of log messages.
+ * The metadata is logged in the format `[ <LIBRARY-NAME> ]` as a prefix to the
+ * log messages.
+ * Refer to #LOG_METADATA_FORMAT for the complete format of the metadata prefix in
+ * log messages.
+ */
+#ifdef DOXYGEN
+    #define LIBRARY_LOG_NAME    "<LIBRARY_NAME>"
+#endif
+
+/* Check if LIBRARY_LOG_NAME macro has been defined. */
+#if !defined( LIBRARY_LOG_NAME )
+    #error "Please define LIBRARY_LOG_NAME for the library."
+#endif
+
+/**
+ * @brief Macro to extract only the file name from file path to use for metadata in
+ * log messages.
+ */
+#define FILENAME               ( strrchr( __FILE__, '/' ) ? strrchr( __FILE__, '/' ) + 1 : __FILE__ )
+
+/* Metadata information to prepend to every log message. */
+#define LOG_METADATA_FORMAT    "[%s] [%s:%d] "                      /**< @brief Format of metadata prefix in log messages as `[<Logging-Level>] [<Library-Name>] [<File-Name>:<Line-Number>]` */
+#define LOG_METADATA_ARGS      LIBRARY_LOG_NAME, FILENAME, __LINE__ /**< @brief Arguments into the metadata logging prefix format. */
+
+#if !defined( DISABLE_LOGGING )
+
+/**
+ * @brief Common macro that maps all the logging interfaces,
+ * (#LogDebug, #LogInfo, #LogWarn, #LogError) to the platform-specific logging
+ * function.
+ *
+ * `printf` from the standard C library is the POSIX platform implementation used
+ * for logging functionality.
+ */
+    #define SdkLog( string )    printf string
+#else
+    #define SdkLog( string )
+#endif
+
+/**
+ * Disable definition of logging interface macros when generating doxygen output,
+ * to avoid conflict with documentation of macros at the end of the file.
+ * @cond DOXYGEN_IGNORE
+ */
+/* Check that LIBRARY_LOG_LEVEL is defined and has a valid value. */
+#if !defined( LIBRARY_LOG_LEVEL ) ||       \
+    ( ( LIBRARY_LOG_LEVEL != LOG_NONE ) && \
+    ( LIBRARY_LOG_LEVEL != LOG_ERROR ) &&  \
+    ( LIBRARY_LOG_LEVEL != LOG_WARN ) &&   \
+    ( LIBRARY_LOG_LEVEL != LOG_INFO ) &&   \
+    ( LIBRARY_LOG_LEVEL != LOG_DEBUG )     \
+    )
+    #error "Please define LIBRARY_LOG_LEVEL as either LOG_NONE, LOG_ERROR, LOG_WARN, LOG_INFO, or LOG_DEBUG."
+#else
+    #if LIBRARY_LOG_LEVEL == LOG_DEBUG
+        /* All log level messages will logged. */
+        #define LogError( message )    SdkLog( ( "[ERROR] " LOG_METADATA_FORMAT, LOG_METADATA_ARGS ) ); SdkLog( message ); SdkLog( ( "\r\n" ) )
+        #define LogWarn( message )     SdkLog( ( "[WARN] " LOG_METADATA_FORMAT, LOG_METADATA_ARGS ) ); SdkLog( message ); SdkLog( ( "\r\n" ) )
+        #define LogInfo( message )     SdkLog( ( "[INFO] " LOG_METADATA_FORMAT, LOG_METADATA_ARGS ) ); SdkLog( message ); SdkLog( ( "\r\n" ) )
+        #define LogDebug( message )    SdkLog( ( "[DEBUG] " LOG_METADATA_FORMAT, LOG_METADATA_ARGS ) ); SdkLog( message ); SdkLog( ( "\r\n" ) )
+
+    #elif LIBRARY_LOG_LEVEL == LOG_INFO
+        /* Only INFO, WARNING and ERROR messages will be logged. */
+        #define LogError( message )    SdkLog( ( "[ERROR] " LOG_METADATA_FORMAT, LOG_METADATA_ARGS ) ); SdkLog( message ); SdkLog( ( "\r\n" ) )
+        #define LogWarn( message )     SdkLog( ( "[WARN] " LOG_METADATA_FORMAT, LOG_METADATA_ARGS ) ); SdkLog( message ); SdkLog( ( "\r\n" ) )
+        #define LogInfo( message )     SdkLog( ( "[INFO] " LOG_METADATA_FORMAT, LOG_METADATA_ARGS ) ); SdkLog( message ); SdkLog( ( "\r\n" ) )
+        #define LogDebug( message )
+
+    #elif LIBRARY_LOG_LEVEL == LOG_WARN
+        /* Only WARNING and ERROR messages will be logged.*/
+        #define LogError( message )    SdkLog( ( "[ERROR] " LOG_METADATA_FORMAT, LOG_METADATA_ARGS ) ); SdkLog( message ); SdkLog( ( "\r\n" ) )
+        #define LogWarn( message )     SdkLog( ( "[WARN] " LOG_METADATA_FORMAT, LOG_METADATA_ARGS ) ); SdkLog( message ); SdkLog( ( "\r\n" ) )
+        #define LogInfo( message )
+        #define LogDebug( message )
+
+    #elif LIBRARY_LOG_LEVEL == LOG_ERROR
+        /* Only ERROR messages will be logged. */
+        #define LogError( message )    SdkLog( ( "[ERROR] " LOG_METADATA_FORMAT, LOG_METADATA_ARGS ) ); SdkLog( message ); SdkLog( ( "\r\n" ) )
+        #define LogWarn( message )
+        #define LogInfo( message )
+        #define LogDebug( message )
+
+    #else /* if LIBRARY_LOG_LEVEL == LOG_ERROR */
+
+        #define LogError( message )
+        #define LogWarn( message )
+        #define LogInfo( message )
+        #define LogDebug( message )
+
+    #endif /* if LIBRARY_LOG_LEVEL == LOG_ERROR */
+#endif /* if !defined( LIBRARY_LOG_LEVEL ) || ( ( LIBRARY_LOG_LEVEL != LOG_NONE ) && ( LIBRARY_LOG_LEVEL != LOG_ERROR ) && ( LIBRARY_LOG_LEVEL != LOG_WARN ) && ( LIBRARY_LOG_LEVEL != LOG_INFO ) && ( LIBRARY_LOG_LEVEL != LOG_DEBUG ) ) */
+/** @endcond */
+
+/* Doxygen documentation of logging interface macro definitions for Doxygen. */
+#ifdef DOXYGEN
+
+/**
+ * @brief Definition of logging interface macro that logs messages at the "Debug"
+ * level, when debug level logging is enabled.
+ *
+ * This macro is only enabled for #LOG_DEBUG level configuration in this
+ * logging stack implementation.
+ */
+    #define LogDebug( message )    SdkLog( ( "[DEBUG] " LOG_METADATA_FORMAT, LOG_METADATA_ARGS ) ); SdkLog( message ); SdkLog( ( "\r\n" ) )
+
+/**
+ * @brief Definition of logging interface macro that logs messages at the "Info"
+ * level, when info level logging is enabled.
+ *
+ * This macro is only enabled for #LOG_DEBUG and #LOG_INFO level configurations
+ * in this logging stack implementation.
+ */
+    #define LogInfo( message )     SdkLog( ( "[INFO] " LOG_METADATA_FORMAT, LOG_METADATA_ARGS ) ); SdkLog( message ); SdkLog( ( "\r\n" ) )
+
+/**
+ * @brief Definition of logging interface macro that logs messages at the "Warning"
+ * level, when warning level logging is enabled.
+ *
+ * This macro is only enabled for #LOG_DEBUG, #LOG_INFO and #LOG_WARN level
+ * configurations in this logging stack implementation.
+ */
+    #define LogWarn( message )     SdkLog( ( "[WARN] " LOG_METADATA_FORMAT, LOG_METADATA_ARGS ) ); SdkLog( message ); SdkLog( ( "\r\n" ) )
+
+/**
+ * @brief Definition of logging interface macro that logs messages at the "Error"
+ * level, when error level logging is enabled.
+ *
+ * This macro is only enabled for all logging level configurations
+ * unless except the #LOG_NONE configuration.
+ */
+    #define LogError( message )    SdkLog( ( "[ERROR] " LOG_METADATA_FORMAT, LOG_METADATA_ARGS ) ); SdkLog( message ); SdkLog( ( "\r\n" ) )
+
+#endif /* ifdef DOXYGEN */
+
+#endif /* ifndef LOGGING_STACK_H_ */

--- a/recipes-sdk/device-defender-for-aws-iot-embedded-sdk/device-defender-for-aws-iot-embedded-sdk_1.4.0.bb
+++ b/recipes-sdk/device-defender-for-aws-iot-embedded-sdk/device-defender-for-aws-iot-embedded-sdk_1.4.0.bb
@@ -1,0 +1,43 @@
+SUMMARY = "Client library for using AWS IoT Defender service"
+DESCRIPTION = "Client library for using AWS IoT Defender service on embedded devices."
+HOMEPAGE = "https://github.com/aws/Device-Defender-for-AWS-IoT-embedded-sdk"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=fbe4a2de4d0307d25b1d725d7d20d06c"
+
+SRC_URI = "\
+    gitsm://github.com/aws/Device-Defender-for-AWS-IoT-embedded-sdk.git;protocol=https;branch=main \
+    file://CMakeLists.txt \
+    file://Finddefender.cmake \
+"
+
+SRCREV = "33f9087d4b6db3c5c024c3254426bbba30a0f10a"
+
+S = "${WORKDIR}/git"
+
+inherit cmake
+
+EXTRA_OECMAKE:append = " \
+    -DCMAKE_C_FLAGS=-DDEFENDER_DO_NOT_USE_CUSTOM_CONFIG=ON \
+    -DLIB_VERSION=${PV} \
+    -DLIB_SOVERSION=${@d.getVar('PV').split('.')[0]} \
+"
+
+do_configure:prepend() {
+    install ${WORKDIR}/CMakeLists.txt ${S}/
+}
+
+do_install:append() {
+    install -d ${D}${datadir}/cmake/Modules
+    install -m 0644 ${WORKDIR}/Finddefender.cmake ${D}${datadir}/cmake/Modules/
+}
+
+FILES:${PN} += "${libdir}/libcore_http.so.*"
+
+FILES:${PN}-dev += "\
+    ${libdir}/libdefender.so \
+    ${includedir}/defender/* \
+    ${datadir}/cmake/Modules/Finddefender.cmake \
+"
+
+# nooelint: oelint.vars.insaneskip:INSANE_SKIP
+INSANE_SKIP:${PN} += "buildpaths"

--- a/recipes-sdk/device-defender-for-aws-iot-embedded-sdk/files/CMakeLists.txt
+++ b/recipes-sdk/device-defender-for-aws-iot-embedded-sdk/files/CMakeLists.txt
@@ -1,0 +1,34 @@
+set( LIB_NAME "defender" )
+
+cmake_minimum_required(VERSION 3.0)
+project(${LIB_NAME} VERSION 1.0.0 LANGUAGES C)
+
+include(${CMAKE_CURRENT_SOURCE_DIR}/${LIB_NAME}FilePaths.cmake)
+
+option(BUILD_SHARED_LIBS "Build shared libraries" ON)
+
+add_library(${LIB_NAME}
+    ${DEFENDER_SOURCES}
+)
+
+set_target_properties(${LIB_NAME} PROPERTIES
+    VERSION ${LIB_VERSION}
+    SOVERSION ${LIB_SOVERSION}
+)
+
+target_include_directories(${LIB_NAME}
+    PUBLIC
+        ${DEFENDER_INCLUDE_PUBLIC_DIRS}
+)
+
+include(GNUInstallDirs)
+
+install(TARGETS ${LIB_NAME}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${LIB_NAME}
+)
+
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/source/include/
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${LIB_NAME}
+    FILES_MATCHING PATTERN "*.h"
+)

--- a/recipes-sdk/device-defender-for-aws-iot-embedded-sdk/files/Finddefender.cmake
+++ b/recipes-sdk/device-defender-for-aws-iot-embedded-sdk/files/Finddefender.cmake
@@ -1,0 +1,20 @@
+find_path(DEFENDER_INCLUDE_PUBLIC_DIRS defender.h
+          PATHS ${CMAKE_INSTALL_PREFIX}/include
+          PATH_SUFFIXES defender)
+
+find_library(DEFENDER_LIBRARY
+             NAMES defender
+             PATHS ${CMAKE_INSTALL_PREFIX}/lib)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(defender DEFAULT_MSG
+                                  DEFENDER_LIBRARY DEFENDER_INCLUDE_PUBLIC_DIRS)
+
+mark_as_advanced(DEFENDER_INCLUDE_PUBLIC_DIRS DEFENDER_LIBRARY)
+
+if(json_FOUND AND NOT TARGET defender::defender)
+  add_library(defender::defender UNKNOWN IMPORTED)
+  set_target_properties(defender::defender PROPERTIES
+    IMPORTED_LOCATION "${DEFENDER_LIBRARY}"
+    INTERFACE_INCLUDE_DIRECTORIES "${DEFENDER_INCLUDE_PUBLIC_DIRS}")
+endif()

--- a/recipes-sdk/device-shadow-for-aws-iot-embedded-sdk/device-shadow-for-aws-iot-embedded-sdk_1.4.1.bb
+++ b/recipes-sdk/device-shadow-for-aws-iot-embedded-sdk/device-shadow-for-aws-iot-embedded-sdk_1.4.1.bb
@@ -1,0 +1,39 @@
+SUMMARY = "Client library for using AWS IoT Shadow service"
+DESCRIPTION = "Client library for using AWS IoT Shadow service on embedded devices"
+HOMEPAGE = "https://github.com/aws/device-shadow-for-aws-iot-embedded-sdk"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=c8c19afab7f99fb196c9287cbd60a258"
+
+SRC_URI = "\
+    gitsm://github.com/aws/Device-Shadow-for-AWS-IoT-embedded-sdk.git;protocol=https;branch=main \
+    file://CMakeLists.txt \
+    file://Findshadow.cmake \
+"
+
+SRCREV = "28ca8cb66b185c5ee9e2458d2ae0259ccac86a8d"
+
+S = "${WORKDIR}/git"
+
+inherit cmake
+
+EXTRA_OECMAKE:append = " -DCMAKE_C_FLAGS=-DSHADOW_DO_NOT_USE_CUSTOM_CONFIG=ON"
+
+do_configure:prepend() {
+    install ${WORKDIR}/CMakeLists.txt ${S}/
+}
+
+do_install:append() {
+    install -d ${D}${datadir}/cmake/Modules
+    install -m 0644 ${WORKDIR}/Findshadow.cmake ${D}${datadir}/cmake/Modules/
+}
+
+FILES:${PN} += "${libdir}/libcore_http.so.*"
+
+FILES:${PN}-dev += "\
+    ${libdir}/libshadow.so \
+    ${includedir}/shadow/* \
+    ${datadir}/cmake/Modules/Findshadow.cmake \
+    "
+
+# nooelint: oelint.vars.insaneskip:INSANE_SKIP
+INSANE_SKIP:${PN} += "buildpaths"

--- a/recipes-sdk/device-shadow-for-aws-iot-embedded-sdk/files/CMakeLists.txt
+++ b/recipes-sdk/device-shadow-for-aws-iot-embedded-sdk/files/CMakeLists.txt
@@ -1,0 +1,34 @@
+set( LIB_NAME "shadow" )
+
+cmake_minimum_required(VERSION 3.0)
+project(${LIB_NAME} VERSION 1.0.0 LANGUAGES C)
+
+include(${CMAKE_CURRENT_SOURCE_DIR}/shadowFilePaths.cmake)
+
+option(BUILD_SHARED_LIBS "Build shared libraries" ON)
+
+add_library(${LIB_NAME}
+    ${SHADOW_SOURCES}
+)
+
+set_target_properties(${LIB_NAME} PROPERTIES
+    VERSION ${LIB_VERSION}
+    SOVERSION ${LIB_SOVERSION}
+)
+
+target_include_directories(${LIB_NAME}
+    PUBLIC
+        ${SHADOW_INCLUDE_PUBLIC_DIRS}
+)
+
+include(GNUInstallDirs)
+
+install(TARGETS ${LIB_NAME}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${LIB_NAME}
+)
+
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/source/include/
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${LIB_NAME}
+    FILES_MATCHING PATTERN "*.h"
+)

--- a/recipes-sdk/device-shadow-for-aws-iot-embedded-sdk/files/Findshadow.cmake
+++ b/recipes-sdk/device-shadow-for-aws-iot-embedded-sdk/files/Findshadow.cmake
@@ -1,0 +1,20 @@
+find_path(SHADOW_INCLUDE_PUBLIC_DIRS shadow.h
+          PATHS ${CMAKE_INSTALL_PREFIX}/include
+          PATH_SUFFIXES shadow)
+
+find_library(SHADOW_LIBRARY
+             NAMES shadow
+             PATHS ${CMAKE_INSTALL_PREFIX}/lib)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(shadow DEFAULT_MSG
+                                  SHADOW_LIBRARY SHADOW_INCLUDE_PUBLIC_DIRS)
+
+mark_as_advanced(SHADOW_INCLUDE_PUBLIC_DIRS SHADOW_LIBRARY)
+
+if(shadow_FOUND AND NOT TARGET shadow::shadow)
+  add_library(shadow::shadow UNKNOWN IMPORTED)
+  set_target_properties(shadow::shadow PROPERTIES
+    IMPORTED_LOCATION "${SHADOW_LIBRARY}"
+    INTERFACE_INCLUDE_DIRECTORIES "${SHADOW_INCLUDE_PUBLIC_DIRS}")
+endif()

--- a/recipes-sdk/fleet-provisioning-for-aws-iot-embedded-sdk/files/CMakeLists.txt
+++ b/recipes-sdk/fleet-provisioning-for-aws-iot-embedded-sdk/files/CMakeLists.txt
@@ -1,0 +1,39 @@
+set( LIB_NAME "fleetprovisioning" )
+
+cmake_minimum_required(VERSION 3.0)
+project(${LIB_NAME} VERSION 1.0.0 LANGUAGES C)
+
+# Include the file containing source definitions
+include(${CMAKE_CURRENT_SOURCE_DIR}/fleetprovisioningFilePaths.cmake)
+
+# Option to build shared libraries
+option(BUILD_SHARED_LIBS "Build shared libraries" ON)
+
+add_library(${LIB_NAME}
+    ${FLEET_PROVISIONING_SOURCES}
+)
+
+set_target_properties(${LIB_NAME} PROPERTIES
+    VERSION ${LIB_VERSION}
+    SOVERSION ${LIB_SOVERSION}
+)
+
+target_include_directories(${LIB_NAME}
+    PUBLIC
+        ${FLEET_PROVISIONING_INCLUDE_PUBLIC_DIRS}
+)
+
+# Installation rules
+include(GNUInstallDirs)
+
+# Install the library and headers
+install(TARGETS ${LIB_NAME}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${LIB_NAME}
+)
+
+# Install header files
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/source/include/
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${LIB_NAME}
+    FILES_MATCHING PATTERN "*.h"
+)

--- a/recipes-sdk/fleet-provisioning-for-aws-iot-embedded-sdk/files/Findfleetprovisioning.cmake
+++ b/recipes-sdk/fleet-provisioning-for-aws-iot-embedded-sdk/files/Findfleetprovisioning.cmake
@@ -1,0 +1,20 @@
+find_path(FLEETPROVISIONING_INCLUDE_PUBLIC_DIRS fleet_provisioning.h
+          PATHS ${CMAKE_INSTALL_PREFIX}/include
+          PATH_SUFFIXES fleetprovisioning)
+
+find_library(FLEETPROVISIONING_LIBRARY
+             NAMES fleetprovisioning
+             PATHS ${CMAKE_INSTALL_PREFIX}/lib)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(fleetprovisioning DEFAULT_MSG
+                                  FLEETPROVISIONING_LIBRARY FLEETPROVISIONING_INCLUDE_PUBLIC_DIRS)
+
+mark_as_advanced(FLEETPROVISIONING_INCLUDE_PUBLIC_DIRS FLEETPROVISIONING_LIBRARY)
+
+if(fleetprovisioning_FOUND AND NOT TARGET fleetprovisioning::fleetprovisioning)
+  add_library(fleetprovisioning::fleetprovisioning UNKNOWN IMPORTED)
+  set_target_properties(fleetprovisioning::fleetprovisioning PROPERTIES
+    IMPORTED_LOCATION "${FLEETPROVISIONING_LIBRARY}"
+    INTERFACE_INCLUDE_DIRECTORIES "${FLEETPROVISIONING_INCLUDE_PUBLIC_DIRS}")
+endif()

--- a/recipes-sdk/fleet-provisioning-for-aws-iot-embedded-sdk/fleet-provisioning-for-aws-iot-embedded-sdk_1.2.1.bb
+++ b/recipes-sdk/fleet-provisioning-for-aws-iot-embedded-sdk/fleet-provisioning-for-aws-iot-embedded-sdk_1.2.1.bb
@@ -1,0 +1,43 @@
+SUMMARY = "Client library for using AWS IoT Fleet Provisioning service"
+DESCRIPTION = "Client library for using AWS IoT Fleet Provisioning service on embedded devices"
+HOMEPAGE = "https://github.com/aws/Fleet-Provisioning-for-AWS-IoT-embedded-sdk"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=fbe4a2de4d0307d25b1d725d7d20d06c"
+
+SRC_URI = "\
+    gitsm://github.com/aws/Fleet-Provisioning-for-AWS-IoT-embedded-sdk.git;protocol=https;branch=main \
+    file://CMakeLists.txt \
+    file://Findfleetprovisioning.cmake \
+"
+
+SRCREV = "203803d8b506b51dad37b326292f7d153e9f8c2c"
+
+S = "${WORKDIR}/git"
+
+inherit cmake
+
+EXTRA_OECMAKE:append = " \
+    -DCMAKE_C_FLAGS=-DFLEET_PROVISIONING_DO_NOT_USE_CUSTOM_CONFIG=ON \
+    -DLIB_VERSION=${PV} \
+    -DLIB_SOVERSION=${@d.getVar('PV').split('.')[0]} \
+"
+
+do_configure:prepend() {
+    install ${WORKDIR}/CMakeLists.txt ${S}/
+}
+
+do_install:append() {
+    install -d ${D}${datadir}/cmake/Modules
+    install -m 0644 ${WORKDIR}/Findfleetprovisioning.cmake ${D}${datadir}/cmake/Modules/
+}
+
+FILES:${PN} += "${libdir}/libcore_http.so.*"
+
+FILES:${PN}-dev += "\
+    ${libdir}/libfleetprovisioning.so \
+    ${includedir}/fleetprovisioning/* \
+    ${datadir}/cmake/Modules/Findfleetprovisioning.cmake \
+"
+
+# nooelint: oelint.vars.insaneskip:INSANE_SKIP
+INSANE_SKIP:${PN} += "buildpaths"

--- a/recipes-sdk/jobs-for-aws-iot-embedded-sdk/files/001-fix-json-include.patch
+++ b/recipes-sdk/jobs-for-aws-iot-embedded-sdk/files/001-fix-json-include.patch
@@ -1,0 +1,14 @@
+Upstream-Status: Inappropriate [oe-specific]
+
+Index: jobs-for-aws-iot-embedded-sdk-1.0+git/source/jobs.c
+===================================================================
+--- jobs-for-aws-iot-embedded-sdk-1.0+git.orig/source/jobs.c
++++ jobs-for-aws-iot-embedded-sdk-1.0+git/source/jobs.c
+@@ -34,7 +34,7 @@
+ /* Internal Includes */
+ #include "jobs.h"
+ /* External Dependencies */
+-#include "core_json.h"
++#include <core_json/core_json.h>
+
+ /** @cond DO_NOT_DOCUMENT */

--- a/recipes-sdk/jobs-for-aws-iot-embedded-sdk/files/CMakeLists.txt
+++ b/recipes-sdk/jobs-for-aws-iot-embedded-sdk/files/CMakeLists.txt
@@ -1,0 +1,35 @@
+set( LIB_NAME "libjobs" )
+cmake_minimum_required(VERSION 3.0)
+project(${LIB_NAME} VERSION 1.0.0 LANGUAGES C)
+
+find_package(core_json REQUIRED)
+
+include(${CMAKE_CURRENT_SOURCE_DIR}/jobsFilePaths.cmake)
+
+option(BUILD_SHARED_LIBS "Build shared libraries" ON)
+
+add_library(${LIB_NAME}
+    ${JOBS_SOURCES}
+)
+
+set_target_properties(${LIB_NAME} PROPERTIES
+    VERSION ${LIB_VERSION}
+    SOVERSION ${LIB_SOVERSION}
+)
+
+target_include_directories(${LIB_NAME}
+    PUBLIC
+        ${JOBS_INCLUDE_PUBLIC_DIRS}
+)
+
+include(GNUInstallDirs)
+
+install(TARGETS ${LIB_NAME}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${LIB_NAME}
+)
+
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/source/include/
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${LIB_NAME}
+    FILES_MATCHING PATTERN "*.h"
+)

--- a/recipes-sdk/jobs-for-aws-iot-embedded-sdk/files/Findjobs.cmake
+++ b/recipes-sdk/jobs-for-aws-iot-embedded-sdk/files/Findjobs.cmake
@@ -1,0 +1,20 @@
+find_path(JOBS_INCLUDE_DIR_jobs.h
+          PATHS ${CMAKE_INSTALL_PREFIX}/include
+          PATH_SUFFIXES libjobs)
+
+find_library(JOBS_LIBRARY
+             NAMES libjobs
+             PATHS ${CMAKE_INSTALL_PREFIX}/lib)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(libjobs DEFAULT_MSG
+                                  JOBS_LIBRARY JOBS_INCLUDE_DIR)
+
+mark_as_advanced(JOBS_INCLUDE_DIR JOBS_LIBRARY)
+
+if(jobs_FOUND AND NOT TARGET jobs::jobs)
+  add_library(jobs::jobs UNKNOWN IMPORTED)
+  set_target_properties(jobs::jobs PROPERTIES
+    IMPORTED_LOCATION "${JOBS_LIBRARY}"
+    INTERFACE_INCLUDE_DIRECTORIES "${JOBS_INCLUDE_DIR}")
+endif()

--- a/recipes-sdk/jobs-for-aws-iot-embedded-sdk/jobs-for-aws-iot-embedded-sdk_2.0.0.bb
+++ b/recipes-sdk/jobs-for-aws-iot-embedded-sdk/jobs-for-aws-iot-embedded-sdk_2.0.0.bb
@@ -1,0 +1,41 @@
+SUMMARY = "Client library for using AWS IoT Jobs service."
+DESCRIPTION = "Client library for using AWS IoT Jobs service on embedded devices."
+HOMEPAGE = "https://github.com/aws/Jobs-for-AWS-IoT-embedded-sdk"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=c8c19afab7f99fb196c9287cbd60a258"
+
+DEPENDS = "corejson"
+
+SRC_URI = "\
+    gitsm://github.com/aws/Jobs-for-AWS-IoT-embedded-sdk.git;protocol=https;branch=main \
+    file://CMakeLists.txt \
+    file://Findjobs.cmake \
+    file://001-fix-json-include.patch \
+"
+
+SRCREV = "d250e33446d39845470c8abd3212ac91d928a653"
+
+S = "${WORKDIR}/git"
+
+inherit cmake
+
+EXTRA_OECMAKE:append = " \
+    -DLIB_VERSION=${PV} \
+    -DLIB_SOVERSION=${@d.getVar('PV').split('.')[0]} \
+"
+
+do_configure:prepend() {
+    install ${WORKDIR}/CMakeLists.txt ${S}/
+}
+
+do_install:append() {
+    install -d ${D}${datadir}/cmake/Modules
+    install -m 0644 ${WORKDIR}/Findjobs.cmake ${D}${datadir}/cmake/Modules/
+}
+
+FILES:${PN} += "${libdir}/libjobs.so.*"
+FILES:${PN}-dev += "\
+    ${libdir}/libjobs.so \
+    ${includedir}/libjobs/* \
+    ${datadir}/cmake/Modules/Findjobs.cmake \
+"

--- a/recipes-sdk/sigv4/files/CMakeLists.txt
+++ b/recipes-sdk/sigv4/files/CMakeLists.txt
@@ -1,0 +1,42 @@
+set( LIB_NAME "sigv4" )
+
+cmake_minimum_required(VERSION 3.0)
+project(${LIB_NAME} VERSION 1.0.0 LANGUAGES C)
+
+# Include the file containing source definitions
+include(${CMAKE_CURRENT_SOURCE_DIR}/sigv4FilePaths.cmake)
+
+# Option to build shared libraries
+option(BUILD_SHARED_LIBS "Build shared libraries" ON)
+
+# Create sigv4 library
+add_library(${LIB_NAME}
+    ${SIGV4_SOURCES}
+)
+
+## Set library properties
+set_target_properties(${LIB_NAME} PROPERTIES
+    VERSION ${LIB_VERSION}
+    SOVERSION ${LIB_SOVERSION}
+)
+
+# Set include directories using the paths from sigv4FilePaths.cmake
+target_include_directories(${LIB_NAME}
+    PUBLIC
+        ${SIGV4_INCLUDE_PUBLIC_DIRS}
+)
+
+# Installation rules
+include(GNUInstallDirs)
+
+# Install the library and headers
+install(TARGETS ${LIB_NAME}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${LIB_NAME}
+)
+
+# Install header files
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/source/include/
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${LIB_NAME}
+    FILES_MATCHING PATTERN "*.h"
+)

--- a/recipes-sdk/sigv4/files/Findcore_sigv4.cmake
+++ b/recipes-sdk/sigv4/files/Findcore_sigv4.cmake
@@ -1,0 +1,21 @@
+# Findsigv4.cmake
+find_path(SIGV4_INCLUDE_PUBLIC_DIRS sigv4.h
+          PATHS ${CMAKE_INSTALL_PREFIX}/include
+          PATH_SUFFIXES sigv4)
+
+find_library(SIGV4_LIBRARY
+             NAMES sigv4
+             PATHS ${CMAKE_INSTALL_PREFIX}/lib)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(sigv4 DEFAULT_MSG
+                                  SIGV4_LIBRARY SIGV4_INCLUDE_PUBLIC_DIRS)
+
+mark_as_advanced(SIGV4_INCLUDE_PUBLIC_DIRS SIGV4_LIBRARY)
+
+if(sigv4_FOUND AND NOT TARGET sigv4::sigv4)
+  add_library(sigv4::sigv4 UNKNOWN IMPORTED)
+  set_target_properties(sigv4::sigv4 PROPERTIES
+    IMPORTED_LOCATION "${SIGV4_LIBRARY}"
+    INTERFACE_INCLUDE_DIRECTORIES "${SIGV4_INCLUDE_PUBLIC_DIRS}")
+endif()

--- a/recipes-sdk/sigv4/sigv4_1.3.0.bb
+++ b/recipes-sdk/sigv4/sigv4_1.3.0.bb
@@ -1,0 +1,41 @@
+SUMMARY = "AWS library to sign AWS HTTP requests"
+DESCRIPTION = "AWS library to sign AWS HTTP requests with Signature Version 4 Signing Process."
+HOMEPAGE = "https://github.com/aws/SigV4-for-AWS-IoT-embedded-sdk"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=000b2cc208c380dab61c7176d8ad5cfc"
+
+SRC_URI = "\
+    gitsm://github.com/aws/SigV4-for-AWS-IoT-embedded-sdk.git;protocol=https;branch=main \
+    file://CMakeLists.txt \
+    file://Findcore_sigv4.cmake \
+"
+SRCREV = "892bcbb2d4b95daf2b7306ba3210e74b25bfae16"
+
+S = "${WORKDIR}/git"
+
+inherit cmake
+
+EXTRA_OECMAKE:append = " \
+    -DCMAKE_C_FLAGS=-DSIGV4_DO_NOT_USE_CUSTOM_CONFIG=ON \
+    -DLIB_VERSION=${PV} \
+    -DLIB_SOVERSION=${@d.getVar('PV').split('.')[0]} \
+"
+
+do_configure:prepend() {
+    install ${WORKDIR}/CMakeLists.txt ${S}/
+}
+
+do_install:append() {
+    install -d ${D}${datadir}/cmake/Modules
+    install -m 0644 ${WORKDIR}/Findcore_sigv4.cmake ${D}${datadir}/cmake/Modules/
+}
+
+FILES:${PN} += "${libdir}/libcore_sigv4.so.*"
+FILES:${PN}-dev += "\
+    ${libdir}/libcore_sigv4.so \
+    ${includedir}/libcore_sigv4/* \
+    ${datadir}/cmake/Modules/Findcore_sigv4.cmake \
+"
+
+# nooelint: oelint.vars.insaneskip:INSANE_SKIP
+INSANE_SKIP:${PN} += "buildpaths"


### PR DESCRIPTION
Adding as a lib:
- backoffalgorithm
- corehttp
- corejson
- coremqtt
- corepkcs11
- device-defender-for-aws-iot-embedded-sdk
- device-shadow-for-aws-iot-embedded-sdk
- fleet-provisioning-for-aws-iot-embedded-sdk
- jobs-for-aws-iot-embedded-sdk
- sigv4

demos as separate recipes:
- aws-iot-device-sdk-embedded-c-fleet-provisioning-keys-cert
- aws-iot-device-sdk-embedded-c-http-demo-basic-tls
- aws-iot-device-sdk-embedded-c-jobs-demo-mosquitto
- aws-iot-device-sdk-embedded-c-mqtt-demo-plaintext

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
