### PR TITLE
aws-greengrass-component-sdk: rename recipe to match version 1.0.1

### DIFF
--- a/recipes-sdk/aws-greengrass-component-sdk/aws-greengrass-component-sdk_1.0.1.bb
+++ b/recipes-sdk/aws-greengrass-component-sdk/aws-greengrass-component-sdk_1.0.1.bb
@@ -6,8 +6,6 @@ HOMEPAGE = "https://github.com/aws-greengrass/aws-greengrass-component-sdk"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=34400b68072d710fecd0a2940a0d1658"
 
-PV = "1.0.1"
-
 SRCREV = "1e2495b4e7a616d35b374bba4635a95dbb678b95"
 SRC_URI = "git://github.com/aws-greengrass/aws-greengrass-component-sdk.git;protocol=https;branch=main \
            file://0001-Add-timespec-blocklist-and-portable-struct-for-cross.patch \


### PR DESCRIPTION
Fixes #15497

## Changes

- Rename recipe file from `_0.4.bb` to `_1.0.1.bb`
- Remove explicit `PV = "1.0.1"` (version now derived from filename per Yocto convention)

## Context

The automated version upgrade PR #15416 updated the recipe contents to version 1.0.1 but did not rename the file. Reported by @ChenQi1989.

## Testing

No functional change — the recipe already built as version 1.0.1 due to the explicit PV override. This is a naming correction only.