### PR TITLE
[Backport whinlatter-next] 2026-04-09_01-42-29_master-next_aws-iot-fleetwise-edge

### DIFF
--- a/recipes-iot/aws-iot-fleetwise/aws-iot-fleetwise-edge/002-fix-abseil-linking.patch
+++ b/recipes-iot/aws-iot-fleetwise/aws-iot-fleetwise-edge/002-fix-abseil-linking.patch
@@ -1,10 +1,18 @@
-Upstream-Status: Pending
+From 165ac718eed6a8c3d03a8da0ce278bf87f4c9e71 Mon Sep 17 00:00:00 2001
+From: Thomas Roos <throos@amazon.de>
+Date: Mon, 9 Feb 2026 13:17:57 +0000
+Subject: [PATCH] aws-iot-fleetwise-edge: fix link of abseil lib
 
-Index: aws-iot-fleetwise-edge-1.3.2/CMakeLists.txt
-===================================================================
---- aws-iot-fleetwise-edge-1.3.2.orig/CMakeLists.txt
-+++ aws-iot-fleetwise-edge-1.3.2/CMakeLists.txt
-@@ -693,6 +693,8 @@ target_link_libraries(aws-iot-fleetwise
+Upstream-Status: Pending
+---
+ CMakeLists.txt | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index c345306..ca2abe6 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -688,6 +688,8 @@ target_link_libraries(aws-iot-fleetwise-edge
    fwe
    fwe-proto
    $<$<BOOL:${FWE_FEATURE_SOMEIP}>:fwe-someip-example>
@@ -13,7 +21,7 @@ Index: aws-iot-fleetwise-edge-1.3.2/CMakeLists.txt
    $<$<BOOL:${FWE_FEATURE_SOMEIP}>:fwe-device-shadow-over-someip>
  )
  target_include_directories(aws-iot-fleetwise-edge PRIVATE
-@@ -732,6 +734,8 @@ if(${BUILD_TESTING})
+@@ -727,6 +729,8 @@ if(${BUILD_TESTING})
      $<$<BOOL:${FWE_FEATURE_SOMEIP}>:fwe-device-shadow-over-someip>
      ${GMOCK_LIB}
      GTest::GTest
@@ -22,7 +30,7 @@ Index: aws-iot-fleetwise-edge-1.3.2/CMakeLists.txt
    )
  
    set(TEST_BINARIES_PARALLEL ${TEST_BINARIES_PARALLEL} fwe-gtest)
-@@ -749,6 +753,8 @@ if(${BUILD_TESTING})
+@@ -744,6 +748,8 @@ if(${BUILD_TESTING})
      fwe
      fwe-proto
      benchmark::benchmark

--- a/recipes-iot/aws-iot-fleetwise/aws-iot-fleetwise-edge_1.3.3.bb
+++ b/recipes-iot/aws-iot-fleetwise/aws-iot-fleetwise-edge_1.3.3.bb
@@ -25,7 +25,7 @@ SRC_URI = "\
     file://run-ptest \
     "
 
-SRCREV = "cefc4c32614c6bb4ea955a5ed0e962001320d19f"
+SRCREV = "62c9e23d1d6b7f836577d42c228f8295ad9334db"
 
 inherit cmake systemd ptest pkgconfig
 

--- a/recipes-iot/aws-iot-fleetwise/files/001-remove-cxx-standard.patch
+++ b/recipes-iot/aws-iot-fleetwise/files/001-remove-cxx-standard.patch
@@ -1,4 +1,4 @@
-From b68324227f8a234e6a955b84cbb19877e459eea5 Mon Sep 17 00:00:00 2001
+From d5743d56a1861b1d23181fab04cad06a53de9984 Mon Sep 17 00:00:00 2001
 From: Thomas Roos <throos@amazon.de>
 Date: Tue, 9 Jan 2024 15:01:35 +0000
 Subject: [PATCH] aws-iot-fleetwise-edge: remove setting of cxx-standard
@@ -9,12 +9,12 @@ Upstream-Status: Submitted [author]
  1 file changed, 5 deletions(-)
 
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 450902a..03fa573 100644
+index 8fa3671..c345306 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -4,11 +4,6 @@ cmake_minimum_required(VERSION 3.10.2)
  
- project(iotfleetwise VERSION 1.3.2)
+ project(iotfleetwise VERSION 1.3.3)
  
 -# FWE uses C++14 for compatibility reasons with Automotive middlewares (Adaptive AUTOSAR, ROS2)
 -# Note: When built with FWE_FEATURE_ROS2, colcon will override these settings


### PR DESCRIPTION
# Description
Backport of #15436 to `whinlatter-next`.