### PR TITLE
ci: fix duplicate permissions blocking auto-approve on whinlatter

### DIFF
--- a/.github/workflows/auto-approve-and-enable-auto-merge.yml
+++ b/.github/workflows/auto-approve-and-enable-auto-merge.yml
@@ -7,8 +7,6 @@ on:
       - '*-next'
 
 permissions: {}
-
-permissions: {}
 jobs:
   auto-approve-and-merge:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
The auto-approve workflow on whinlatter-next has a duplicate `permissions: {}` line that causes GitHub Actions to silently skip the workflow. This is why all whinlatter backport PRs require manual merge while scarthgap ones auto-merge.

One-line fix: remove the duplicate.