### PR TITLE
[Backport kirkstone-next] 2026-04-17_01-42-02_master-next_aws-crt-python

### DIFF
--- a/recipes-sdk/aws-crt-python/aws-crt-python_0.32.1.bb
+++ b/recipes-sdk/aws-crt-python/aws-crt-python_0.32.1.bb
@@ -38,7 +38,7 @@ SRC_URI = "\
     file://run-ptest \
     "
 
-SRCREV = "d0ac2a91e041736ec07dc2a0e8ba372eaccabfdd"
+SRCREV = "eba5fc17a5984e867d1f9d28f2833bc22c2dde70"
 UPSTREAM_CHECK_GITTAGREGEX = "v(?P<pver>.*)"
 
 S = "${WORKDIR}/git"

--- a/recipes-sdk/aws-crt-python/files/001-fix-cross-compilation-support.patch
+++ b/recipes-sdk/aws-crt-python/files/001-fix-cross-compilation-support.patch
@@ -1,4 +1,4 @@
-From 37f16a53c356482102e9d339aef566990ed04c0d Mon Sep 17 00:00:00 2001
+From 82784e747b107535ebd5339cdd3e7b03731928f2 Mon Sep 17 00:00:00 2001
 From: AWS Meta Layer <meta-aws@amazon.com>
 Date: Thu, 24 Jul 2025 12:00:00 +0000
 Subject: [PATCH] Fix cross-compilation support


### PR DESCRIPTION
# Description
Backport of #15481 to `kirkstone-next`.