### PR TITLE
fix arm32 builds for embedded-c libs, append instead of replace CFLAGS

### DIFF
--- a/recipes-sdk/corehttp/corehttp_3.1.1.bb
+++ b/recipes-sdk/corehttp/corehttp_3.1.1.bb
@@ -19,10 +19,11 @@ inherit cmake ptest
 EXTRA_OECMAKE += "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
 
 EXTRA_OECMAKE:append = " \
-    -DCMAKE_C_FLAGS=-DHTTP_DO_NOT_USE_CUSTOM_CONFIG=ON \
     -DLIB_VERSION=${PV} \
     -DLIB_SOVERSION=${@d.getVar('PV').split('.')[0]} \
 "
+
+OECMAKE_C_FLAGS:append = " -DHTTP_DO_NOT_USE_CUSTOM_CONFIG=ON"
 
 do_configure:prepend() {
     cp ${UNPACKDIR}/CMakeLists.txt ${S}/

--- a/recipes-sdk/coremqtt/coremqtt_2.3.1.bb
+++ b/recipes-sdk/coremqtt/coremqtt_2.3.1.bb
@@ -17,10 +17,11 @@ inherit cmake ptest
 EXTRA_OECMAKE += "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
 
 EXTRA_OECMAKE:append = " \
-    -DCMAKE_C_FLAGS=-DMQTT_DO_NOT_USE_CUSTOM_CONFIG=ON \
     -DLIB_VERSION=${PV} \
     -DLIB_SOVERSION=${@d.getVar('PV').split('.')[0]} \
 "
+
+OECMAKE_C_FLAGS:append = " -DMQTT_DO_NOT_USE_CUSTOM_CONFIG=ON"
 
 do_configure:prepend() {
     cp ${UNPACKDIR}/CMakeLists.txt ${S}/

--- a/recipes-sdk/corepkcs11/corepkcs11_3.6.3.bb
+++ b/recipes-sdk/corepkcs11/corepkcs11_3.6.3.bb
@@ -29,10 +29,11 @@ SRCREV_FORMAT .= "_corepkscs11_mbedtls"
 
 EXTRA_OECMAKE:append = " \
     -DFETCHCONTENT_SOURCE_DIR_MBEDTLS=${S}/source/dependency/3rdparty/mbedtls \
-    -DCMAKE_C_FLAGS=-DPKCS_DO_NOT_USE_CUSTOM_CONFIG=ON \
     -DLIB_VERSION=${PV} \
     -DLIB_SOVERSION=${@d.getVar('PV').split('.')[0]} \
 "
+
+OECMAKE_C_FLAGS:append = " -DPKCS_DO_NOT_USE_CUSTOM_CONFIG=ON"
 
 LDFLAGS += "-Wl,--copy-dt-needed-entries"
 

--- a/recipes-sdk/device-defender-for-aws-iot-embedded-sdk/device-defender-for-aws-iot-embedded-sdk_1.4.0.bb
+++ b/recipes-sdk/device-defender-for-aws-iot-embedded-sdk/device-defender-for-aws-iot-embedded-sdk_1.4.0.bb
@@ -18,10 +18,11 @@ inherit cmake ptest
 EXTRA_OECMAKE += "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
 
 EXTRA_OECMAKE:append = " \
-    -DCMAKE_C_FLAGS=-DDEFENDER_DO_NOT_USE_CUSTOM_CONFIG=ON \
     -DLIB_VERSION=${PV} \
     -DLIB_SOVERSION=${@d.getVar('PV').split('.')[0]} \
 "
+
+OECMAKE_C_FLAGS:append = " -DDEFENDER_DO_NOT_USE_CUSTOM_CONFIG=ON"
 
 do_configure:prepend() {
     install ${UNPACKDIR}/CMakeLists.txt ${S}/

--- a/recipes-sdk/device-shadow-for-aws-iot-embedded-sdk/device-shadow-for-aws-iot-embedded-sdk_1.4.1.bb
+++ b/recipes-sdk/device-shadow-for-aws-iot-embedded-sdk/device-shadow-for-aws-iot-embedded-sdk_1.4.1.bb
@@ -17,7 +17,7 @@ inherit cmake ptest
 
 EXTRA_OECMAKE += "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
 
-EXTRA_OECMAKE:append = " -DCMAKE_C_FLAGS=-DSHADOW_DO_NOT_USE_CUSTOM_CONFIG=ON"
+OECMAKE_C_FLAGS:append = " -DSHADOW_DO_NOT_USE_CUSTOM_CONFIG=ON"
 
 do_configure:prepend() {
     install ${UNPACKDIR}/CMakeLists.txt ${S}/

--- a/recipes-sdk/fleet-provisioning-for-aws-iot-embedded-sdk/fleet-provisioning-for-aws-iot-embedded-sdk_1.2.1.bb
+++ b/recipes-sdk/fleet-provisioning-for-aws-iot-embedded-sdk/fleet-provisioning-for-aws-iot-embedded-sdk_1.2.1.bb
@@ -18,10 +18,11 @@ inherit cmake ptest
 EXTRA_OECMAKE += "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
 
 EXTRA_OECMAKE:append = " \
-    -DCMAKE_C_FLAGS=-DFLEET_PROVISIONING_DO_NOT_USE_CUSTOM_CONFIG=ON \
     -DLIB_VERSION=${PV} \
     -DLIB_SOVERSION=${@d.getVar('PV').split('.')[0]} \
 "
+
+OECMAKE_C_FLAGS:append = " -DFLEET_PROVISIONING_DO_NOT_USE_CUSTOM_CONFIG=ON"
 
 do_configure:prepend() {
     install ${UNPACKDIR}/CMakeLists.txt ${S}/

--- a/recipes-sdk/linux-webrtc-reference-for-amazon-kinesis-video-streams/linux-webrtc-reference-for-amazon-kinesis-video-streams_git.bb
+++ b/recipes-sdk/linux-webrtc-reference-for-amazon-kinesis-video-streams/linux-webrtc-reference-for-amazon-kinesis-video-streams_git.bb
@@ -12,7 +12,7 @@ DEPENDS += "\
 EXTRA_OECMAKE:append = " -DCMAKE_BUILD_TYPE=RelWithDebInfo"
 
 # set log level
-EXTRA_OECMAKE:append = " -DCMAKE_C_FLAGS=-DLIBRARY_LOG_LEVEL=LOG_INFO"
+OECMAKE_C_FLAGS:append = " -DLIBRARY_LOG_LEVEL=LOG_INFO"
 
 ###
 # Use this for development to specify a local folder as source dir (cloned repo)

--- a/recipes-sdk/sigv4/sigv4_1.3.0.bb
+++ b/recipes-sdk/sigv4/sigv4_1.3.0.bb
@@ -17,10 +17,11 @@ inherit cmake ptest
 EXTRA_OECMAKE += "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
 
 EXTRA_OECMAKE:append = " \
-    -DCMAKE_C_FLAGS=-DSIGV4_DO_NOT_USE_CUSTOM_CONFIG=ON \
     -DLIB_VERSION=${PV} \
     -DLIB_SOVERSION=${@d.getVar('PV').split('.')[0]} \
 "
+
+OECMAKE_C_FLAGS:append = " -DSIGV4_DO_NOT_USE_CUSTOM_CONFIG=ON"
 
 do_configure:prepend() {
     install ${UNPACKDIR}/CMakeLists.txt ${S}/


### PR DESCRIPTION
corehttp
coremqtt
corepkcs11
device-defender-for-aws-iot-embedded-sdk
device-shadow-for-aws-iot-embedded-sdk
fleet-provisioning-for-aws-iot-embedded-sdk
linux-webrtc-reference-for-amazon-kinesis-video-streams sigv4

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
