### PR TITLE
aws-crt-python: upgrade 0.27.4 -> 0.27.6

### DIFF
--- a/recipes-sdk/aws-crt-python/aws-crt-python_0.27.6.bb
+++ b/recipes-sdk/aws-crt-python/aws-crt-python_0.27.6.bb
@@ -34,10 +34,11 @@ SRC_URI = "\
      'gitsm://github.com/awslabs/aws-crt-python.git;protocol=https;branch=main', \
     d)} \
     file://001-fix-cross-compilation-support.patch \
+    file://002-revert-bdist-wheel.patch \
     file://run-ptest \
     "
 
-SRCREV = "5cf5e7d70f5ecd3a88fae15fa3f427b82f30fbae"
+SRCREV = "4250709624119de1af3ca86816e1a154fcac7cc8"
 UPSTREAM_CHECK_GITTAGREGEX = "v(?P<pver>.*)"
 
 S = "${WORKDIR}/git"

--- a/recipes-sdk/aws-crt-python/files/001-fix-cross-compilation-support.patch
+++ b/recipes-sdk/aws-crt-python/files/001-fix-cross-compilation-support.patch
@@ -1,4 +1,4 @@
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From 953be9b5f00875d786e8da53194ecc7878d3f5ca Mon Sep 17 00:00:00 2001
 From: AWS Meta Layer <meta-aws@amazon.com>
 Date: Thu, 24 Jul 2025 12:00:00 +0000
 Subject: [PATCH] Fix cross-compilation support
@@ -10,13 +10,18 @@ compatibility flags to suppress deprecated warnings.
 Upstream-Status: Inappropriate [oe-specific]
 
 Signed-off-by: AWS Meta Layer <meta-aws@amazon.com>
+---
+ setup.py | 12 ++++++++++++
+ 1 file changed, 12 insertions(+)
 
+diff --git a/setup.py b/setup.py
+index 61d91d9..dacd84b 100644
 --- a/setup.py
 +++ b/setup.py
 @@ -283,12 +283,24 @@ class awscrt_build_ext(setuptools.command.build_ext.build_ext):
              f'-DCMAKE_BUILD_TYPE={build_type}',
          ])
-
+ 
 +        # Handle cross-compilation
 +        if os.environ.get('CMAKE_TOOLCHAIN_FILE'):
 +            cmake_args.append('-DCMAKE_TOOLCHAIN_FILE=' + os.environ['CMAKE_TOOLCHAIN_FILE'])
@@ -27,9 +32,9 @@ Signed-off-by: AWS Meta Layer <meta-aws@amazon.com>
          if using_libcrypto():
              if using_system_libcrypto():
                  cmake_args.append('-DUSE_OPENSSL=ON')
-
+ 
              cmake_args.append('-DAWS_USE_LIBCRYPTO_TO_SUPPORT_ED25519_EVERYWHERE=ON')
-
+ 
 +        # Add OpenSSL compatibility flags to suppress deprecated warnings
 +        cmake_args.extend([
 +            '-DCMAKE_C_FLAGS=-DOPENSSL_SUPPRESS_DEPRECATED'

--- a/recipes-sdk/aws-crt-python/files/002-revert-bdist-wheel.patch
+++ b/recipes-sdk/aws-crt-python/files/002-revert-bdist-wheel.patch
@@ -1,0 +1,28 @@
+This reverts https://github.com/awslabs/aws-crt-python/pull/671/commits/dd9073ddc8cc9c1b6995b4d5684005386e3eed01
+Upstream-Status: Inappropriate [oe-specific]
+
+Index: git/pyproject.toml
+===================================================================
+--- git.orig/pyproject.toml
++++ git/pyproject.toml
+@@ -1,6 +1,7 @@
+ [build-system]
+ requires = [
+   "setuptools>=75.3.1",
++  "wheel>=0.45.1",      # used by our setup.py
+ ]
+ build-backend = "setuptools.build_meta"
+
+Index: git/setup.py
+===================================================================
+--- git.orig/setup.py
++++ git/setup.py
+@@ -11,7 +11,7 @@ import shutil
+ import subprocess
+ import sys
+ import sysconfig
+-from setuptools.command.bdist_wheel import bdist_wheel
++from wheel.bdist_wheel import bdist_wheel
+
+ if sys.platform == 'win32':
+     # distutils is deprecated in Python 3.10 and removed in 3.12. However, it still works because Python defines a compatibility interface as long as setuptools is installed.


### PR DESCRIPTION
(cherry picked from commit c4d1e146009bb98dc161e3d30688a145e77efbd3)

Add 002-revert-bdist-wheel.patch as we use an older version of setuptools

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
