### PR TITLE
[Backport scarthgap-next] 2026-05-14_01-46-59_master-next_aws-c-common

### DIFF
--- a/recipes-sdk/aws-c-common/aws-c-common_0.13.0.bb
+++ b/recipes-sdk/aws-c-common/aws-c-common_0.13.0.bb
@@ -14,7 +14,7 @@ SRC_URI = "\
     file://ptest_result.py \
     file://0001-skip-iso8601-tests-on-32bit.patch \
 "
-SRCREV = "95515a8b1ff40d5bb14f965ca4cbbe99ad1843df"
+SRCREV = "7f18168e834b2abf276c6f92ae3b27af494fcca1"
 
 # will match only x.x.x for auto upgrades, because: https://github.com/awslabs/aws-c-common/issues/1025
 UPSTREAM_CHECK_GITTAGREGEX = "(?P<pver>\d\.\d+(\.\d+)+)"

--- a/recipes-sdk/aws-c-common/files/0001-skip-iso8601-tests-on-32bit.patch
+++ b/recipes-sdk/aws-c-common/files/0001-skip-iso8601-tests-on-32bit.patch
@@ -1,4 +1,4 @@
-From def81943596cf2157918aa309df9a907b2e2603c Mon Sep 17 00:00:00 2001
+From 1a67d3ebcfc74050b63a983468d10d86e793e43c Mon Sep 17 00:00:00 2001
 From: Thomas Roos <throos@amazon.de>
 Date: Tue, 12 Aug 2025 08:51:48 +0000
 Subject: [PATCH] Skip ISO8601 parsing tests on 32-bit architectures due to


### PR DESCRIPTION
# Description
Backport of #15685 to `scarthgap-next`.