### PR TITLE
ci: exclude aws-c-iot from ptest when aws-iot-device-sdk-cpp-v2 is present

### DIFF
--- a/.github/workflows/build-test-recipe.yml
+++ b/.github/workflows/build-test-recipe.yml
@@ -249,6 +249,13 @@ jobs:
             echo "Excluded aws-cli (v1) due to conflict with aws-cli-v2"
           fi
 
+          # Handle RCONFLICTS: aws-iot-device-sdk-cpp-v2 conflicts with aws-c-iot (see #15582)
+          # The SDK bundles its own aws-c-iot when build-deps is enabled
+          if echo "$RECIPES" | grep -qw "aws-iot-device-sdk-cpp-v2" && echo "$RECIPES" | grep -qw "aws-c-iot"; then
+            RECIPES=$(echo "$RECIPES" | tr ' ' '\n' | grep -v '^aws-c-iot$' | tr '\n' ' ')
+            echo "Excluded aws-c-iot due to RCONFLICTS with aws-iot-device-sdk-cpp-v2"
+          fi
+
           echo RECIPES to build, test: "$RECIPES"
           echo "recipes=$RECIPES" >> $GITHUB_OUTPUT
       - name: Run build


### PR DESCRIPTION
The SDK recipe with `build-deps` enabled bundles its own `aws-c-iot` and declares `RCONFLICTS:${PN} = "aws-c-iot"`. When the CI tries to install both `aws-iot-device-sdk-cpp-v2-ptest` and `aws-c-iot-ptest` into the same test image, opkg cannot resolve the conflict.

Add mutual exclusion logic (same pattern as the existing `aws-cli-v2`/`aws-cli` handling) to drop `aws-c-iot` from the recipe list when `aws-iot-device-sdk-cpp-v2` is being tested.

Refs: #15582