### PR TITLE
aws-iot-device-sdk-embedded-c-http-demo-s3-download: disable mbedtls …

### DIFF
--- a/recipes-sdk/aws-iot-device-sdk-embedded-c/aws-iot-device-sdk-embedded-c-http-demo-s3-download/002-mbedtls-compat.patch
+++ b/recipes-sdk/aws-iot-device-sdk-embedded-c/aws-iot-device-sdk-embedded-c-http-demo-s3-download/002-mbedtls-compat.patch
@@ -1,0 +1,12 @@
+Index: git/demos/http/common/src/http_demo_s3_utils.c
+===================================================================
+--- git.orig/demos/http/common/src/http_demo_s3_utils.c
++++ git/demos/http/common/src/http_demo_s3_utils.c
+@@ -36,7 +36,6 @@
+ 
+ /* MBEDTLS API header. */
+ #include "mbedtls/sha256.h"
+-#include "mbedtls/compat-2.x.h"
+ 
+ /* OpenSSL transport header. */
+ #include "openssl_posix.h"

--- a/recipes-sdk/aws-iot-device-sdk-embedded-c/aws-iot-device-sdk-embedded-c-http-demo-s3-download_202412.00.bb
+++ b/recipes-sdk/aws-iot-device-sdk-embedded-c/aws-iot-device-sdk-embedded-c-http-demo-s3-download_202412.00.bb
@@ -18,6 +18,7 @@ SRC_URI = "\
     file://CMakeLists.txt \
     file://run-ptest \
     file://001-fix-includes.patch \
+    file://002-mbedtls-compat.patch \
     "
 
 SRCREV = "da99638ec373c791a45557b0cd91fc20968d492d"


### PR DESCRIPTION
…compat patch

Not necessary on old version of mbedtls.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
