### PR TITLE
ci: use REVIEWER_TOKEN instead of deprecated BOT2_CREDENTIAL

### DIFF
--- a/.github/workflows/auto-approve-and-enable-auto-merge.yml
+++ b/.github/workflows/auto-approve-and-enable-auto-merge.yml
@@ -8,6 +8,7 @@ on:
 
 permissions: {}
 
+permissions: {}
 jobs:
   auto-approve-and-merge:
     runs-on: ubuntu-22.04
@@ -21,17 +22,17 @@ jobs:
         uses: docker://agilepathway/pull-request-label-checker:v1.6.55
         with:
           any_of: version-upgrade
-          repo_token: ${{ secrets.BOT2_CREDENTIAL }}
+          repo_token: ${{ secrets.REVIEWER_TOKEN }}
 
       - name: Auto approve
         uses: juliangruber/approve-pull-request-action@v2.0.6
         with:
-          github-token: ${{ secrets.BOT2_CREDENTIAL }}
+          github-token: ${{ secrets.REVIEWER_TOKEN }}
           number: ${{ github.event.pull_request.number }}
 
       - name: Enable Pull Request Automerge
         uses: peter-evans/enable-pull-request-automerge@v3.0.0
         with:
-          token: ${{ secrets.BOT2_CREDENTIAL }}
+          token: ${{ secrets.REVIEWER_TOKEN }}
           pull-request-number: ${{ github.event.pull_request.number }}
           merge-method: rebase


### PR DESCRIPTION
The auto-approve workflow uses `secrets.BOT2_CREDENTIAL` which belongs to the deprecated `aws-iot-embedded-linux-ci2` account. Switch to `secrets.REVIEWER_TOKEN` (meta-aws-reviewer) to match master.