### PR TITLE
greengrass-bin: use systemd logging and start after docker if exist

### DIFF
--- a/recipes-iot/aws-iot-greengrass/greengrass-bin/002-fix-service-exec-and-docker.patch
+++ b/recipes-iot/aws-iot-greengrass/greengrass-bin/002-fix-service-exec-and-docker.patch
@@ -1,0 +1,34 @@
+Fix systemd service ExecStart and add Docker dependencies
+
+This patch addresses two issues:
+
+1. Fixes ExecStart to properly invoke the loader without the unreplaced
+   REPLACE_WITH_LOADER_LOG_FILE placeholder, allowing journalctl to capture logs
+
+2. Adds Docker service ordering for systems using containerized Greengrass components
+
+See: https://github.com/aws4embeddedlinux/meta-aws/issues/14242
+
+Upstream-Status: Inappropriate [OE-Specific]
+
+Index: greengrass-bin/bin/greengrass.service.template
+===================================================================
+--- greengrass-bin.orig/bin/greengrass.service.template
++++ greengrass-bin/bin/greengrass.service.template
+@@ -1,6 +1,7 @@
+ [Unit]
+ Description=Greengrass Core
+ After=network.target
++After=docker.service
+ 
+ [Service]
+ Type=simple
+@@ -8,7 +9,7 @@ PIDFile=REPLACE_WITH_GG_LOADER_PID_FILE
+ RemainAfterExit=no
+ Restart=on-failure
+ RestartSec=10
+-ExecStart=/bin/sh -c "exec REPLACE_WITH_GG_LOADER_FILE >> REPLACE_WITH_LOADER_LOG_FILE 2>&1"
++ExecStart=/bin/sh REPLACE_WITH_GG_LOADER_FILE
+ KillMode=mixed
+ 
+ [Install]

--- a/recipes-iot/aws-iot-greengrass/greengrass-bin/greengrass.service.patch
+++ b/recipes-iot/aws-iot-greengrass/greengrass-bin/greengrass.service.patch
@@ -9,5 +9,5 @@ Index: greengrass-bin/bin/greengrass.service.template
  Restart=on-failure
  RestartSec=10
 +ExecStartPre=/bin/sh -c "/greengrass/v2/config/replace_board_id.sh /greengrass/v2/config/config.yaml"
- ExecStart=/bin/sh -c "exec REPLACE_WITH_GG_LOADER_FILE >> REPLACE_WITH_LOADER_LOG_FILE 2>&1"
+ ExecStart=/bin/sh REPLACE_WITH_GG_LOADER_FILE
  KillMode=mixed

--- a/recipes-iot/aws-iot-greengrass/greengrass-bin_2.16.0.bb
+++ b/recipes-iot/aws-iot-greengrass/greengrass-bin_2.16.0.bb
@@ -21,6 +21,7 @@ PACKAGECONFIG[fleetprovisioning] = ""
 
 SRC_URI = "\
     https://d2s8p88vqu9w66.cloudfront.net/releases/greengrass-${PV}.zip;subdir=greengrass-bin \
+    file://002-fix-service-exec-and-docker.patch \
     file://greengrassv2-init.yaml \
     file://run-ptest \
     "
@@ -36,7 +37,7 @@ SRC_URI:append = " ${@bb.utils.contains('PACKAGECONFIG', 'fleetprovisioning', '\
     file://greengrass.service.patch \
     ', '', d)}"
 
-SRC_URI[sha256sum] = "650b4bbee368d5bdb8c5a89ef6b76c08c508050ead594360681d760a299f33ef"
+SRC_URI[sha256sum] = "f07742c76eca868617127b5c6c9028e41c45c2b4ec25dd0db6f3b40ef7638b4e"
 SRC_URI[fleetprovisioning.sha256sum] = "1e7fdc625d4e1e7795d63f0e97981feecad526277bf211154505de145009e8c1"
 UPSTREAM_CHECK_REGEX ?= "releases/tag/v?(?P<pver>\d+(\.\d+)+)"
 


### PR DESCRIPTION
Details here https://github.com/aws4embeddedlinux/meta-aws/issues/14242

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
