### PR TITLE
ci: filter out recipes that do not inherit ptest

### DIFF
--- a/.github/workflows/build-test-recipe.yml
+++ b/.github/workflows/build-test-recipe.yml
@@ -256,6 +256,17 @@ jobs:
             echo "Excluded aws-c-iot due to RCONFLICTS with aws-iot-device-sdk-cpp-v2"
           fi
 
+          # Filter out recipes that do not inherit ptest (see #15672)
+          PTEST_RECIPES=""
+          for recipe in $RECIPES; do
+            RECIPE_FILES=$(find meta-aws/ -name "${recipe}.bb" -o -name "${recipe}_*.bb" 2>/dev/null)
+            if [ -n "$RECIPE_FILES" ] && echo "$RECIPE_FILES" | xargs grep -ql 'inherit.*ptest' 2>/dev/null; then
+              PTEST_RECIPES+="$recipe "
+            else
+              echo "Skipping $recipe: does not inherit ptest"
+            fi
+          done
+          export RECIPES="$PTEST_RECIPES"
           echo RECIPES to build, test: "$RECIPES"
           echo "recipes=$RECIPES" >> $GITHUB_OUTPUT
       - name: Run build


### PR DESCRIPTION
The build-test-recipe workflow appends `-ptest` to every changed recipe when building the test image. Recipes that don't inherit ptest (like `aws-iot-device-sdk-cpp-v2-samples-mqtt5-pubsub`) have no `-ptest` package, causing:

```
ERROR: Nothing RPROVIDES 'aws-iot-device-sdk-cpp-v2-samples-mqtt5-pubsub-ptest'
ERROR: Required build target 'core-image-minimal' has no buildable providers.
```

This adds a filter that checks whether each recipe actually inherits ptest before including it in the test list.

Fixes: #15672