### PR TITLE
ci: pr-cve-check only scan changed recipes

### DIFF
--- a/.github/workflows/pr-cve-check.yml
+++ b/.github/workflows/pr-cve-check.yml
@@ -12,7 +12,51 @@ permissions:
   contents: read
 
 jobs:
+  changed:
+    name: Get changed recipes
+    runs-on: ubuntu-latest
+    outputs:
+      recipes: ${{ steps.recipes.outputs.recipes }}
+    steps:
+    - uses: actions/checkout@v4
+    - name: Get changed recipe names
+      id: recipes
+      env:
+        BASE_REF: ${{ github.base_ref }}
+        HEAD_REF: ${{ github.head_ref }}
+        HEAD_REPO_URL: ${{ github.event.pull_request.head.repo.clone_url }}
+        HEAD_REPO_NAME: ${{ github.event.pull_request.head.repo.full_name }}
+        REPOSITORY: ${{ github.repository }}
+        HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+      run: |
+        if [ -n "$BASE_REF" ] && [ -n "$HEAD_REF" ] && [ -n "$HEAD_SHA" ]; then
+          git fetch origin "$BASE_REF:$BASE_REF"
+
+          if [ "$HEAD_REPO_NAME" != "$REPOSITORY" ] && [ -n "$HEAD_REPO_URL" ]; then
+            git remote add fork "$HEAD_REPO_URL"
+            git fetch fork "$HEAD_REF"
+          else
+            git fetch origin "$HEAD_REF:$HEAD_REF"
+          fi
+
+          FORK_POINT=$(git merge-base "$BASE_REF" "$HEAD_SHA")
+          DIFF=$(git diff --name-only --diff-filter=d "$FORK_POINT" "$HEAD_SHA")
+        else
+          DIFF=""
+        fi
+
+        RECIPES=$(echo "$DIFF" | grep '\.bb$\|\.inc$' | sed 's!.*/!!' | sed 's!\.bb$!!' | sed 's!\.inc$!!' | sed 's!_.*!!' | sort | uniq | tr '\n' ' ')
+
+        if [ -z "$RECIPES" ]; then
+          echo "No changed recipes found"
+        else
+          echo "Changed recipes: $RECIPES"
+        fi
+        echo "recipes=$RECIPES" >> $GITHUB_OUTPUT
+
   pr-cve-check:
+    needs: changed
+    if: needs.changed.outputs.recipes != ''
     runs-on: ubuntu-22.04
     steps:
       - name: Install required packages to run cve-check
@@ -40,10 +84,13 @@ jobs:
             ~/bitbake-builds/poky-without-meta-aws-poky-distro_poky-altcfg-machine_qemux86-64/build/downloads
           key: cache-cve-sstate-downloads
       - name: Run CVE check
+        env:
+          RECIPES: ${{ needs.changed.outputs.recipes }}
         run: |
           source ~/bitbake-builds/poky-without-meta-aws-poky-distro_poky-altcfg-machine_qemux86-64/build/init-build-env
           echo 'INHERIT += "create-spdx-3.0 sbom-cve-check-recipe"' >> conf/local.conf
-          bitbake -c sbom_cve_check_recipe `find ${{ github.workspace }}/meta-aws -name *.bb -type f  | sed 's!.*/!!' | sed 's!.bb!!' | sed 's!_.*!!' | sort | uniq | sed -z 's/\n/ /g'`
+          echo "Running CVE check on changed recipes: $RECIPES"
+          bitbake -c sbom_cve_check_recipe $RECIPES
       - name: Collect CVE results
         if: '!cancelled()'
         run: |


### PR DESCRIPTION
## Problem

The `pr-cve-check` workflow runs CVE checks against **every** `.bb` recipe in the layer on every PR, regardless of what changed. This causes very long run times (50+ minutes and counting).

## Fix

Add a `changed` job (mirroring the `build-test-recipe` pattern) that:
1. Detects which `.bb`/`.inc` files were modified in the PR
2. Extracts recipe names from the changed files
3. Only runs CVE checks on those specific recipes
4. Skips the heavy CVE check job entirely if no recipe files changed

## Testing

The diff detection logic mirrors the proven pattern from `build-test-recipe.yml`.