### PR TITLE
[Backport whinlatter-next] 2026-04-17_01-42-02_master-next_python3-botocore

### DIFF
--- a/recipes-devtools/python/python3-botocore_1.42.90.bb
+++ b/recipes-devtools/python/python3-botocore_1.42.90.bb
@@ -12,7 +12,7 @@ SRC_URI = "\
     file://python_dependency_test.py \
     "
 
-SRCREV = "9b76a624ae6311605797bc0b4cdc7c3e064c1593"
+SRCREV = "8cde7cabb8dd585d43dd8f2ec6a11fbaa3f2f1bc"
 
 inherit setuptools3 ptest
 


### PR DESCRIPTION
# Description
Backport of #15482 to `whinlatter-next`.