### PR TITLE
[Backport scarthgap-next] 2026-04-29_01-43-43_master-next_aws-crt-cpp

### DIFF
--- a/recipes-sdk/aws-crt-cpp/aws-crt-cpp/001-shared-static-crt-libs.patch
+++ b/recipes-sdk/aws-crt-cpp/aws-crt-cpp/001-shared-static-crt-libs.patch
@@ -1,4 +1,4 @@
-From 1c881640ef222f0f85e9f16d96862f155a94f264 Mon Sep 17 00:00:00 2001
+From 001641e967ec8b869cb24b03c43cd5d1f745863d Mon Sep 17 00:00:00 2001
 From: Thomas Roos <throos@amazon.de>
 Date: Tue, 20 May 2025 08:45:29 +0000
 Subject: [PATCH] aws-crt-cpp: change to build-deps as default

--- a/recipes-sdk/aws-crt-cpp/aws-crt-cpp/002-enable-tests-with-crosscompiling.patch
+++ b/recipes-sdk/aws-crt-cpp/aws-crt-cpp/002-enable-tests-with-crosscompiling.patch
@@ -1,4 +1,4 @@
-From 2a28428bb2fbbf97d2324a66d63058510aef0f35 Mon Sep 17 00:00:00 2001
+From e23e9158b0a2e41cc981427fdb96a8af59ea2c65 Mon Sep 17 00:00:00 2001
 From: Thomas Roos <throos@amazon.de>
 Date: Mon, 29 Sep 2025 12:51:03 +0000
 Subject: [PATCH] This enable the tests even when crosscompiling.

--- a/recipes-sdk/aws-crt-cpp/aws-crt-cpp_0.38.6.bb
+++ b/recipes-sdk/aws-crt-cpp/aws-crt-cpp_0.38.6.bb
@@ -28,7 +28,7 @@ SRC_URI = "\
     file://002-enable-tests-with-crosscompiling.patch \
     "
 
-SRCREV = "bca5d26fd37b0d39ba8fbffb3058560f0d4d193f"
+SRCREV = "bd19f640464f22b666660fe724531a6819f80c25"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
# Description
Backport of #15596 to `scarthgap-next`.