### PR TITLE
linux-webrtc-reference-for-amazon-kinesis-video-streams: INSANE_SKIP …

### DIFF
--- a/recipes-sdk/linux-webrtc-reference-for-amazon-kinesis-video-streams/linux-webrtc-reference-for-amazon-kinesis-video-streams_git.bb
+++ b/recipes-sdk/linux-webrtc-reference-for-amazon-kinesis-video-streams/linux-webrtc-reference-for-amazon-kinesis-video-streams_git.bb
@@ -156,3 +156,7 @@ do_install_ptest:append() {
 # }
 
 OECMAKE_CXX_FLAGS += "${@bb.utils.contains('PACKAGECONFIG', 'sanitize', '-fsanitize=address,undefined -fno-omit-frame-pointer', '', d)}"
+
+# nooelint: oelint.vars.insaneskip:INSANE_SKIP
+INSANE_SKIP:${PN} += "buildpaths"
+INSANE_SKIP:${PN}-dbg += "buildpaths"


### PR DESCRIPTION
…buildpaths

Needs a proper fix, but as this is still not a production ready release ok for now.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
