### PR TITLE
aws-crt-cpp: workaround compile failure for qemuriscv64

### DIFF
--- a/recipes-sdk/aws-crt-cpp/aws-crt-cpp_0.32.5.bb
+++ b/recipes-sdk/aws-crt-cpp/aws-crt-cpp_0.32.5.bb
@@ -51,6 +51,10 @@ PACKAGECONFIG ??= "\
     ${@bb.utils.contains('PTEST_ENABLED', '1', 'with-tests', '', d)} \
     "
 
+PACKAGECONFIG:append:riscv64 = " \
+    static \
+"
+
 PACKAGECONFIG:append:x86-64 = " ${@bb.utils.contains('PTEST_ENABLED', '1', 'sanitize', '', d)}"
 
 EXTRA_OECMAKE += "${@bb.utils.contains('PACKAGECONFIG', 'sanitize', '-DCMAKE_BUILD_TYPE=Debug', '-DCMAKE_BUILD_TYPE=Release', d)}"


### PR DESCRIPTION
Build aws-crt-cpp failed for qemuriscv64
$ echo 'MACHINE = "qemuriscv64-64"' >> conf/local.conf $ bitbake aws-crt-cpp
...
|/usr/src/debug/openssl/3.4.1/crypto/aes/aes-riscv64.s:972:(.text+0x946): relocation truncated to fit: R_RISCV_JAL against symbol `AES_set_encrypt_key' defined in .text section in tmp/work/riscv64-wrs-linux/aws-crt-cpp/0.32.5/recipe-sysroot/usr/lib/libcrypto.a(libcrypto-lib-aes-riscv64.o) ...

Explicitly add static to PACKAGECONFIG for riscv64

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
