### PR TITLE
ci: fix COMPATIBLE_MACHINE filtering + corretto mutual exclusion

### DIFF
--- a/.github/workflows/build-test-recipe.yml
+++ b/.github/workflows/build-test-recipe.yml
@@ -160,7 +160,7 @@ jobs:
           export RECIPES=$( echo "${{ needs.changed.outputs.diff }}" | tr ' ' '\n' | grep '\.bb.*$' | sed 's!.*/!!' | sed 's!.bb!!' | sed 's!_.*!!' | sort | uniq | sed -z $'s/\\\n/ /g')
           if [ "" == "$RECIPES" ]; then
             echo "No changed recipes, adding everything with a ptest to test, build"
-            THINGS_TO_EXCLUDE="! -name aws-lc* ! -name neo-ai-tv* ! -name corretto-17-bin* ! -name corretto-21-bin* ! -name corretto-8-bin* ! -name corretto-25-bin* ! -name firecracker-bin* ! -name jailer-bin* ! -name amazon-kvs-producer-sdk-c* ! -name  aws-cli-v2* ! -name  aws-iot-device-sdk-embedded-c* ! -name greengrass_* ! -name greengrass-bin* "
+            THINGS_TO_EXCLUDE="! -name aws-lc* ! -name neo-ai-tv* ! -name amazon-kvs-producer-sdk-c* ! -name aws-cli-v2* ! -name aws-iot-device-sdk-embedded-c* ! -name greengrass_* ! -name greengrass-bin* "
             export RECIPES=$(find meta-aws/ -name *.bb -type f \( ${THINGS_TO_EXCLUDE} \) -print | xargs grep -l 'inherit.*ptest.*'| sed 's!.*/!!' | sed 's!.bb!!' | sed 's!_.*!!' | sort | uniq | sed -z $'s/\\\n/ /g')
             echo THINGS_TO_EXCLUDE: $THINGS_TO_EXCLUDE
           fi
@@ -181,13 +181,13 @@ jobs:
               SKIP_RECIPE=true
             fi
 
-            # Check for default COMPATIBLE_MACHINE = "null" without override for this arch
-            if echo "$RECIPE_FILES" | xargs grep -q "^COMPATIBLE_MACHINE[[:space:]]*=[[:space:]]*\"null\"" 2>/dev/null; then
+            # Check for default COMPATIBLE_MACHINE = "null" or "(^$)" without override for this arch
+            if echo "$RECIPE_FILES" | xargs grep -qE 'COMPATIBLE_MACHINE[[:space:]]*=[[:space:]]*"(null|\(\^)' 2>/dev/null; then
               # Check if there's an override for this specific architecture
               case "${{ matrix.machine }}" in
                 qemuarm)
-                  if ! echo "$RECIPE_FILES" | xargs grep -q "COMPATIBLE_MACHINE:armv7[av][[:space:]]*=[[:space:]]*\"(.*)\"" 2>/dev/null; then
-                    echo "Skipping $recipe: COMPATIBLE_MACHINE = null (no armv7 override)"
+                  if ! echo "$RECIPE_FILES" | xargs grep -qE "COMPATIBLE_MACHINE:(arm|armv7[ave]*)[[:space:]]*=[[:space:]]*\"\(.\?\*\)\"" 2>/dev/null; then
+                    echo "Skipping $recipe: COMPATIBLE_MACHINE default blocks, no arm/armv7 override"
                     SKIP_RECIPE=true
                   fi
                   ;;
@@ -238,6 +238,13 @@ jobs:
           if echo "$RECIPES" | grep -qw "aws-cli-v2" && echo "$RECIPES" | grep -qw "aws-cli"; then
             RECIPES=$(echo "$RECIPES" | tr ' ' '\n' | grep -v '^aws-cli$' | tr '\n' ' ')
             echo "Excluded aws-cli (v1) due to conflict with aws-cli-v2"
+          fi
+
+          # Handle mutually exclusive corretto versions - keep only corretto-11-bin
+          if echo "$RECIPES" | grep -qw "corretto-11-bin"; then
+            RECIPES=$(echo "$RECIPES" | tr ' ' '\n' | grep -v '^corretto-[0-9]*-bin$' | tr '\n' ' ')
+            RECIPES="$RECIPES corretto-11-bin"
+            echo "Kept only corretto-11-bin (corretto versions are mutually exclusive)"
           fi
 
           echo RECIPES to build, test: "$RECIPES"


### PR DESCRIPTION
Backport of the COMPATIBLE_MACHINE filtering fix from master-next plus corretto mutual exclusion handling.

Fixes the false CI failures on arm32/riscv64 and corretto conflicts on x86-64/aarch64.