### PR TITLE
aws-iot-device-sdk-cpp-v2-version.inc: explicitly set PV

### DIFF
--- a/recipes-sdk/aws-iot-device-sdk-cpp-v2/aws-iot-device-sdk-cpp-v2-version.inc
+++ b/recipes-sdk/aws-iot-device-sdk-cpp-v2/aws-iot-device-sdk-cpp-v2-version.inc
@@ -1,3 +1,4 @@
 BRANCH ?= "main"
 SRC_URI = "gitsm://github.com/aws/aws-iot-device-sdk-cpp-v2.git;protocol=https;branch=${BRANCH}"
 SRCREV = "0a3ddbc93410f3c2fe0af56dab07f38e982f5cba"
+PV = "1.35.1"


### PR DESCRIPTION
The version of recipe aws-iot-device-sdk-cpp-v2-samples-mqtt5-pubsub is `1.0' $ ls tmp/work/corei7-64-wrs-linux/aws-iot-device-sdk-cpp-v2-samples-mqtt5-pubsub/ 1.0

Because no PV in recipe, and use 1.0 as default

Due to recipe aws-iot-device-sdk-cpp-v2-samples-mqtt5-pubsub and aws-iot-device-sdk-cpp-v2-samples-fleet-provisoning use the same source of aws-iot-device-sdk-cpp-v2
...
aws-iot-device-sdk-cpp-v2-version.inc <-- aws-iot-device-sdk-cpp-v2-samples.inc <-- aws-iot-device-sdk-cpp-v2-samples-mqtt5-pubsub.bb aws-iot-device-sdk-cpp-v2-version.inc <-- aws-iot-device-sdk-cpp-v2-samples.inc <-- aws-iot-device-sdk-cpp-v2-samples-fleet-provisoning.bb ...

Explicitly set PV in aws-iot-device-sdk-cpp-v2-version.inc

After apply this patch:
$ ls tmp/work/corei7-64-wrs-linux/aws-iot-device-sdk-cpp-v2-samples-mqtt5-pubsub/ 1.35.1

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
