### PR TITLE
aws-crt-python: update ptest shebang to use python3

### DIFF
--- a/recipes-sdk/aws-crt-python/aws-crt-python_0.27.6.bb
+++ b/recipes-sdk/aws-crt-python/aws-crt-python_0.27.6.bb
@@ -106,6 +106,7 @@ RDEPENDS:${PN} += "\
 do_install_ptest() {
     install -d ${D}${PTEST_PATH}/tests
     cp -rf ${S}/test ${D}${PTEST_PATH}/tests/
+    find ${D}${PTEST_PATH}/tests -type f -exec sed -i '1s|^#! */usr/bin/python$|#!/usr/bin/python3|' {} +
 }
 
 BBCLASSEXTEND = "native nativesdk"


### PR DESCRIPTION
Some test scripts in ptest still use `#!/usr/bin/python`, which may not be available on modern systems where only `python3` is installed. This change updates the shebang line in all ptest test scripts to use `#!/usr/bin/python3` to ensure compatibility.

Affected files include (but are not limited to):
  - aws-lc/util/generate-asm-lcov.py
  - s2n/tests/sidetrail/bin/bpl_trace_to_c.py

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
