### PR TITLE
Release: merge whinlatter-next to whinlatter (2026-05-05)

### DIFF
--- a/recipes-devtools/python/python3-s3transfer_0.17.0.bb
+++ b/recipes-devtools/python/python3-s3transfer_0.17.0.bb
@@ -11,7 +11,7 @@ SRC_URI = "\
     file://run-ptest \
     file://python_dependency_test.py \
     "
-SRCREV = "8647a30a80866593afaf1cc21e6c42891df2f068"
+SRCREV = "28fe009e64b8041b41624d289b804eb78fe0b8ef"
 
 
 inherit setuptools3 ptest

--- a/recipes-iot/aws-iot-fleetwise/aws-iot-fleetwise-edge/002-fix-abseil-linking.patch
+++ b/recipes-iot/aws-iot-fleetwise/aws-iot-fleetwise-edge/002-fix-abseil-linking.patch
@@ -1,4 +1,4 @@
-From 165ac718eed6a8c3d03a8da0ce278bf87f4c9e71 Mon Sep 17 00:00:00 2001
+From a0764a9d5ab6a56ea32dd833f2b1630e12baf167 Mon Sep 17 00:00:00 2001
 From: Thomas Roos <throos@amazon.de>
 Date: Mon, 9 Feb 2026 13:17:57 +0000
 Subject: [PATCH] aws-iot-fleetwise-edge: fix link of abseil lib
@@ -9,7 +9,7 @@ Upstream-Status: Pending
  1 file changed, 6 insertions(+)
 
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index c345306..ca2abe6 100644
+index 03a15d7..33ca1f6 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -688,6 +688,8 @@ target_link_libraries(aws-iot-fleetwise-edge

--- a/recipes-iot/aws-iot-fleetwise/aws-iot-fleetwise-edge_1.3.4.bb
+++ b/recipes-iot/aws-iot-fleetwise/aws-iot-fleetwise-edge_1.3.4.bb
@@ -25,7 +25,7 @@ SRC_URI = "\
     file://run-ptest \
     "
 
-SRCREV = "62c9e23d1d6b7f836577d42c228f8295ad9334db"
+SRCREV = "15e20f306615f2800ea56eebe66898c2911383c6"
 
 inherit cmake systemd ptest pkgconfig
 

--- a/recipes-iot/aws-iot-fleetwise/files/001-remove-cxx-standard.patch
+++ b/recipes-iot/aws-iot-fleetwise/files/001-remove-cxx-standard.patch
@@ -1,4 +1,4 @@
-From d5743d56a1861b1d23181fab04cad06a53de9984 Mon Sep 17 00:00:00 2001
+From 2ec5dff53ad7c9054f908613d70b2595539e3db4 Mon Sep 17 00:00:00 2001
 From: Thomas Roos <throos@amazon.de>
 Date: Tue, 9 Jan 2024 15:01:35 +0000
 Subject: [PATCH] aws-iot-fleetwise-edge: remove setting of cxx-standard
@@ -9,12 +9,12 @@ Upstream-Status: Submitted [author]
  1 file changed, 5 deletions(-)
 
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 8fa3671..c345306 100644
+index c6409d8..03a15d7 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -4,11 +4,6 @@ cmake_minimum_required(VERSION 3.10.2)
  
- project(iotfleetwise VERSION 1.3.3)
+ project(iotfleetwise VERSION 1.3.4)
  
 -# FWE uses C++14 for compatibility reasons with Automotive middlewares (Adaptive AUTOSAR, ROS2)
 -# Note: When built with FWE_FEATURE_ROS2, colcon will override these settings

--- a/recipes-sdk/aws-c-s3/aws-c-s3_0.12.3.bb
+++ b/recipes-sdk/aws-c-s3/aws-c-s3_0.12.3.bb
@@ -19,7 +19,7 @@ SRC_URI = "\
     git://github.com/awslabs/aws-c-s3.git;protocol=https;branch=${BRANCH} \
     file://run-ptest \
     "
-SRCREV = "ab764f57ec3cab7866c0f8b7d9e9772b7cc1b9ee"
+SRCREV = "a31a657840daffbfa7749b63cd0e2a178a6a5d9e"
 
 inherit cmake ptest pkgconfig
 

--- a/recipes-sdk/aws-crt-cpp/aws-crt-cpp/001-shared-static-crt-libs.patch
+++ b/recipes-sdk/aws-crt-cpp/aws-crt-cpp/001-shared-static-crt-libs.patch
@@ -1,4 +1,4 @@
-From 1c881640ef222f0f85e9f16d96862f155a94f264 Mon Sep 17 00:00:00 2001
+From 001641e967ec8b869cb24b03c43cd5d1f745863d Mon Sep 17 00:00:00 2001
 From: Thomas Roos <throos@amazon.de>
 Date: Tue, 20 May 2025 08:45:29 +0000
 Subject: [PATCH] aws-crt-cpp: change to build-deps as default

--- a/recipes-sdk/aws-crt-cpp/aws-crt-cpp/002-enable-tests-with-crosscompiling.patch
+++ b/recipes-sdk/aws-crt-cpp/aws-crt-cpp/002-enable-tests-with-crosscompiling.patch
@@ -1,4 +1,4 @@
-From 2a28428bb2fbbf97d2324a66d63058510aef0f35 Mon Sep 17 00:00:00 2001
+From e23e9158b0a2e41cc981427fdb96a8af59ea2c65 Mon Sep 17 00:00:00 2001
 From: Thomas Roos <throos@amazon.de>
 Date: Mon, 29 Sep 2025 12:51:03 +0000
 Subject: [PATCH] This enable the tests even when crosscompiling.

--- a/recipes-sdk/aws-crt-cpp/aws-crt-cpp_0.38.6.bb
+++ b/recipes-sdk/aws-crt-cpp/aws-crt-cpp_0.38.6.bb
@@ -28,7 +28,7 @@ SRC_URI = "\
     file://002-enable-tests-with-crosscompiling.patch \
     "
 
-SRCREV = "bca5d26fd37b0d39ba8fbffb3058560f0d4d193f"
+SRCREV = "bd19f640464f22b666660fe724531a6819f80c25"
 
 inherit cmake pkgconfig ptest
 

--- a/recipes-sdk/aws-crt-python/aws-crt-python_0.32.2.bb
+++ b/recipes-sdk/aws-crt-python/aws-crt-python_0.32.2.bb
@@ -36,7 +36,7 @@ SRC_URI = "\
     file://run-ptest \
     "
 
-SRCREV = "eba5fc17a5984e867d1f9d28f2833bc22c2dde70"
+SRCREV = "3e14d24aa02a9f227eb592b12e682651f9e97aa9"
 UPSTREAM_CHECK_GITTAGREGEX = "v(?P<pver>.*)"
 
 inherit setuptools3_legacy ptest

--- a/recipes-sdk/aws-crt-python/files/001-fix-cross-compilation-support.patch
+++ b/recipes-sdk/aws-crt-python/files/001-fix-cross-compilation-support.patch
@@ -1,4 +1,4 @@
-From 82784e747b107535ebd5339cdd3e7b03731928f2 Mon Sep 17 00:00:00 2001
+From 53c5b5114303185c8d4a69ec241901835554df33 Mon Sep 17 00:00:00 2001
 From: AWS Meta Layer <meta-aws@amazon.com>
 Date: Thu, 24 Jul 2025 12:00:00 +0000
 Subject: [PATCH] Fix cross-compilation support
@@ -15,10 +15,10 @@ Signed-off-by: AWS Meta Layer <meta-aws@amazon.com>
  1 file changed, 12 insertions(+)
 
 diff --git a/setup.py b/setup.py
-index c71b7db..e14b2fd 100644
+index 380e5e9..9dfd6ea 100644
 --- a/setup.py
 +++ b/setup.py
-@@ -298,12 +298,24 @@ class awscrt_build_ext(setuptools.command.build_ext.build_ext):
+@@ -370,12 +370,24 @@ class awscrt_build_ext(setuptools.command.build_ext.build_ext):
              f'-DCMAKE_BUILD_TYPE={build_type}',
          ])
  

--- a/recipes-sdk/aws-lc/aws-lc_1.72.1.bb
+++ b/recipes-sdk/aws-lc/aws-lc_1.72.1.bb
@@ -878,7 +878,7 @@ SRC_URI = "\
     git://github.com/awslabs/aws-lc.git;protocol=https;branch=${BRANCH} \
     file://run-ptest \
     "
-SRCREV = "d50ded594c835fd277997461815ad473949f2c7a"
+SRCREV = "6af5337f678501c9ec87dd86ab3f42c8fe5717da"
 UPSTREAM_CHECK_GITTAGREGEX = "v(?P<pver>.*)"
 
 # nooelint: oelint.vars.specific

--- a/recipes-sdk/coremqtt/coremqtt_5.0.2.bb
+++ b/recipes-sdk/coremqtt/coremqtt_5.0.2.bb
@@ -10,7 +10,7 @@ SRC_URI = "gitsm://github.com/FreeRTOS/coreMQTT.git;protocol=https;branch=main \
     file://run-ptest \
 "
 
-SRCREV = "76e9d89cb8e2fb4cff965329d835594cebebf618"
+SRCREV = "04845c6a8e5f9cf2d232f1c6e80baeb81302e690"
 
 inherit cmake ptest
 


### PR DESCRIPTION
## Weekly Release: whinlatter-next → whinlatter

### CVE Status

- Upstream CVE detected (not blocking — not a direct CVE in modified recipes)

### Note

The aws-iot-device-sdk-cpp-v2 static CRT fix (#15582) will need to be backported separately to whinlatter-next after the master-next fix is validated.

⚠️ **Whinlatter EOL is May 2026 — this may be one of the final releases for this branch.**