### PR TITLE
[Backport whinlatter-next] 2026-05-22_01-47-47_master-next_aws-c-cal

### DIFF
--- a/recipes-sdk/aws-c-cal/aws-c-cal_0.9.14.bb
+++ b/recipes-sdk/aws-c-cal/aws-c-cal_0.9.14.bb
@@ -21,7 +21,7 @@ SRC_URI = "\
     file://run-ptest \
     "
 
-SRCREV = "1cb9412158890201a6ffceed779f90fe1f48180c"
+SRCREV = "9edd8eac2b21ca6a04535b91d60d361c2f1bb60f"
 
 inherit cmake ptest pkgconfig
 

--- a/recipes-sdk/aws-c-cal/files/001-enable-tests-with-crosscompiling.patch
+++ b/recipes-sdk/aws-c-cal/files/001-enable-tests-with-crosscompiling.patch
@@ -1,4 +1,4 @@
-From 75dff69bd5595658dfc986cfed4338334b719998 Mon Sep 17 00:00:00 2001
+From ae9b50671e120cf1bf9e120f93a636e95a9a42af Mon Sep 17 00:00:00 2001
 From: Thomas Roos <throos@amazon.de>
 Date: Mon, 29 Sep 2025 12:51:03 +0000
 Subject: [PATCH] This enable the tests even when crosscompiling.


### PR DESCRIPTION
# Description
Backport of #15730 to `whinlatter-next`.