### PR TITLE
greengrass-bin: use systemd logging and start after docker if exist

### DIFF
--- a/recipes-iot/aws-iot-greengrass/greengrass-bin/002-fix-service-exec-and-docker.patch
+++ b/recipes-iot/aws-iot-greengrass/greengrass-bin/002-fix-service-exec-and-docker.patch
@@ -1,0 +1,46 @@
+Fix systemd service ExecStart and add Docker dependencies
+
+This patch addresses two issues:
+
+1. Fixes ExecStart to properly invoke the loader without the unreplaced
+   REPLACE_WITH_LOADER_LOG_FILE placeholder, allowing journalctl to capture logs
+
+2. Adds Docker service ordering for systems using containerized Greengrass components
+
+See: https://github.com/aws4embeddedlinux/meta-aws/issues/14242
+
+Upstream-Status: Inappropriate [OE-Specific]
+
+Index: greengrass-bin/bin/greengrass.service.template
+===================================================================
+--- greengrass-bin.orig/bin/greengrass.service.template
++++ greengrass-bin/bin/greengrass.service.template
+@@ -2,6 +2,7 @@
+ Description=Greengrass Core
+ After=network.target
+ After=systemd-time-wait-sync.service
++After=docker.service
+ 
+ [Service]
+ Type=simple
+@@ -9,7 +10,7 @@ PIDFile=REPLACE_WITH_GG_LOADER_PID_FILE
+ RemainAfterExit=no
+ Restart=on-failure
+ RestartSec=10
+-ExecStart=/bin/sh -c "exec REPLACE_WITH_GG_LOADER_FILE >> REPLACE_WITH_LOADER_LOG_FILE 2>&1"
++ExecStart=/bin/sh REPLACE_WITH_GG_LOADER_FILE
+ KillMode=mixed
+ 
+ [Install]
+ 
+ [Service]
+ Type=simple
+@@ -8,7 +10,7 @@ PIDFile=REPLACE_WITH_GG_LOADER_PID_FILE
+ RemainAfterExit=no
+ Restart=on-failure
+ RestartSec=10
+-ExecStart=/bin/sh -c "exec REPLACE_WITH_GG_LOADER_FILE >> REPLACE_WITH_LOADER_LOG_FILE 2>&1"
++ExecStart=/bin/sh REPLACE_WITH_GG_LOADER_FILE
+ KillMode=mixed
+ 
+ [Install]

--- a/recipes-iot/aws-iot-greengrass/greengrass-bin_2.16.0.bb
+++ b/recipes-iot/aws-iot-greengrass/greengrass-bin_2.16.0.bb
@@ -21,6 +21,7 @@ PACKAGECONFIG[pkcs11] = ",,greengrass-plugin-pkcs11,greengrass-plugin-pkcs11"
 SRC_URI = "\
     https://d2s8p88vqu9w66.cloudfront.net/releases/greengrass-${PV}.zip;subdir=greengrass-bin \
     file://001-service-time-wait.patch \
+    file://002-fix-service-exec-and-docker.patch \
     file://greengrassv2-init.yaml \
     file://run-ptest \
     file://config.yaml.template \


### PR DESCRIPTION
Details here https://github.com/aws4embeddedlinux/meta-aws/issues/14242

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
