### PR TITLE
aws-sdk-cpp, aws-iot-fleetwise-edge: mark non compatible with riscv64

### DIFF
--- a/recipes-iot/aws-iot-fleetwise/aws-iot-fleetwise-edge_1.3.2.bb
+++ b/recipes-iot/aws-iot-fleetwise/aws-iot-fleetwise-edge_1.3.2.bb
@@ -4,6 +4,8 @@ HOMEPAGE = "https://github.com/aws/aws-iot-fleetwise-edge"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=34400b68072d710fecd0a2940a0d1658"
 
+COMPATIBLE_MACHINE:riscv64 = "null"
+
 # nooelint: oelint.vars.dependsordered
 DEPENDS = "\
     aws-sdk-cpp \

--- a/recipes-sdk/aws-sdk-cpp/aws-sdk-cpp_1.11.700.bb
+++ b/recipes-sdk/aws-sdk-cpp/aws-sdk-cpp_1.11.700.bb
@@ -4,6 +4,8 @@ HOMEPAGE = "https://github.com/aws/aws-sdk-cpp"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=e3fc50a88d0a364313df4b21ef20c29e"
 
+COMPATIBLE_MACHINE:riscv64 = "null"
+
 DEPENDS += "\
     aws-crt-cpp \
     curl \


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
