### PR TITLE
aws-greengrass-component-sdk: add samples PACKAGECONFIG flag

### DIFF
--- a/recipes-sdk/aws-greengrass-component-sdk/README.md
+++ b/recipes-sdk/aws-greengrass-component-sdk/README.md
@@ -1,0 +1,94 @@
+# aws-greengrass-component-sdk
+
+Yocto/OE recipe for the [AWS Greengrass Component SDK](https://github.com/aws-greengrass/aws-greengrass-component-sdk) — a lightweight library for building AWS IoT Greengrass components in C, C++, and Rust.
+
+## What this builds
+
+- **C static library** (`libgg-sdk.a`) and headers
+- **C++ static library** (`libgg-sdk++.a`) and headers
+- **Rust rlib** (`libgg_sdk.rlib`) for Rust components
+- **Sample binaries** demonstrating every supported IPC operation
+- **Component recipe JSONs** for Greengrass deployment reference
+
+## Configuration
+
+Add to your `local.conf` or distro config:
+
+### Default (SDK + samples)
+
+No configuration needed. The recipe builds with `rust` and `samples` enabled by default.
+
+### Disable samples (SDK only)
+
+```bitbake
+PACKAGECONFIG:pn-aws-greengrass-component-sdk = "rust"
+```
+
+### Disable Rust support
+
+```bitbake
+PACKAGECONFIG:pn-aws-greengrass-component-sdk = "samples"
+```
+
+### Minimal (C/C++ SDK only, no samples, no Rust)
+
+```bitbake
+PACKAGECONFIG:pn-aws-greengrass-component-sdk = ""
+```
+
+## Packages
+
+| Package | Contents |
+|---------|----------|
+| `aws-greengrass-component-sdk` | Meta package (SDK is static-only, use `-dev` or `-staticdev`) |
+| `aws-greengrass-component-sdk-dev` | Headers (`gg/*.h`, `gg/*.hpp`) and Rust rlib |
+| `aws-greengrass-component-sdk-staticdev` | Static libraries (`libgg-sdk.a`, `libgg-sdk++.a`) |
+| `aws-greengrass-component-sdk-samples` | C/C++/Rust sample binaries and component recipe JSONs |
+| `aws-greengrass-component-sdk-doc` | Documentation |
+| `aws-greengrass-component-sdk-ptest` | Runtime tests for sample binaries |
+
+## Adding samples to your image
+
+```bitbake
+IMAGE_INSTALL:append = " aws-greengrass-component-sdk-samples"
+```
+
+The sample binaries are installed to `/usr/bin/` and the component recipe
+JSONs to `/usr/share/greengrass/component-recipes/`.
+
+## Writing your own Greengrass component
+
+Greengrass components are **self-contained static binaries** that communicate
+with the Greengrass nucleus via IPC. The SDK is a build-time dependency only.
+
+### C/C++ component recipe
+
+```bitbake
+DEPENDS = "aws-greengrass-component-sdk"
+inherit cmake
+
+# Your CMakeLists.txt links against gg-sdk (C) or gg-sdk++ (C++)
+# target_link_libraries(my-component PRIVATE gg-sdk)
+```
+
+### Rust component recipe
+
+```bitbake
+DEPENDS = "aws-greengrass-component-sdk"
+inherit cargo
+
+export RUSTFLAGS:append = " \
+    --extern gg_sdk=${STAGING_LIBDIR}/rustlib/${RUST_HOST_SYS}/lib/libgg_sdk.rlib \
+    -L ${STAGING_LIBDIR} \
+"
+```
+
+### Deploying your component
+
+1. Build your component recipe with `bitbake my-component`
+2. Copy the binary to S3
+3. Create a component recipe JSON (see samples in `/usr/share/greengrass/component-recipes/`)
+4. Register with `aws greengrassv2 create-component-version`
+5. Deploy to your thing group
+
+See the [upstream deployment guide](https://github.com/aws-greengrass/aws-greengrass-component-sdk/blob/main/samples/README.md) for details.

--- a/recipes-sdk/aws-greengrass-component-sdk/aws-greengrass-component-sdk_0.4.bb
+++ b/recipes-sdk/aws-greengrass-component-sdk/aws-greengrass-component-sdk_0.4.bb
@@ -49,15 +49,16 @@ export BINDGEN_EXTRA_CLANG_ARGS = "--sysroot=${STAGING_DIR_TARGET} ${TARGET_CC_A
 EXTRA_OECMAKE = " \
     -DCMAKE_BUILD_TYPE=MinSizeRel \
     -DBUILD_SHARED_LIBS=OFF \
-    -DBUILD_SAMPLES=ON \
     -DENABLE_WERROR=OFF \
 "
 
-PACKAGECONFIG ??= "rust"
+PACKAGECONFIG ??= "rust samples"
 PACKAGECONFIG[rust] = ",,,"
+PACKAGECONFIG[samples] = ",,,"
 
 # default is stripped, we wanna do this by yocto
 EXTRA_OECMAKE:append = " -DCMAKE_BUILD_TYPE=RelWithDebInfo"
+EXTRA_OECMAKE:append = " ${@"-DBUILD_SAMPLES=ON" if bb.utils.contains("PACKAGECONFIG", "samples", True, False, d) else "-DBUILD_SAMPLES=OFF"}"
 
 DEBUG_PREFIX_MAP += "-ffile-prefix-map=${UNPACKDIR}=${TARGET_DBGSRC_DIR}"
 DEBUG_PREFIX_MAP += "-ffile-prefix-map=${TMPDIR}=${TARGET_DBGSRC_DIR}"
@@ -85,9 +86,14 @@ do_configure:prepend() {
 do_compile() {
     cmake_do_compile
 
-    if echo "${PACKAGECONFIG}" | grep -q "rust"; then
-        bbnote "Building Rust examples"
+    if ${@bb.utils.contains('PACKAGECONFIG', 'rust', 'true', 'false', d)}; then
+        bbnote "Building Rust library"
         cargo_do_compile
+
+        if ${@bb.utils.contains('PACKAGECONFIG', 'samples', 'true', 'false', d)}; then
+            bbnote "Building Rust examples"
+            CARGO_BUILD_FLAGS="${CARGO_BUILD_FLAGS} --examples" cargo_do_compile
+        fi
     fi
 }
 
@@ -96,25 +102,45 @@ SRC_URI:append = " file://run-ptest"
 do_install() {
     cmake --install ${B} --prefix ${D}${prefix}
 
-    install -d ${D}${bindir}
-    if [ -d "${B}/bin" ]; then
-        for sample in ${B}/bin/*; do
-            if [ -f "$sample" ]; then
-                install -m 0755 "$sample" ${D}${bindir}/
+    # Install C/C++ sample binaries and component recipes
+    if ${@bb.utils.contains('PACKAGECONFIG', 'samples', 'true', 'false', d)}; then
+        install -d ${D}${bindir}
+        if [ -d "${B}/bin" ]; then
+            for sample in ${B}/bin/*; do
+                if [ -f "$sample" ]; then
+                    install -m 0755 "$sample" ${D}${bindir}/
+                fi
+            done
+        fi
+
+        # Install component recipe JSONs for deployment reference
+        install -d ${D}${datadir}/greengrass/component-recipes
+        for recipe_json in ${S}/samples/*.json ${S}/cpp/samples/*.json; do
+            if [ -f "$recipe_json" ]; then
+                install -m 0644 "$recipe_json" ${D}${datadir}/greengrass/component-recipes/
             fi
         done
     fi
 
     if ${@bb.utils.contains('PACKAGECONFIG', 'rust', 'true', 'false', d)}; then
-        if [ -d "${B}/target/${CARGO_TARGET_SUBDIR}/examples" ]; then
-            for example in ${B}/target/${CARGO_TARGET_SUBDIR}/examples/*; do
-                if [ -f "$example" ] && [ -x "$example" ] && [ ! "${example##*.}" = "d" ]; then
-                    case "$(basename $example)" in
-                        *-[0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f])
-                            continue
-                            ;;
-                    esac
-                    install -m 0755 "$example" ${D}${bindir}/rust_$(basename $example)
+        if ${@bb.utils.contains('PACKAGECONFIG', 'samples', 'true', 'false', d)}; then
+            if [ -d "${B}/target/${CARGO_TARGET_SUBDIR}/examples" ]; then
+                for example in ${B}/target/${CARGO_TARGET_SUBDIR}/examples/*; do
+                    if [ -f "$example" ] && [ -x "$example" ] && [ ! "${example##*.}" = "d" ]; then
+                        case "$(basename $example)" in
+                            *-[0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f])
+                                continue
+                                ;;
+                        esac
+                        install -m 0755 "$example" ${D}${bindir}/rust_$(basename $example)
+                    fi
+                done
+            fi
+
+            # Install Rust example component recipe JSONs
+            for recipe_json in ${S}/rust/examples/*.json; do
+                if [ -f "$recipe_json" ]; then
+                    install -m 0644 "$recipe_json" ${D}${datadir}/greengrass/component-recipes/
                 fi
             done
         fi
@@ -169,37 +195,43 @@ do_install() {
 do_install_ptest() {
     install -m 0755 ${WORKDIR}/sources/run-ptest ${D}${PTEST_PATH}/
 
-    if [ -d "${B}/bin" ]; then
-        for sample in ${B}/bin/*; do
-            if [ -f "$sample" ]; then
-                install -m 0755 "$sample" ${D}${PTEST_PATH}/
-            fi
-        done
-    fi
-
-    if ${@bb.utils.contains('PACKAGECONFIG', 'rust', 'true', 'false', d)}; then
-        if [ -d "${B}/target/${CARGO_TARGET_SUBDIR}/examples" ]; then
-            for example in ${B}/target/${CARGO_TARGET_SUBDIR}/examples/*; do
-                if [ -f "$example" ] && [ -x "$example" ] && [ ! "${example##*.}" = "d" ]; then
-                    case "$(basename $example)" in
-                        *-[0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f])
-                            continue
-                            ;;
-                    esac
-                    install -m 0755 "$example" ${D}${PTEST_PATH}/rust_$(basename $example)
+    if ${@bb.utils.contains('PACKAGECONFIG', 'samples', 'true', 'false', d)}; then
+        if [ -d "${B}/bin" ]; then
+            for sample in ${B}/bin/*; do
+                if [ -f "$sample" ]; then
+                    install -m 0755 "$sample" ${D}${PTEST_PATH}/
                 fi
             done
+        fi
+
+        if ${@bb.utils.contains('PACKAGECONFIG', 'rust', 'true', 'false', d)}; then
+            if [ -d "${B}/target/${CARGO_TARGET_SUBDIR}/examples" ]; then
+                for example in ${B}/target/${CARGO_TARGET_SUBDIR}/examples/*; do
+                    if [ -f "$example" ] && [ -x "$example" ] && [ ! "${example##*.}" = "d" ]; then
+                        case "$(basename $example)" in
+                            *-[0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f])
+                                continue
+                                ;;
+                        esac
+                        install -m 0755 "$example" ${D}${PTEST_PATH}/rust_$(basename $example)
+                    fi
+                done
+            fi
         fi
     fi
 
     rm -rf ${D}${PTEST_PATH}/.debug
 }
 
-PACKAGES = "${PN} ${PN}-dev ${PN}-staticdev ${PN}-doc ${PN}-ptest ${PN}-dbg"
+PACKAGES = "${PN} ${PN}-samples ${PN}-dev ${PN}-staticdev ${PN}-doc ${PN}-ptest ${PN}-dbg"
 
-FILES:${PN} = " \
-    ${libdir}/libgg-sdk.so* \
-    ${bindir}/* \
+FILES:${PN} = ""
+ALLOW_EMPTY:${PN} = "1"
+
+FILES:${PN}-samples = " \
+    ${bindir}/sample_* \
+    ${bindir}/rust_* \
+    ${datadir}/greengrass/component-recipes/* \
 "
 
 FILES:${PN}-dev = " \


### PR DESCRIPTION
Make sample binary compilation opt-in via `PACKAGECONFIG[samples]`. Default is off.

To enable:
```
PACKAGECONFIG:append:pn-aws-greengrass-component-sdk = " samples"
```

When enabled:
- Builds C/C++ samples via CMake (BUILD_SAMPLES=ON)
- Builds Rust examples via cargo --examples
- Installs sample binaries to `/usr/bin/`
- Installs upstream component recipe JSONs to `/usr/share/greengrass/component-recipes/`
- Packages as `aws-greengrass-component-sdk-samples`

The component recipe JSONs serve as deployment reference templates that users customize with their S3 bucket and thing group.

NOTE: Yocto SDK (populate_sdk) integration needs separate verification.