### PR TITLE
cloud-init: Update SYSTEMD_SERVICE

### DIFF
--- a/dynamic-layers/virtualization-layer/recipes-extended/cloud-init/cloud-init_%.bbappend
+++ b/dynamic-layers/virtualization-layer/recipes-extended/cloud-init/cloud-init_%.bbappend
@@ -9,7 +9,7 @@ do_install:append:aws-ec2 () {
 }
 
 SYSTEMD_PACKAGES = "${PN}-systemd"
-SYSTEMD_SERVICE:${PN}-systemd = "cloud-init.service"
+SYSTEMD_SERVICE:${PN}-systemd = "cloud-init-local.service cloud-init-main.service cloud-init-network.service cloud-config.service cloud-final.service"
 SYSTEMD_AUTO_ENABLE:${PN}-systemd = "enable"
 
 inherit features_check


### PR DESCRIPTION
cloud-init >= 25.x dropped cloud-init.service (renamed to cloud-init-network.service) and introduced cloud-init-main.service as the new primary entry point.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
