### PR TITLE
Fix amazon-kvs-webrtc-sdk build by disabling IngestionFunctionalityTests

### DIFF
--- a/recipes-sdk/amazon-kvs-webrtc-sdk/amazon-kvs-webrtc-sdk_1.15.0.bb
+++ b/recipes-sdk/amazon-kvs-webrtc-sdk/amazon-kvs-webrtc-sdk_1.15.0.bb
@@ -22,6 +22,7 @@ BRANCH = "main"
 SRC_URI = "\
     git://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c.git;protocol=https;branch=${BRANCH} \
     file://001-disable-download-of-kvs-common-lws.patch \
+    file://002-disable-ingestion-tests.patch \
     file://run-ptest \
     file://ptest_result.py \
 "

--- a/recipes-sdk/amazon-kvs-webrtc-sdk/files/002-disable-ingestion-tests.patch
+++ b/recipes-sdk/amazon-kvs-webrtc-sdk/files/002-disable-ingestion-tests.patch
@@ -1,0 +1,18 @@
+Upstream-Status: Inappropriate [disable failing test due to missing AWS SDK header]
+
+Disable IngestionFunctionalityTests.cpp from compilation as it requires
+aws/core/utils/pagination/Paginator.h which is not available in the current
+AWS SDK version.
+
+Index: amazon-kvs-webrtc-sdk-1.15.0/tst/CMakeLists.txt
+===================================================================
+--- amazon-kvs-webrtc-sdk-1.15.0.orig/tst/CMakeLists.txt
++++ amazon-kvs-webrtc-sdk-1.15.0/tst/CMakeLists.txt
+@@ -37,6 +37,7 @@ if(ENABLE_AWS_SDK_IN_TESTS)
+ endif()
+ 
+ file(GLOB WEBRTC_CLIENT_TEST_SOURCE_FILES "*.cpp" )
++list(REMOVE_ITEM WEBRTC_CLIENT_TEST_SOURCE_FILES "${CMAKE_CURRENT_SOURCE_DIR}/IngestionFunctionalityTests.cpp")
+ 
+ add_executable(webrtc_client_test ${WEBRTC_CLIENT_TEST_SOURCE_FILES} SignalingApiFunctionalityTest.h)
+ target_link_libraries(webrtc_client_test


### PR DESCRIPTION
The test file requires aws/core/utils/pagination/Paginator.h which is not available in the current AWS SDK version. Exclude it from compilation.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
