### PR TITLE
aws-crt-cpp: fix build error when DEBUG_BUILD is enabled

### DIFF
--- a/recipes-sdk/aws-crt-cpp/aws-crt-cpp_0.38.6.bb
+++ b/recipes-sdk/aws-crt-cpp/aws-crt-cpp_0.38.6.bb
@@ -33,6 +33,7 @@ SRCREV = "bd19f640464f22b666660fe724531a6819f80c25"
 inherit cmake pkgconfig ptest
 
 CFLAGS:append = " -Wl,-Bsymbolic"
+CFLAGS:append = " ${@oe.utils.vartrue('DEBUG_BUILD', '-DXXH_NO_INLINE_HINTS=1', '', d)}"
 
 EXTRA_OECMAKE += "\
     -DCMAKE_MODULE_PATH=${STAGING_LIBDIR}/cmake \


### PR DESCRIPTION
Rebased version of #15583 by @BinCaoWR — the original PR had merge conflicts due to a version upgrade.

Applies the same one-line fix to the current `aws-crt-cpp_0.38.6.bb`.

Co-authored-by: BinCaoWR <BinCaoWR@users.noreply.github.com>