### PR TITLE
aws-iot-fleetwise-edge: disable service activation

### DIFF
--- a/recipes-iot/aws-iot-fleetwise/aws-iot-fleetwise-edge_1.3.2.bb
+++ b/recipes-iot/aws-iot-fleetwise/aws-iot-fleetwise-edge_1.3.2.bb
@@ -47,6 +47,7 @@ EXTRA_OECMAKE += "-DFWE_AWS_SDK_SHARED_LIBS=ON"
 EXTRA_OECMAKE:append = " -DCMAKE_BUILD_TYPE=RelWithDebInfo"
 
 SYSTEMD_SERVICE:${PN} = "fwe@.service"
+SYSTEMD_AUTO_ENABLE:${PN} = "disable"
 
 # Default values for configure-fwe
 CERTIFICATE_FILE ?= "/etc/aws-iot-fleetwise/certificate.pem"


### PR DESCRIPTION
ERROR: core-image-minimal-1.0-r0 do_rootfs: Postinstall scriptlets of ['aws-iot-fleetwise-edge'] have failed. If the intention is to defer them to first boot, then please place them into pkg_postinst_ontarget:${PN} (). Deferring to first boot via 'exit 1' is no longer supported.

This is as there is no specific instance to activate. Thus deactivating.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
