### PR TITLE
ci: fix COMPATIBLE_MACHINE filtering — eliminates false CI failures

### DIFF
--- a/.github/workflows/build-test-recipe.yml
+++ b/.github/workflows/build-test-recipe.yml
@@ -160,7 +160,7 @@ jobs:
           export RECIPES=$( echo "${{ needs.changed.outputs.diff }}" | tr ' ' '\n' | grep '\.bb.*$' | sed 's!.*/!!' | sed 's!.bb!!' | sed 's!_.*!!' | sort | uniq | sed -z $'s/\\\n/ /g')
           if [ "" == "$RECIPES" ]; then
             echo "No changed recipes, adding everything with a ptest to test, build"
-            THINGS_TO_EXCLUDE="! -name aws-lc* ! -name neo-ai-tv* ! -name corretto-17-bin* ! -name corretto-21-bin* ! -name corretto-8-bin* ! -name corretto-25-bin* ! -name firecracker-bin* ! -name jailer-bin* ! -name amazon-kvs-producer-sdk-c* ! -name  aws-cli-v2* ! -name  aws-iot-device-sdk-embedded-c* ! -name greengrass_* ! -name greengrass-bin* "
+            THINGS_TO_EXCLUDE="! -name aws-lc* ! -name neo-ai-tv* ! -name amazon-kvs-producer-sdk-c* ! -name aws-cli-v2* ! -name aws-iot-device-sdk-embedded-c* ! -name greengrass_* ! -name greengrass-bin* "
             export RECIPES=$(find meta-aws/ -name *.bb -type f \( ${THINGS_TO_EXCLUDE} \) -print | xargs grep -l 'inherit.*ptest.*'| sed 's!.*/!!' | sed 's!.bb!!' | sed 's!_.*!!' | sort | uniq | sed -z $'s/\\\n/ /g')
             echo THINGS_TO_EXCLUDE: $THINGS_TO_EXCLUDE
           fi
@@ -181,13 +181,13 @@ jobs:
               SKIP_RECIPE=true
             fi
 
-            # Check for default COMPATIBLE_MACHINE = "null" without override for this arch
-            if echo "$RECIPE_FILES" | xargs grep -q "^COMPATIBLE_MACHINE[[:space:]]*=[[:space:]]*\"null\"" 2>/dev/null; then
+            # Check for default COMPATIBLE_MACHINE = "null" or "(^$)" without override for this arch
+            if echo "$RECIPE_FILES" | xargs grep -qE 'COMPATIBLE_MACHINE[[:space:]]*=[[:space:]]*"(null|\(\^)' 2>/dev/null; then
               # Check if there's an override for this specific architecture
               case "${{ matrix.machine }}" in
                 qemuarm)
-                  if ! echo "$RECIPE_FILES" | xargs grep -q "COMPATIBLE_MACHINE:armv7[av][[:space:]]*=[[:space:]]*\"(.*)\"" 2>/dev/null; then
-                    echo "Skipping $recipe: COMPATIBLE_MACHINE = null (no armv7 override)"
+                  if ! echo "$RECIPE_FILES" | xargs grep -qE "COMPATIBLE_MACHINE:(arm|armv7[ave]*)[[:space:]]*=[[:space:]]*\"\(\.?\*\)\"" 2>/dev/null; then
+                    echo "Skipping $recipe: COMPATIBLE_MACHINE default blocks, no arm/armv7 override"
                     SKIP_RECIPE=true
                   fi
                   ;;
@@ -215,8 +215,20 @@ jobs:
             # Check explicit COMPATIBLE_MACHINE:$ARCH = "null"
             case "${{ matrix.machine }}" in
               qemuarm)
-                if echo "$RECIPE_FILES" | xargs grep -q "COMPATIBLE_MACHINE:armv7[av][[:space:]]*=[[:space:]]*\"null\"" 2>/dev/null; then
-                  echo "Skipping $recipe: COMPATIBLE_MACHINE:armv7 = null"
+                if echo "$RECIPE_FILES" | xargs grep -qE "COMPATIBLE_MACHINE:(arm|armv7[ave]*)[[:space:]]*=[[:space:]]*\"null\"" 2>/dev/null; then
+                  echo "Skipping $recipe: COMPATIBLE_MACHINE:arm/armv7 = null"
+                  SKIP_RECIPE=true
+                fi
+                ;;
+              qemuarm64)
+                if echo "$RECIPE_FILES" | xargs grep -q "COMPATIBLE_MACHINE:aarch64[[:space:]]*=[[:space:]]*\"null\"" 2>/dev/null; then
+                  echo "Skipping $recipe: COMPATIBLE_MACHINE:aarch64 = null"
+                  SKIP_RECIPE=true
+                fi
+                ;;
+              qemux86-64)
+                if echo "$RECIPE_FILES" | xargs grep -q "COMPATIBLE_MACHINE:x86-64[[:space:]]*=[[:space:]]*\"null\"" 2>/dev/null; then
+                  echo "Skipping $recipe: COMPATIBLE_MACHINE:x86-64 = null"
                   SKIP_RECIPE=true
                 fi
                 ;;


### PR DESCRIPTION
Fixes #15547

## Problem

The COMPATIBLE_MACHINE filter in build-test-recipe had three bugs causing false CI failures on every release cycle.

## Changes

1. **Recognize `(^$)` as blocking default** — `amazon-cloudwatch-agent` uses this pattern, filter only checked for `"null"`
2. **Fix qemuarm override check** — now checks `:arm`, `:armv7a`, `:armv7ve` (was only checking `armv7[av]`)
3. **Add missing arch-specific null checks** for qemuarm64 and qemux86-64
4. **Remove hardcoded exclusions** for corretto-\*/firecracker-bin/jailer-bin from THINGS_TO_EXCLUDE — the filter handles them properly now

## Proof

Tested locally against all recipes for all four qemu machines. Results match expected behavior:

| Recipe | qemuarm | qemuarm64 | qemux86-64 | qemuriscv64 |
|--------|---------|-----------|------------|-------------|
| corretto-8-bin | SKIP ✅ | BUILD ✅ | BUILD ✅ | SKIP ✅ |
| corretto-11-bin | BUILD ✅ | BUILD ✅ | BUILD ✅ | SKIP ✅ |
| corretto-17-bin | SKIP ✅ | BUILD ✅ | BUILD ✅ | SKIP ✅ |
| amazon-cloudwatch-agent | SKIP ✅ | BUILD ✅ | BUILD ✅ | SKIP ✅ |
| firecracker-bin | SKIP ✅ | BUILD ✅ | BUILD ✅ | SKIP ✅ |
| aws-sdk-cpp | BUILD ✅ | BUILD ✅ | BUILD ✅ | BUILD ✅ |