### PR TITLE
[Backport whinlatter-next] 2026-04-21_01-42-10_master-next_aws-sdk-cpp

### DIFF
--- a/recipes-sdk/aws-sdk-cpp/aws-sdk-cpp_1.11.793.bb
+++ b/recipes-sdk/aws-sdk-cpp/aws-sdk-cpp_1.11.793.bb
@@ -19,7 +19,7 @@ SRC_URI = "\
     file://ptest_result.py \
     "
 
-SRCREV = "6043165eef423e6a70d607e7878d99b4b6e49b9c"
+SRCREV = "7fe885d2fd5fae774f0e5f0821b76d0faea20c69"
 
 inherit cmake ptest pkgconfig
 


### PR DESCRIPTION
# Description
Backport of #15503 to `whinlatter-next`.