### PR TITLE
[Backport whinlatter-next] 2026-05-22_01-47-47_master-next_aws-c-event-stream

### DIFF
--- a/recipes-sdk/aws-c-event-stream/aws-c-event-stream_0.7.1.bb
+++ b/recipes-sdk/aws-c-event-stream/aws-c-event-stream_0.7.1.bb
@@ -20,7 +20,7 @@ SRC_URI = "\
     git://github.com/awslabs/aws-c-event-stream.git;protocol=https;branch=${BRANCH} \
     file://run-ptest \
     "
-SRCREV = "66cafb1d8bb1bfeb62a7601ce03d1a6fcd4798ed"
+SRCREV = "51bef3c44e1058b1689751539170b2e0f589ccdb"
 
 inherit cmake ptest pkgconfig
 


### PR DESCRIPTION
# Description
Backport of #15734 to `whinlatter-next`.