### PR TITLE
corretto-8-bin: remove libgl dependency

### DIFF
--- a/recipes-devtools/amazon-corretto/corretto-8-bin_8.462.08.1.bb
+++ b/recipes-devtools/amazon-corretto/corretto-8-bin_8.462.08.1.bb
@@ -44,13 +44,5 @@ require corretto-bin-common.inc
 do_package_qa[noexec] = "1"
 EXCLUDE_FROM_SHLIBS = "1"
 
-# nooelint: oelint.vars.dependsordered
-RDEPENDS:${PN} += "\
-    cairo \
-    gtk+ \
-    libgl \
-    pango \
-"
-
 # this is used by meta-aws-tests to find this recipe for ptests, so it should stay in this file instead of moving into corretto-bin-common
 inherit ptest

--- a/recipes-devtools/amazon-corretto/corretto-bin-common.inc
+++ b/recipes-devtools/amazon-corretto/corretto-bin-common.inc
@@ -58,12 +58,12 @@ RDEPENDS:${PN} += "\
 
 do_install:append() {
     if ${@bb.utils.contains('DISTRO_FEATURES','x11','false','true',d)}; then
-        rm ${D}${libdir}/${SHR}/lib/libawt_xawt.so
-        rm ${D}${libdir}/${SHR}/lib/libjawt.so
-        rm ${D}${libdir}/${SHR}/lib/libsplashscreen.so
+        rm -f ${D}${libdir}/${SHR}/lib/libawt_xawt.so
+        rm -f ${D}${libdir}/${SHR}/lib/libjawt.so
+        rm -f ${D}${libdir}/${SHR}/lib/libsplashscreen.so
     fi
     if ${@bb.utils.contains('DISTRO_FEATURES','alsa','false','true',d)}; then
-        rm ${D}${libdir}/${SHR}/lib/libjsound.so
+        rm -f ${D}${libdir}/${SHR}/lib/libjsound.so
     fi
 }
 


### PR DESCRIPTION
Not necessary, checklayer was complaining about this.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
