### PR TITLE
s2n: Remove memory-intensive tests from ptest

### DIFF
--- a/recipes-sdk/s2n/s2n/run-ptest
+++ b/recipes-sdk/s2n/s2n/run-ptest
@@ -162,7 +162,6 @@ TESTS="\
 ./s2n_extension_type_test \
 ./s2n_handshake_partial_test \
 ./s2n_handshake_test \
-./s2n_mem_allocator_test \
 ./s2n_mem_test \
 ./s2n_mem_usage_test \
 ./s2n_mutual_auth_test \
@@ -170,7 +169,6 @@ TESTS="\
 ./s2n_pem_rsa_dhe_test \
 ./s2n_pem_test \
 ./s2n_pkey_test \
-./s2n_post_handshake_recv_test \
 ./s2n_recv_test \
 ./s2n_release_non_empty_buffers_test \
 ./s2n_renegotiate_io_test \


### PR DESCRIPTION
Remove s2n_mem_allocator_test and s2n_post_handshake_recv_test from the ptest suite as they cause out-of-memory issues and system crashes during test execution. The mem_allocator test runs over 42 million test cases, and the post_handshake_recv test causes kernel panics.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
