### PR TITLE
Release: merge kirkstone-next to kirkstone (2026-04-22)

### DIFF
--- a/.github/workflows/auto-approve-and-enable-auto-merge.yml
+++ b/.github/workflows/auto-approve-and-enable-auto-merge.yml
@@ -6,6 +6,7 @@ on:
     branches:
       - '*-next'
 
+permissions: {}
 jobs:
   auto-approve-and-merge:
     runs-on: ubuntu-22.04
@@ -19,17 +20,17 @@ jobs:
         uses: docker://agilepathway/pull-request-label-checker:v1.6.55
         with:
           any_of: version-upgrade
-          repo_token: ${{ secrets.BOT2_CREDENTIAL }}
+          repo_token: ${{ secrets.REVIEWER_TOKEN }}
 
       - name: Auto approve
         uses: juliangruber/approve-pull-request-action@v2.0.6
         with:
-          github-token: ${{ secrets.BOT2_CREDENTIAL }}
+          github-token: ${{ secrets.REVIEWER_TOKEN }}
           number: ${{ github.event.pull_request.number }}
 
       - name: Enable Pull Request Automerge
         uses: peter-evans/enable-pull-request-automerge@v3.0.0
         with:
-          token: ${{ secrets.BOT2_CREDENTIAL }}
+          token: ${{ secrets.REVIEWER_TOKEN }}
           pull-request-number: ${{ github.event.pull_request.number }}
           merge-method: rebase

--- a/recipes-devtools/amazon-corretto/corretto-11-bin_11.0.31.11.1.bb
+++ b/recipes-devtools/amazon-corretto/corretto-11-bin_11.0.31.11.1.bb
@@ -16,10 +16,10 @@ BASE:x86 = "amazon-corretto-${PV}-linux-x86"
 SRC_URI:x86 = "https://corretto.aws/downloads/resources/${PV}/amazon-corretto-${PV}-linux-x86.tar.gz;name=x86"
 
 # you can find checksum here: https://github.com/corretto/corretto-11/releases  since devtool upgrade can only do one arch atm.
-SRC_URI[x86-64.sha256sum] = "c4843d67b7c8f5f8ffbab43b90b8595243f48aa545b713e30e1d29a5f23b364c"
-SRC_URI[aarch64.sha256sum] = "16f7d0d23a232cd754f7d2e511efa85b369af55ef1eb0e4718e9e41aa9991ef6"
-SRC_URI[arm.sha256sum] = "8eddf8eee5626420ed871c546e533bbc79fba81413762655c3d3255648f6121e"
-SRC_URI[x86.sha256sum] = "a1cf80b537539cfe0186aecb7852602a742d6e2ca60815a39d88dda6035c4413"
+SRC_URI[x86-64.sha256sum] = "70f6ff3668f27d1052f9e26c7a00d601774a556a49e6e9e7faa9d510ae1d0dbe"
+SRC_URI[aarch64.sha256sum] = "8ee5fba821463363dc76a18049e338d12c74752430a743aa405af126a62218da"
+SRC_URI[arm.sha256sum] = "2a2253ec40e3c275fa29687382f7782ff0a421114385ec34a2df2e32fd17d634"
+SRC_URI[x86.sha256sum] = "7423a636ca1000688e874cdb961a507012f6eacb9cf42afc1273a7f279c61ada"
 
 COMPATIBLE_MACHINE:armv7a = "(.*)"
 COMPATIBLE_MACHINE:armv7ve = "(.*)"

--- a/recipes-devtools/amazon-corretto/corretto-17-bin_17.0.19.10.1.bb
+++ b/recipes-devtools/amazon-corretto/corretto-17-bin_17.0.19.10.1.bb
@@ -8,8 +8,8 @@ SRC_URI:append:aarch64 = " https://corretto.aws/downloads/resources/${PV}/amazon
 SRC_URI:append:x86-64 = " https://corretto.aws/downloads/resources/${PV}/amazon-corretto-${PV}-linux-x64.tar.gz;name=x86-64"
 
 # you can find checksum here: https://github.com/corretto/corretto-17/releases since devtool upgrade can only do one arch atm.
-SRC_URI[x86-64.sha256sum] = "87411b0792a0f2b8e0fef1178c012bfe338b5f5fedb8c1e7985213cb7f790428"
-SRC_URI[aarch64.sha256sum] = "dd6da079227bcc69894d01f256fe3397485d312122c9c7c14e43784cb5983924"
+SRC_URI[x86-64.sha256sum] = "d0f1b880445691425511c3aa62cb89889f03a71c2a43597a3df174fc01d3f3a0"
+SRC_URI[aarch64.sha256sum] = "1b9f75b5a2f740ab3305577858e2fc87dad827b60678d4573234d6357be59fa8"
 
 # also available in master (not kirkstone) in classes-recipe: github-releases
 UPSTREAM_CHECK_REGEX ?= "releases/tag/v?(?P<pver>\d+(\.\d+)+)"

--- a/recipes-devtools/amazon-corretto/corretto-21-bin_21.0.11.10.1.bb
+++ b/recipes-devtools/amazon-corretto/corretto-21-bin_21.0.11.10.1.bb
@@ -8,8 +8,8 @@ SRC_URI:append:aarch64 = " https://corretto.aws/downloads/resources/${PV}/amazon
 SRC_URI:append:x86-64 = " https://corretto.aws/downloads/resources/${PV}/amazon-corretto-${PV}-linux-x64.tar.gz;name=x86-64"
 
 # you can find checksum here: https://github.com/corretto/corretto-21/releases since devtool upgrade can only do one arch atm.
-SRC_URI[x86-64.sha256sum] = "770f85bf2bbbb99dbe0248409e9424755d94dd6caf38fb9c1ef6434c4f650d48"
-SRC_URI[aarch64.sha256sum] = "f1e55ad92fcc8a9d15ea4ee3d2e395c5e649ba1b29e403be5b5580a62474bd27"
+SRC_URI[x86-64.sha256sum] = "5b4dc8817df13f88f9bfc434e5d018adb535889ff2fe0ccf758bcebcc216f394"
+SRC_URI[aarch64.sha256sum] = "bc419602d71d819bce147239fbdc48bfbc900fa1d60693537fb9a22bd6b86475"
 
 # also available in master (not kirkstone) in classes-recipe: github-releases
 UPSTREAM_CHECK_REGEX ?= "releases/tag/v?(?P<pver>\d+(\.\d+)+)"

--- a/recipes-devtools/amazon-corretto/corretto-25-bin_25.0.3.9.1.bb
+++ b/recipes-devtools/amazon-corretto/corretto-25-bin_25.0.3.9.1.bb
@@ -8,8 +8,8 @@ SRC_URI:append:aarch64 = " https://corretto.aws/downloads/resources/${PV}/amazon
 SRC_URI:append:x86-64 = " https://corretto.aws/downloads/resources/${PV}/amazon-corretto-${PV}-linux-x64.tar.gz;name=x86-64"
 
 # you can find checksum here: https://github.com/corretto/corretto-25/releases since devtool upgrade can only do one arch atm.
-SRC_URI[x86-64.sha256sum] = "313e9921e573cf28a4876ab039d56b3a142e7b1b1e847b0dddd170b8dee80387"
-SRC_URI[aarch64.sha256sum] = "6e966b3c3609c25f40e29d6cdb81f83f52a3723c8196a4c38e0d5d03e463c4e5"
+SRC_URI[x86-64.sha256sum] = "00486fa402136f8d40512b101c645dd4db9be2b5535171530ad241cd96c1223d"
+SRC_URI[aarch64.sha256sum] = "8b1fd78bbd1f188f3884f580be674727174635252c0d4d6dfa7cd15de51879ce"
 
 # also available in master (not kirkstone) in classes-recipe: github-releases
 UPSTREAM_CHECK_REGEX ?= "releases/tag/v?(?P<pver>\d+(\.\d+)+)"

--- a/recipes-sdk/aws-crt-python/aws-crt-python_0.32.1.bb
+++ b/recipes-sdk/aws-crt-python/aws-crt-python_0.32.1.bb
@@ -38,7 +38,7 @@ SRC_URI = "\
     file://run-ptest \
     "
 
-SRCREV = "d0ac2a91e041736ec07dc2a0e8ba372eaccabfdd"
+SRCREV = "eba5fc17a5984e867d1f9d28f2833bc22c2dde70"
 UPSTREAM_CHECK_GITTAGREGEX = "v(?P<pver>.*)"
 
 S = "${WORKDIR}/git"

--- a/recipes-sdk/aws-crt-python/files/001-fix-cross-compilation-support.patch
+++ b/recipes-sdk/aws-crt-python/files/001-fix-cross-compilation-support.patch
@@ -1,4 +1,4 @@
-From 37f16a53c356482102e9d339aef566990ed04c0d Mon Sep 17 00:00:00 2001
+From 82784e747b107535ebd5339cdd3e7b03731928f2 Mon Sep 17 00:00:00 2001
 From: AWS Meta Layer <meta-aws@amazon.com>
 Date: Thu, 24 Jul 2025 12:00:00 +0000
 Subject: [PATCH] Fix cross-compilation support

--- a/recipes-sdk/aws-iot-device-sdk-python-v2/aws-iot-device-sdk-python-v2_1.29.0.bb
+++ b/recipes-sdk/aws-iot-device-sdk-python-v2/aws-iot-device-sdk-python-v2_1.29.0.bb
@@ -8,7 +8,7 @@ SRC_URI = "\
         git://github.com/aws/aws-iot-device-sdk-python-v2.git;protocol=https;branch=${BRANCH} \
         file://run-ptest\
         "
-SRCREV = "cd5115cdd1aa4c24b75af354fbfae56dd1e4b0bd"
+SRCREV = "bb7ceeaaba160e9a1efff7eea7c771fec3006c4b"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Weekly release: `kirkstone-next` → `kirkstone`