### PR TITLE
[Backport scarthgap-next] 2026-04-21_01-42-10_master-next_aws-cli

### DIFF
--- a/recipes-support/aws-cli/aws-cli_1.44.82.bb
+++ b/recipes-support/aws-cli/aws-cli_1.44.82.bb
@@ -9,7 +9,7 @@ SRC_URI = "\
     file://run-ptest \
 "
 
-SRCREV = "1f06c52cd7a6c5f420ec8898c4ec61baa1f4e766"
+SRCREV = "6b2ccd7c7efd2bb706a2c3ae87046859fd067b1f"
 
 # version 2.x has got library link issues - so stick to version 1.x for now
 UPSTREAM_CHECK_GITTAGREGEX = "(?P<pver>1\.\d+(\.\d+)+)"


### PR DESCRIPTION
# Description
Backport of #15505 to `scarthgap-next`.