### PR TITLE
firecracker-bin, jailer-bin: remove virtual/cross-binutils dep

### DIFF
--- a/recipes-containers/firecracker-bin/firecracker-bin_1.10.1.bb
+++ b/recipes-containers/firecracker-bin/firecracker-bin_1.10.1.bb
@@ -44,6 +44,3 @@ do_install() {
 
     install -m 0755 ${S}/firecracker-v${PV}-${TARGET_ARCH} ${D}${bindir}/firecracker
 }
-
-# https://bugzilla.yoctoproject.org/show_bug.cgi?id=15227
-PACKAGE_DEPENDS:append:class-target = " virtual/cross-binutils"

--- a/recipes-containers/firecracker-bin/jailer-bin_1.10.1.bb
+++ b/recipes-containers/firecracker-bin/jailer-bin_1.10.1.bb
@@ -47,6 +47,3 @@ do_install() {
 
     install -m 0755 ${S}/jailer-v${PV}-${TARGET_ARCH} ${D}${bindir}/jailer
 }
-
-# https://bugzilla.yoctoproject.org/show_bug.cgi?id=15227
-PACKAGE_DEPENDS:append:class-target = " virtual/cross-binutils"


### PR DESCRIPTION
As this is not necessary on kirkstone

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
