### PR TITLE
[Backport whinlatter-next] 2026-05-19_01-47-25_master-next_aws-c-auth

### DIFF
--- a/recipes-sdk/aws-c-auth/aws-c-auth_0.10.2.bb
+++ b/recipes-sdk/aws-c-auth/aws-c-auth_0.10.2.bb
@@ -23,7 +23,7 @@ SRC_URI = "\
     git://github.com/awslabs/aws-c-auth.git;protocol=https;branch=${BRANCH} \
     file://run-ptest \
     "
-SRCREV = "fc4b87655e5cd3921f18d1859193c74af4102071"
+SRCREV = "4b5cf14bfbb7d402ed89c7d614d77e924a65321f"
 
 inherit cmake ptest pkgconfig
 


### PR DESCRIPTION
# Description
Backport of #15702 to `whinlatter-next`.