### PR TITLE
aws-crt-cpp: fix build error when DEBUG_BUILD is enabled

### DIFF
--- a/recipes-sdk/aws-crt-cpp/aws-crt-cpp_0.38.5.bb
+++ b/recipes-sdk/aws-crt-cpp/aws-crt-cpp_0.38.5.bb
@@ -33,6 +33,7 @@ SRCREV = "bca5d26fd37b0d39ba8fbffb3058560f0d4d193f"
 inherit cmake pkgconfig ptest
 
 CFLAGS:append = " -Wl,-Bsymbolic"
+CFLAGS:append = " ${@oe.utils.vartrue('DEBUG_BUILD', '-DXXH_NO_INLINE_HINTS=1', '', d)}"
 
 EXTRA_OECMAKE += "\
     -DCMAKE_MODULE_PATH=${STAGING_LIBDIR}/cmake \


### PR DESCRIPTION
xxhash marks its SSE2 hash functions with __attribute__((always_inline)). It has auto-detection logic to disable this when __NO_INLINE__ is defined (i.e. at -O0 or -fno-inline). However, when DEBUG_BUILD is enabled (i.e. -Og), which does not define __NO_INLINE__ — so xxhash keeps always_inline. But -Og doesn't inline aggressively enough to satisfy always_inline, causing the following build error.

  error: inlining failed in call to 'always_inline' 'XXH3_accumulate_sse2'

Fix this issue by adding -DXXH_NO_INLINE_HINTS=1 to CFLAGS to disable always_inline when DEBUG_BUILD is enabled.

Tested "bitbake aws-crt-cpp" build pass when DEBUG_BUILD is enabled.