### PR TITLE
[Backport scarthgap-next] 2026-05-19_01-47-25_master-next_aws-c-mqtt

### DIFF
--- a/recipes-sdk/aws-c-mqtt/aws-c-mqtt_0.16.0.bb
+++ b/recipes-sdk/aws-c-mqtt/aws-c-mqtt_0.16.0.bb
@@ -23,7 +23,7 @@ SRC_URI = "\
     file://run-ptest \
     "
 
-SRCREV = "3c2ceee52b66db42228053a4fb55210c8f8433a0"
+SRCREV = "2ef9605ec9c50bea3f921e08022ddd57eed70901"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
# Description
Backport of #15704 to `scarthgap-next`.