### PR TITLE
ci: auto-approve exits gracefully when version-upgrade label missing

### DIFF
--- a/.github/workflows/auto-approve-and-enable-auto-merge.yml
+++ b/.github/workflows/auto-approve-and-enable-auto-merge.yml
@@ -6,30 +6,36 @@ on:
     branches:
       - '*-next'
 
-permissions: {}
+permissions:
+  pull-requests: read
 
 jobs:
   auto-approve-and-merge:
     runs-on: ubuntu-22.04
     name: auto approve and enable auto-merge
     steps:
-      - name: Sleep (give PR time to create labels)
-        run: sleep 1m
-        shell: bash
-
-      - name: Check label after delay
-        uses: docker://agilepathway/pull-request-label-checker:v1.6.55
-        with:
-          any_of: version-upgrade
-          repo_token: ${{ secrets.REVIEWER_TOKEN }}
+      - name: Check for version-upgrade label
+        id: check-label
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          labels=$(gh api repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels --jq '.[].name' 2>/dev/null || echo "")
+          if echo "$labels" | grep -q "^version-upgrade$"; then
+            echo "found=true" >> $GITHUB_OUTPUT
+          else
+            echo "PR does not have version-upgrade label, skipping."
+            echo "found=false" >> $GITHUB_OUTPUT
+          fi
 
       - name: Auto approve
+        if: steps.check-label.outputs.found == 'true'
         uses: juliangruber/approve-pull-request-action@v2.0.6
         with:
           github-token: ${{ secrets.REVIEWER_TOKEN }}
           number: ${{ github.event.pull_request.number }}
 
       - name: Enable Pull Request Automerge
+        if: steps.check-label.outputs.found == 'true'
         uses: peter-evans/enable-pull-request-automerge@v3.0.0
         with:
           token: ${{ secrets.REVIEWER_TOKEN }}


### PR DESCRIPTION
The auto-approve workflow fails with 401 on fork PRs because secrets aren't available, and shows a red X on every non-bot PR even when it's not applicable.

Changes:
- Check for `version-upgrade` label using `github.token` (always available) instead of Docker action with `REVIEWER_TOKEN`
- Skip approve/merge steps if label not found (green check instead of red X)
- Remove the 1-minute sleep delay (label check is now direct)
- Only use `REVIEWER_TOKEN` for the approve and automerge steps where it's actually needed