### PR TITLE
aws-iot-device-sdk-cpp-v2: Fix do_package QA Issue

### DIFF
--- a/recipes-sdk/aws-iot-device-sdk-cpp-v2/aws-iot-device-sdk-cpp-v2_1.40.1.bb
+++ b/recipes-sdk/aws-iot-device-sdk-cpp-v2/aws-iot-device-sdk-cpp-v2_1.40.1.bb
@@ -45,6 +45,8 @@ PACKAGECONFIG ??= "\
     "
 
 FILES:${PN} += "${@bb.utils.contains('PACKAGECONFIG', 'build-deps', '/usr/lib/*', '', d)}"
+FILES:${PN} += "${libdir}/lib*.so.*"
+
 FILES:${PN}-dev += "\
     ${libdir}/*/cmake \
     ${libdir}/pkgconfig/*.pc \


### PR DESCRIPTION
Append ${libdir}/lib*.so.* to FILES to fix the do_package installed-vs-shipped error that only occurs when BASELIB="lib64".

ERROR: aws-iot-device-sdk-cpp-v2-1.40.1-r0 do_package: QA Issue: aws-iot-device-sdk-cpp-v2: Files/directories were installed but not shipped in any package:
  /usr/lib64/libaws-c-io.so.1.0.0
  /usr/lib64/libaws-c-s3.so.0unstable
  /usr/lib64/libaws-c-cal.so.1.0.0
  /usr/lib64/libaws-c-s3.so.1.0.0
  /usr/lib64/libaws-c-http.so.1.0.0
  /usr/lib64/libaws-c-common.so.1.0.0
  /usr/lib64/libaws-c-auth.so.1.0.0
  /usr/lib64/libs2n.so.1
  /usr/lib64/libs2n.so.1.0.0
  /usr/lib64/libaws-c-event-stream.so.1.0.0
  /usr/lib64/libaws-checksums.so.1.0.0
  /usr/lib64/libaws-c-common.so.1
  /usr/lib64/libaws-c-mqtt.so.1.0.0
  /usr/lib64/libaws-c-iot.so.0unstable
  /usr/lib64/libaws-c-iot.so.1.0.0
  /usr/lib64/libaws-c-compression.so.1.0.0
  /usr/lib64/libaws-c-sdkutils.so.1.0.0
Please set FILES such that these items are packaged. Alternatively if they are unneeded, avoid installing them or delete them within do_install. aws-iot-device-sdk-cpp-v2: 17 installed and not shipped files. [installed-vs-shipped] ERROR: aws-iot-device-sdk-cpp-v2-1.40.1-r0 do_package: Fatal QA errors were found, failing task.

Fixed issue #15716
