### PR TITLE
ci: disable pr-cve-check until migration to sbom-cve-check

### DIFF
--- a/.github/workflows/pr-cve-check.yml
+++ b/.github/workflows/pr-cve-check.yml
@@ -1,13 +1,10 @@
 name: pr-cve-check
 
+# DISABLED: cve-check.bbclass was removed from OE-core master (2026-03-31)
+# See https://github.com/aws4embeddedlinux/meta-aws/issues/15461
+# TODO: Migrate to sbom-cve-check
 on:
   workflow_dispatch:
-  pull_request:
-    branches:
-      - 'master-next'
-    paths:
-      - '**.bb'
-      - '**.inc'
 permissions:
   contents: read
 


### PR DESCRIPTION
cve-check.bbclass was removed from OE-core master on 2026-03-31 (commit 00de455). The replacement is sbom-cve-check from Bootlin.

Disable the PR trigger to unblock PRs. Manual dispatch still available for testing the migration.

Fixes #15461