### PR TITLE
[Backport kirkstone-next] 2026-04-22_01-43-11_master-next_corretto-11-bin

### DIFF
--- a/recipes-devtools/amazon-corretto/corretto-11-bin_11.0.31.11.1.bb
+++ b/recipes-devtools/amazon-corretto/corretto-11-bin_11.0.31.11.1.bb
@@ -16,10 +16,10 @@ BASE:x86 = "amazon-corretto-${PV}-linux-x86"
 SRC_URI:x86 = "https://corretto.aws/downloads/resources/${PV}/amazon-corretto-${PV}-linux-x86.tar.gz;name=x86"
 
 # you can find checksum here: https://github.com/corretto/corretto-11/releases  since devtool upgrade can only do one arch atm.
-SRC_URI[x86-64.sha256sum] = "c4843d67b7c8f5f8ffbab43b90b8595243f48aa545b713e30e1d29a5f23b364c"
-SRC_URI[aarch64.sha256sum] = "16f7d0d23a232cd754f7d2e511efa85b369af55ef1eb0e4718e9e41aa9991ef6"
-SRC_URI[arm.sha256sum] = "8eddf8eee5626420ed871c546e533bbc79fba81413762655c3d3255648f6121e"
-SRC_URI[x86.sha256sum] = "a1cf80b537539cfe0186aecb7852602a742d6e2ca60815a39d88dda6035c4413"
+SRC_URI[x86-64.sha256sum] = "70f6ff3668f27d1052f9e26c7a00d601774a556a49e6e9e7faa9d510ae1d0dbe"
+SRC_URI[aarch64.sha256sum] = "8ee5fba821463363dc76a18049e338d12c74752430a743aa405af126a62218da"
+SRC_URI[arm.sha256sum] = "2a2253ec40e3c275fa29687382f7782ff0a421114385ec34a2df2e32fd17d634"
+SRC_URI[x86.sha256sum] = "7423a636ca1000688e874cdb961a507012f6eacb9cf42afc1273a7f279c61ada"
 
 COMPATIBLE_MACHINE:armv7a = "(.*)"
 COMPATIBLE_MACHINE:armv7ve = "(.*)"


### PR DESCRIPTION
# Description
Backport of #15526 to `kirkstone-next`.