### PR TITLE
aws-iot-device-client: BUILD_SDK=ON static by default

### DIFF
--- a/recipes-iot/aws-iot-device-client/aws-iot-device-client_1.10.1.bb
+++ b/recipes-iot/aws-iot-device-client/aws-iot-device-client_1.10.1.bb
@@ -5,7 +5,7 @@ LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=3eb31626add6ada64ff9ac772bd3c653"
 
 DEPENDS = "\
-    aws-iot-device-sdk-cpp-v2 \
+    ${@bb.utils.contains('PACKAGECONFIG', 'no-buildin-sdk', 'aws-iot-device-sdk-cpp-v2', '', d)} \
     openssl \
     "
 
@@ -21,11 +21,24 @@ BRANCH ?= "main"
 # nooelint: oelint.file.patchsignedoff:Patch
 SRC_URI = "\
     git://github.com/awslabs/aws-iot-device-client.git;protocol=https;branch=${BRANCH} \
+    ${@bb.utils.contains('PACKAGECONFIG', 'no-buildin-sdk', '', 'gitsm://github.com/aws/aws-iot-device-sdk-cpp-v2.git;protocol=https;branch=main;name=aws-iot-device-sdk-cpp-v2;destsuffix=aws-iot-device-sdk-cpp-v2-src', d)} \
+    ${@bb.utils.contains('PACKAGECONFIG', 'no-buildin-sdk', '', 'git://github.com/google/googletest.git;protocol=https;branch=main;name=googletest;destsuffix=googletest-src', d)} \
     file://run-ptest \
     file://001-disable-tests.patch \
+    file://002-set-cmake-min-version-for-external-project-sdk-and-src-path.patch \
     "
 
 SRCREV = "7f9547bca3e1a199f2824f4376e1782b082b226f"
+
+# must match CMakeLists.txt.awssdk (check is done through failing patch)
+# nooelint: oelint.vars.specific
+SRCREV_aws-iot-device-sdk-cpp-v2 = "74c8b683ebe5b1cbf484f6acaa281f56aaa63948"
+
+# must match CMakeLists.txt.googletest (check is done through failing patch)
+# nooelint: oelint.vars.specific
+SRCREV_googletest = "15460959cbbfa20e66ef0b5ab497367e47fc0a04"
+
+SRCREV_FORMAT .= "_aws-iot-device-sdk-cpp-v2_googletest"
 
 inherit cmake systemd ptest
 
@@ -42,19 +55,25 @@ do_install() {
 }
 
 EXTRA_OECMAKE += "\
-    -DBUILD_SDK=OFF \
     -DBUILD_TEST_DEPS=ON \
     -DCMAKE_BUILD_TYPE=RelWithDebInfo \
     -DCMAKE_VERBOSE_MAKEFILE=ON \
     -DCMAKE_CXX_FLAGS_RELEASE=-s \
+    -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
 "
 
 CXXFLAGS += "-Wno-ignored-attributes"
 
-PACKAGECONFIG ??= " dsn dsc ds st fp dd pubsub samples jobs"
+PACKAGECONFIG ??= "dsn dsc ds st fp dd pubsub samples jobs"
 
-# enable PACKAGECONFIG = "static" to build static instead of shared
-PACKAGECONFIG[static] = "-DBUILD_SHARED_LIBS=OFF,-DBUILD_SHARED_LIBS=ON,,"
+# enable PACKAGECONFIG = "no-static" to build shared instead of static, this is the default as -DBUILD_SDK=ON is default,
+# otherwise installing shared libs from this seems wrong. As other programs use different versions of the sdk maybe.
+PACKAGECONFIG[no-static] = "-DBUILD_SHARED_LIBS=ON,-DBUILD_SHARED_LIBS=OFF,,"
+
+# no-buildin-sdk - seems that secure tunneling is broken with newer versions of aws-iot-device-sdk-cpp-v2
+# (https://github.com/aws4embeddedlinux/meta-aws/issues/13012)
+# thus not using separate sdk should be the default
+PACKAGECONFIG[no-buildin-sdk] = "-DBUILD_SDK=OFF,-DBUILD_SDK=ON,,"
 
 PACKAGECONFIG[samples] = "-DEXCLUDE_SAMPLES=OFF,-DEXCLUDE_SAMPLES=ON,,"
 PACKAGECONFIG[pubsub] = "-DEXCLUDE_PUBSUB=OFF,-DEXCLUDE_PUBSUB=ON,,"
@@ -77,3 +96,9 @@ RDEPENDS:${PN} = "\
 
 SYSTEMD_AUTO_ENABLE = "enable"
 SYSTEMD_SERVICE:${PN} = "aws-iot-device-client.service"
+
+# nooelint: oelint.vars.insaneskip:INSANE_SKIP
+INSANE_SKIP:${PN} += "buildpaths"
+
+# nooelint: oelint.vars.insaneskip:INSANE_SKIP
+INSANE_SKIP:${PN}-dbg += "buildpaths"

--- a/recipes-iot/aws-iot-device-client/files/002-set-cmake-min-version-for-external-project-sdk-and-src-path.patch
+++ b/recipes-iot/aws-iot-device-client/files/002-set-cmake-min-version-for-external-project-sdk-and-src-path.patch
@@ -1,0 +1,71 @@
+Upstream-Status: Inappropriate [oe-specific]
+
+Index: aws-iot-device-client-1.10.1/CMakeLists.txt.awssdk
+===================================================================
+--- aws-iot-device-client-1.10.1.orig/CMakeLists.txt.awssdk
++++ aws-iot-device-client-1.10.1/CMakeLists.txt.awssdk
+@@ -4,12 +4,7 @@ project(aws-iot-device-sdk-cpp-v2-downlo
+
+ include(ExternalProject)
+ ExternalProject_Add(aws-iot-device-sdk-cpp-v2
+-        GIT_REPOSITORY          https://github.com/aws/aws-iot-device-sdk-cpp-v2.git
+-        GIT_TAG                 74c8b683ebe5b1cbf484f6acaa281f56aaa63948
+-        SOURCE_DIR              "${CMAKE_BINARY_DIR}/aws-iot-device-sdk-cpp-v2-src"
++        SOURCE_DIR              "${CMAKE_SOURCE_DIR}/../aws-iot-device-sdk-cpp-v2-src"
+         BINARY_DIR              "${CMAKE_BINARY_DIR}/aws-iot-device-sdk-cpp-v2-build"
+-        CONFIGURE_COMMAND       ""
+-        BUILD_COMMAND           ""
+-        INSTALL_COMMAND         ""
+-        TEST_COMMAND            ""
++        CMAKE_ARGS             -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+         )
+Index: aws-iot-device-client-1.10.1/CMakeLists.txt.gtest
+===================================================================
+--- aws-iot-device-client-1.10.1.orig/CMakeLists.txt.gtest
++++ aws-iot-device-client-1.10.1/CMakeLists.txt.gtest
+@@ -4,12 +4,10 @@ project(googletest-download NONE)
+
+ include(ExternalProject)
+ ExternalProject_Add(googletest
+-        GIT_REPOSITORY    https://github.com/google/googletest.git
+-        GIT_TAG           release-1.12.0
+-        SOURCE_DIR        "${CMAKE_BINARY_DIR}/googletest-src"
++        SOURCE_DIR        "${CMAKE_SOURCE_DIR}/../googletest-src"
+         BINARY_DIR        "${CMAKE_BINARY_DIR}/googletest-build"
+         CONFIGURE_COMMAND ""
+         BUILD_COMMAND     ""
+         INSTALL_COMMAND   ""
+         TEST_COMMAND      ""
+-        )
+\ No newline at end of file
++        )
+Index: aws-iot-device-client-1.10.1/CMakeLists.txt
+===================================================================
+--- aws-iot-device-client-1.10.1.orig/CMakeLists.txt
++++ aws-iot-device-client-1.10.1/CMakeLists.txt
+@@ -176,7 +176,7 @@ if (BUILD_SDK)
+             WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/aws-iot-device-sdk-cpp-v2-download)
+
+     # Add aws-iot-device-sdk-cpp-v2 directly to the build
+-    add_subdirectory(${CMAKE_BINARY_DIR}/aws-iot-device-sdk-cpp-v2-src
++    add_subdirectory(${CMAKE_SOURCE_DIR}/../aws-iot-device-sdk-cpp-v2-src
+             ${CMAKE_BINARY_DIR}/aws-iot-device-sdk-cpp-v2-build)
+ else ()
+     include_directories(/include)
+@@ -249,7 +249,7 @@ endif ()
+ if (BUILD_TEST_DEPS)
+     # Download and unpack googletest at configure time
+     configure_file(CMakeLists.txt.gtest
+-            ${CMAKE_BINARY_DIR}/googletest-download/CMakeLists.txt)
++	    ${CMAKE_SOURCE_DIR}/../googletest-download/CMakeLists.txt)
+     execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
+             WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/googletest-download)
+     execute_process(COMMAND ${CMAKE_COMMAND} --build .
+@@ -262,7 +262,7 @@ if (BUILD_TEST_DEPS)
+     # Add googletest directly to our build. This adds
+     # the following targets: gtest, gtest_main, gmock
+     # and gmock_main
+-    add_subdirectory(${CMAKE_BINARY_DIR}/googletest-src
++    add_subdirectory(${CMAKE_SOURCE_DIR}/../googletest-src
+             ${CMAKE_BINARY_DIR}/googletest-build)
+ endif ()


### PR DESCRIPTION
BUILD_SDK=ON as default
aws-iot-device-sdk-cpp-v2 needs to be 1.30.3 otherwise: "While other versions of the aws-iot-device-sdk-cpp-v2 may work,
 it is highly recommended that the specified commit is used."

and static because installing shared libs from this seems wrong.

closes #13012

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
