### PR TITLE
aws-crt-python: remove not necessary python shebang for ptest

### DIFF
--- a/recipes-sdk/aws-crt-python/aws-crt-python_0.27.6.bb
+++ b/recipes-sdk/aws-crt-python/aws-crt-python_0.27.6.bb
@@ -106,7 +106,6 @@ RDEPENDS:${PN} += "\
 do_install_ptest() {
     install -d ${D}${PTEST_PATH}/tests
     cp -rf ${S}/test ${D}${PTEST_PATH}/tests/
-    find ${D}${PTEST_PATH}/tests -type f -exec sed -i '1s|^#! */usr/bin/python$|#!/usr/bin/python3|' {} +
 }
 
 BBCLASSEXTEND = "native nativesdk"


### PR DESCRIPTION
see #13328 discussion

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
