### PR TITLE
[Backport scarthgap-next] 2026-05-05_01-42-53_master-next_aws-iot-fleetwise-edge

### DIFF
--- a/recipes-iot/aws-iot-fleetwise/aws-iot-fleetwise-edge/002-fix-abseil-linking.patch
+++ b/recipes-iot/aws-iot-fleetwise/aws-iot-fleetwise-edge/002-fix-abseil-linking.patch
@@ -1,4 +1,4 @@
-From 165ac718eed6a8c3d03a8da0ce278bf87f4c9e71 Mon Sep 17 00:00:00 2001
+From a0764a9d5ab6a56ea32dd833f2b1630e12baf167 Mon Sep 17 00:00:00 2001
 From: Thomas Roos <throos@amazon.de>
 Date: Mon, 9 Feb 2026 13:17:57 +0000
 Subject: [PATCH] aws-iot-fleetwise-edge: fix link of abseil lib
@@ -9,7 +9,7 @@ Upstream-Status: Pending
  1 file changed, 6 insertions(+)
 
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index c345306..ca2abe6 100644
+index 03a15d7..33ca1f6 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -688,6 +688,8 @@ target_link_libraries(aws-iot-fleetwise-edge

--- a/recipes-iot/aws-iot-fleetwise/aws-iot-fleetwise-edge_1.3.4.bb
+++ b/recipes-iot/aws-iot-fleetwise/aws-iot-fleetwise-edge_1.3.4.bb
@@ -27,7 +27,7 @@ SRC_URI = "\
     file://run-ptest \
     "
 
-SRCREV = "62c9e23d1d6b7f836577d42c228f8295ad9334db"
+SRCREV = "15e20f306615f2800ea56eebe66898c2911383c6"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-iot/aws-iot-fleetwise/files/001-remove-cxx-standard.patch
+++ b/recipes-iot/aws-iot-fleetwise/files/001-remove-cxx-standard.patch
@@ -1,4 +1,4 @@
-From d5743d56a1861b1d23181fab04cad06a53de9984 Mon Sep 17 00:00:00 2001
+From 2ec5dff53ad7c9054f908613d70b2595539e3db4 Mon Sep 17 00:00:00 2001
 From: Thomas Roos <throos@amazon.de>
 Date: Tue, 9 Jan 2024 15:01:35 +0000
 Subject: [PATCH] aws-iot-fleetwise-edge: remove setting of cxx-standard
@@ -9,12 +9,12 @@ Upstream-Status: Submitted [author]
  1 file changed, 5 deletions(-)
 
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 8fa3671..c345306 100644
+index c6409d8..03a15d7 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -4,11 +4,6 @@ cmake_minimum_required(VERSION 3.10.2)
  
- project(iotfleetwise VERSION 1.3.3)
+ project(iotfleetwise VERSION 1.3.4)
  
 -# FWE uses C++14 for compatibility reasons with Automotive middlewares (Adaptive AUTOSAR, ROS2)
 -# Note: When built with FWE_FEATURE_ROS2, colcon will override these settings


### PR DESCRIPTION
# Description
Backport of #15624 to `scarthgap-next`.