### PR TITLE
linux-webrtc-reference-for-amazon-kinesis-video-streams: disable amaz…

### DIFF
--- a/recipes-sdk/linux-webrtc-reference-for-amazon-kinesis-video-streams/linux-webrtc-reference-for-amazon-kinesis-video-streams_git.bb
+++ b/recipes-sdk/linux-webrtc-reference-for-amazon-kinesis-video-streams/linux-webrtc-reference-for-amazon-kinesis-video-streams_git.bb
@@ -67,8 +67,10 @@ PACKAGECONFIG[gstreamer] = ",,\
 
 RDEPENDS:${PN} += "ca-certificates"
 
+# TODO: fix ptest
+# amazon-kvs-webrtc-sdk
+
 RDEPENDS:${PN}-ptest += "\
-    amazon-kvs-webrtc-sdk \
     coreutils \
     util-linux \
 "


### PR DESCRIPTION
…on-kvs-webrtc-sdk dependency

Cause this will make this build fail on arm32.
Ptest eeds proper implementation -> TODO

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
