### PR TITLE
ci: remove kirkstone references — Yocto 4.0 LTS EOL

### DIFF
--- a/.github/workflows/build-test-recipe.yml
+++ b/.github/workflows/build-test-recipe.yml
@@ -104,9 +104,6 @@ jobs:
           # See GitHub issue for configuration management improvements
           # Map Yocto release to BitBake version
           # case "${{ needs.changed.outputs.release }}" in
-          #   kirkstone)
-          #     BITBAKE_BRANCH="2.0"
-          #     ;;
           #   scarthgap)
           #     BITBAKE_BRANCH="2.8"
           #     ;;


### PR DESCRIPTION
Partial fix for #15552

## Changes

### In this PR:
- Remove kirkstone from BitBake version mapping comment in build-test-recipe.yml

### Done via API (already applied):
- ✅ Removed kirkstone-next from `-next staging branches` ruleset
- ✅ Deleted `kirkstone-next` specific ruleset

### Already done (prior work):
- ✅ Removed from auto-backport.yml targets
- ✅ Removed from build-test-all-branches.yml
- ✅ Main README updated in PR #15564

### Remaining (tracked in #15552):
- [ ] Add deprecation notice to kirkstone branch README (requires direct branch push)
- [ ] Archive branches in October 2026 (EOL + 6 months)