### PR TITLE
[Backport whinlatter-next] 2026-04-28_01-43-00_master-next_aws-c-s3

### DIFF
--- a/recipes-sdk/aws-c-s3/aws-c-s3_0.12.3.bb
+++ b/recipes-sdk/aws-c-s3/aws-c-s3_0.12.3.bb
@@ -19,7 +19,7 @@ SRC_URI = "\
     git://github.com/awslabs/aws-c-s3.git;protocol=https;branch=${BRANCH} \
     file://run-ptest \
     "
-SRCREV = "ab764f57ec3cab7866c0f8b7d9e9772b7cc1b9ee"
+SRCREV = "a31a657840daffbfa7749b63cd0e2a178a6a5d9e"
 
 inherit cmake ptest pkgconfig
 


### PR DESCRIPTION
# Description
Backport of #15589 to `whinlatter-next`.