### PR TITLE
[Backport scarthgap-next] 2026-04-28_01-43-00_master-next_aws-crt-python

### DIFF
--- a/recipes-sdk/aws-crt-python/aws-crt-python_0.32.2.bb
+++ b/recipes-sdk/aws-crt-python/aws-crt-python_0.32.2.bb
@@ -37,7 +37,7 @@ SRC_URI = "\
     file://run-ptest \
     "
 
-SRCREV = "eba5fc17a5984e867d1f9d28f2833bc22c2dde70"
+SRCREV = "3e14d24aa02a9f227eb592b12e682651f9e97aa9"
 UPSTREAM_CHECK_GITTAGREGEX = "v(?P<pver>.*)"
 
 S = "${WORKDIR}/git"

--- a/recipes-sdk/aws-crt-python/files/001-fix-cross-compilation-support.patch
+++ b/recipes-sdk/aws-crt-python/files/001-fix-cross-compilation-support.patch
@@ -1,4 +1,4 @@
-From 82784e747b107535ebd5339cdd3e7b03731928f2 Mon Sep 17 00:00:00 2001
+From 53c5b5114303185c8d4a69ec241901835554df33 Mon Sep 17 00:00:00 2001
 From: AWS Meta Layer <meta-aws@amazon.com>
 Date: Thu, 24 Jul 2025 12:00:00 +0000
 Subject: [PATCH] Fix cross-compilation support
@@ -15,10 +15,10 @@ Signed-off-by: AWS Meta Layer <meta-aws@amazon.com>
  1 file changed, 12 insertions(+)
 
 diff --git a/setup.py b/setup.py
-index c71b7db..e14b2fd 100644
+index 380e5e9..9dfd6ea 100644
 --- a/setup.py
 +++ b/setup.py
-@@ -298,12 +298,24 @@ class awscrt_build_ext(setuptools.command.build_ext.build_ext):
+@@ -370,12 +370,24 @@ class awscrt_build_ext(setuptools.command.build_ext.build_ext):
              f'-DCMAKE_BUILD_TYPE={build_type}',
          ])
  


### PR DESCRIPTION
# Description
Backport of #15586 to `scarthgap-next`.