### PR TITLE
whinlatter-next: sync 11 recipes with master versions

### DIFF
--- a/.github/workflows/build-test-recipe.yml
+++ b/.github/workflows/build-test-recipe.yml
@@ -234,6 +234,12 @@ jobs:
           done
           export RECIPES="$FILTERED_RECIPES"
 
+          # Handle mutually exclusive recipes (see #15435)
+          if echo "$RECIPES" | grep -qw "aws-cli-v2" && echo "$RECIPES" | grep -qw "aws-cli"; then
+            RECIPES=$(echo "$RECIPES" | tr ' ' '\n' | grep -v '^aws-cli$' | tr '\n' ' ')
+            echo "Excluded aws-cli (v1) due to conflict with aws-cli-v2"
+          fi
+
           echo RECIPES to build, test: "$RECIPES"
           echo "recipes=$RECIPES" >> $GITHUB_OUTPUT
       - name: Run build

--- a/recipes-devtools/python/python3-boto3_1.42.89.bb
+++ b/recipes-devtools/python/python3-boto3_1.42.89.bb
@@ -12,7 +12,7 @@ SRC_URI = "\
     file://python_dependency_test.py \
     "
 
-SRCREV = "b7b0a0fecc981d567dec67d5c7a9927daa38cce6"
+SRCREV = "54a9dc1891d5e38110e5f77fc45fbc7e2e112bfe"
 
 inherit setuptools3 ptest
 

--- a/recipes-devtools/python/python3-botocore_1.42.89.bb
+++ b/recipes-devtools/python/python3-botocore_1.42.89.bb
@@ -12,7 +12,7 @@ SRC_URI = "\
     file://python_dependency_test.py \
     "
 
-SRCREV = "56a6ef8c49887d3cba09ee5a085f16e97c1fdde1"
+SRCREV = "9b76a624ae6311605797bc0b4cdc7c3e064c1593"
 
 inherit setuptools3 ptest
 

--- a/recipes-sdk/amazon-kvs-webrtc-sdk/amazon-kvs-webrtc-sdk_1.18.0.bb
+++ b/recipes-sdk/amazon-kvs-webrtc-sdk/amazon-kvs-webrtc-sdk_1.18.0.bb
@@ -26,9 +26,11 @@ SRC_URI = "\
     file://ptest_result.py \
 "
 
-SRCREV = "057047ed6efe9320e7056f4f4b708b9b8934d51d"
+SRCREV = "ef4649473b2d1dc25215eca9d21cda6c802c06f2"
 
 inherit cmake pkgconfig ptest
+
+COMPATIBLE_MACHINE:riscv64 = "null"
 
 PACKAGECONFIG ??= "\
     ${@bb.utils.contains('PTEST_ENABLED', '1', 'with-tests with-samples', '', d)} \
@@ -63,7 +65,7 @@ EXTRA_OECMAKE += "\
     -DUNDEFINED_BEHAVIOR_SANITIZER=OFF \
     -DDEBUG_HEAP=OFF \
     -DCOMPILER_WARNINGS=OFF \
-    -DALIGNED_MEMORY_MODEL=OFF \
+    -DALIGNED_MEMORY_MODEL=${@'ON' if 'riscv' in d.getVar('TARGET_ARCH') else 'OFF'} \
     ${@bb.utils.contains('PTEST_ENABLED', '1', '-DDBUILD_TEST=ON -DCMAKE_BUILD_TYPE=Debug ', '-DBUILD_TEST=OFF -DCMAKE_BUILD_TYPE=Release', d)} \
 "
 

--- a/recipes-sdk/aws-c-io/aws-c-io_0.26.3.bb
+++ b/recipes-sdk/aws-c-io/aws-c-io_0.26.3.bb
@@ -23,7 +23,7 @@ SRC_URI = "\
     file://001-enable-tests-with-crosscompiling.patch \
     file://run-ptest \
     "
-SRCREV = "bfb0819d3906502483611ce832a5ec6b897c8421"
+SRCREV = "1ec8081f208ef8d51381889eda3bda9756fd5bb5"
 
 inherit cmake ptest pkgconfig
 

--- a/recipes-sdk/aws-c-mqtt/aws-c-mqtt_0.15.2.bb
+++ b/recipes-sdk/aws-c-mqtt/aws-c-mqtt_0.15.2.bb
@@ -23,7 +23,7 @@ SRC_URI = "\
     file://run-ptest \
     "
 
-SRCREV = "dc2fe7be81070f7c5095ad386d9a23c180a4276b"
+SRCREV = "3c2ceee52b66db42228053a4fb55210c8f8433a0"
 
 inherit cmake ptest
 

--- a/recipes-sdk/aws-crt-cpp/aws-crt-cpp/001-shared-static-crt-libs.patch
+++ b/recipes-sdk/aws-crt-cpp/aws-crt-cpp/001-shared-static-crt-libs.patch
@@ -1,4 +1,4 @@
-From 5722514196694fa25491ae8d5b81ad9e62199077 Mon Sep 17 00:00:00 2001
+From 1c881640ef222f0f85e9f16d96862f155a94f264 Mon Sep 17 00:00:00 2001
 From: Thomas Roos <throos@amazon.de>
 Date: Tue, 20 May 2025 08:45:29 +0000
 Subject: [PATCH] aws-crt-cpp: change to build-deps as default

--- a/recipes-sdk/aws-crt-cpp/aws-crt-cpp/002-enable-tests-with-crosscompiling.patch
+++ b/recipes-sdk/aws-crt-cpp/aws-crt-cpp/002-enable-tests-with-crosscompiling.patch
@@ -1,4 +1,4 @@
-From 15ab81b46199f77c37a7b48239f7d983e1f05a2c Mon Sep 17 00:00:00 2001
+From 2a28428bb2fbbf97d2324a66d63058510aef0f35 Mon Sep 17 00:00:00 2001
 From: Thomas Roos <throos@amazon.de>
 Date: Mon, 29 Sep 2025 12:51:03 +0000
 Subject: [PATCH] This enable the tests even when crosscompiling.

--- a/recipes-sdk/aws-crt-cpp/aws-crt-cpp_0.38.5.bb
+++ b/recipes-sdk/aws-crt-cpp/aws-crt-cpp_0.38.5.bb
@@ -28,7 +28,7 @@ SRC_URI = "\
     file://002-enable-tests-with-crosscompiling.patch \
     "
 
-SRCREV = "19d1cb67f94011561368d508583efa5308618712"
+SRCREV = "bca5d26fd37b0d39ba8fbffb3058560f0d4d193f"
 
 inherit cmake pkgconfig ptest
 

--- a/recipes-sdk/aws-sdk-cpp/aws-sdk-cpp_1.11.790.bb
+++ b/recipes-sdk/aws-sdk-cpp/aws-sdk-cpp_1.11.790.bb
@@ -17,10 +17,9 @@ SRC_URI = "\
     git://github.com/aws/aws-sdk-cpp.git;protocol=https;branch=main \
     file://run-ptest \
     file://ptest_result.py \
-    file://0001-tinyxml2-fix-null-format-string.patch \
     "
 
-SRCREV = "4dd4b2e5d209145a045a3d72b1aeae7360b63080"
+SRCREV = "cad95407f1ec292e6b65fd5018edda49c680dab3"
 
 inherit cmake ptest pkgconfig
 

--- a/recipes-sdk/s2n/s2n/run-ptest
+++ b/recipes-sdk/s2n/s2n/run-ptest
@@ -27,7 +27,6 @@ TESTS="\
 ./s2n_client_supported_groups_extension_test \
 ./s2n_connection_context_test \
 ./s2n_connection_preferences_test \
-./s2n_drbg_test \
 ./s2n_early_data_io_api_test \
 ./s2n_ecc_point_format_extension_test \
 ./s2n_ecc_preferences_test \
@@ -38,7 +37,6 @@ TESTS="\
 ./s2n_extension_list_process_test \
 ./s2n_extension_list_send_test \
 ./s2n_extension_type_lists_test \
-./s2n_fork_generation_number_test \
 ./s2n_fragmentation_coalescing_test \
 ./s2n_handshake_errno_test \
 ./s2n_handshake_hashes_test \

--- a/recipes-sdk/s2n/s2n_1.7.2.bb
+++ b/recipes-sdk/s2n/s2n_1.7.2.bb
@@ -17,7 +17,7 @@ SRC_URI = "\
     file://run-ptest \
     "
 
-SRCREV = "f5e5e83031be60691f22442373fb8371274fcd56"
+SRCREV = "a71ea1f9764ee9ae91b47c34faa0447c4fe11d0a"
 UPSTREAM_CHECK_GITTAGREGEX = "v(?P<pver>.*)"
 
 inherit cmake ptest pkgconfig

--- a/recipes-support/aws-cli-v2/aws-cli-v2_2.34.30.bb
+++ b/recipes-support/aws-cli-v2/aws-cli-v2_2.34.30.bb
@@ -23,7 +23,7 @@ DEPENDS += "\
     python3-ruamel-yaml-clib-native \
     python3-ruamel-yaml-native \
     python3-s3transfer \
-    python3-urllib3-1.x-native \
+    python3-urllib3-native \
     python3-zipp-native \
 "
 
@@ -32,7 +32,7 @@ SRC_URI = "\
     file://run-ptest \
 "
 
-SRCREV = "2ac8e450281927d8bae118b00dfefc50d3908c29"
+SRCREV = "7f985d7ae64be6d278fba26fc44773150b32f561"
 
 # version 2.x
 UPSTREAM_CHECK_GITTAGREGEX = "(?P<pver>2\.\d+(\.\d+)+)"
@@ -68,19 +68,19 @@ RDEPENDS:${PN} += "\
     python3-ruamel-yaml \
     python3-sqlite3 \
     python3-unixadmin \
-    python3-urllib3-1.x \
+    python3-urllib3 \
     python3-zipp \
 "
 
 do_patch() {
     sed -i -E 's/(([a-zA-Z0-9_.-]+)(>=?[0-9.]+)?(,)?(<[0-9.]+\*|<=?[0-9.]+)?|([a-zA-Z0-9_.-]+)==[0-9.]+)/\2\3\6/' ${S}/pyproject.toml ${S}/requirements/bootstrap.txt
-    
+
     # Patch awscli logger to handle CRT initialization errors
     sed -i '/def enable_crt_logging():/,/awscrt.io.init_logging/ {
         s/awscrt.io.init_logging/try:\n        awscrt.io.init_logging/
         /awscrt.io.init_logging/a\    except RuntimeError:\n        pass
     }' ${S}/awscli/logger.py
-    
+
     sed -i '/def disable_crt_logging():/,/awscrt.io.init_logging/ {
         s/awscrt.io.init_logging/try:\n        awscrt.io.init_logging/
         /awscrt.io.init_logging/a\    except RuntimeError:\n        pass

--- a/recipes-support/aws-cli/aws-cli_1.44.79.bb
+++ b/recipes-support/aws-cli/aws-cli_1.44.79.bb
@@ -9,7 +9,7 @@ SRC_URI = "\
     file://run-ptest \
 "
 
-SRCREV = "395a8a986fab29ea48db3b83e905138c83c5c4e6"
+SRCREV = "7e8999e0ad0c6c0b89a25da5997eb10ae32e2de2"
 
 # version 2.x has got library link issues - so stick to version 1.x for now
 UPSTREAM_CHECK_GITTAGREGEX = "(?P<pver>1\.\d+(\.\d+)+)"


### PR DESCRIPTION
Sync whinlatter-next recipe versions to match master branch.

## Recipe Upgrades
- amazon-kvs-webrtc-sdk: 1.15.0 → 1.18.0
- aws-c-io: 0.26.1 → 0.26.3
- aws-c-mqtt: 0.15.0 → 0.15.2
- aws-cli: 1.44.59 → 1.44.79
- aws-cli-v2: 2.34.7 → 2.34.30
- aws-crt-cpp: 0.38.3 → 0.38.5
- aws-sdk-cpp: 1.11.782 → 1.11.790 (tinyxml2 patch dropped — upstreamed)
- python3-boto3: 1.42.65 → 1.42.89
- python3-botocore: 1.42.81 → 1.42.89
- python3-ruamel-yaml-clib: 0.2.12 → 0.2.15
- s2n: 1.7.0 → 1.7.2 (with ptest fix for removed upstream tests)

All versions copied from master branch recipes.