### PR TITLE
Remove the custom SucessExitStatus

### DIFF
--- a/recipes-iot/aws-iot-greengrass/greengrass-lite/ggl.gg_fleetprovisioning.service
+++ b/recipes-iot/aws-iot-greengrass/greengrass-lite/ggl.gg_fleetprovisioning.service
@@ -13,8 +13,6 @@ Restart=on-failure
 RestartSec=10s
 # try forever
 TimeoutSec=0
-# Consider exit codes 0, 1 as successful completion
-SuccessExitStatus=0 1
 User=root
 Group=root
 RemainAfterExit=true


### PR DESCRIPTION
FleetProvisioning no longer will exit with 1 on success case.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
