### PR TITLE
aws-iot-fleetwise-edge: add INSANE_SKIP for ptest buildpaths

### DIFF
--- a/recipes-iot/aws-iot-fleetwise/aws-iot-fleetwise-edge_1.3.2.bb
+++ b/recipes-iot/aws-iot-fleetwise/aws-iot-fleetwise-edge_1.3.2.bb
@@ -105,6 +105,9 @@ RDEPENDS:${PN}-ptest += "\
     python3 \
 "
 
+# nooelint: oelint.vars.insaneskip:INSANE_SKIP
+INSANE_SKIP:${PN}-ptest += "buildpaths"
+
 # nooelint: oelint.vars.insaneskip:INSANE_SKIP - -fsanitize=address does cause this
 INSANE_SKIP:${PN} += "${@bb.utils.contains('PACKAGECONFIG', 'sanitize', 'buildpaths', '', d)}"
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
