### PR TITLE
greengrass*.bbclass: add python3-pyyaml-native depends

### DIFF
--- a/classes/greengrass-component.bbclass
+++ b/classes/greengrass-component.bbclass
@@ -35,6 +35,8 @@
 
 require greengrass-common.inc
 
+DEPENDS:prepend = "python3-pyyaml-native "
+
 # Extract component information from YAML file, allow recipe override
 python __anonymous() {
     import yaml

--- a/classes/greengrass-lite-component.bbclass
+++ b/classes/greengrass-lite-component.bbclass
@@ -3,6 +3,8 @@
 # This class handles local component deployment for AWS IoT Greengrass Lite
 # Supports both zero-copy (direct placement) and traditional (copy-based) deployment
 
+DEPENDS:prepend = "python3-pyyaml-native "
+
 # Configuration: Zero-copy deployment (default: enabled)
 # Set GREENGRASS_LITE_ZERO_COPY = "0" to use traditional copy-based deployment
 GREENGRASS_LITE_ZERO_COPY ??= "1"


### PR DESCRIPTION
Seems that this is missing on autobuilder.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
