### PR TITLE
[Backport whinlatter-next] 2026-05-26_01-45-40_master-next_aws-crt-cpp

### DIFF
--- a/recipes-sdk/aws-crt-cpp/aws-crt-cpp/001-shared-static-crt-libs.patch
+++ b/recipes-sdk/aws-crt-cpp/aws-crt-cpp/001-shared-static-crt-libs.patch
@@ -1,4 +1,4 @@
-From 6d99dbc2c6f54aac9c4ef570330c9726e9226437 Mon Sep 17 00:00:00 2001
+From 77b249dbc3258423412f956d35981c3e72aebbdc Mon Sep 17 00:00:00 2001
 From: Thomas Roos <throos@amazon.de>
 Date: Tue, 20 May 2025 08:45:29 +0000
 Subject: [PATCH] aws-crt-cpp: change to build-deps as default

--- a/recipes-sdk/aws-crt-cpp/aws-crt-cpp/002-enable-tests-with-crosscompiling.patch
+++ b/recipes-sdk/aws-crt-cpp/aws-crt-cpp/002-enable-tests-with-crosscompiling.patch
@@ -1,4 +1,4 @@
-From e9933dd0ed1c299167639c90901a18956302e96a Mon Sep 17 00:00:00 2001
+From b4726f63e1494496122496ee0a8eaa68bb6fba39 Mon Sep 17 00:00:00 2001
 From: Thomas Roos <throos@amazon.de>
 Date: Mon, 29 Sep 2025 12:51:03 +0000
 Subject: [PATCH] This enable the tests even when crosscompiling.

--- a/recipes-sdk/aws-crt-cpp/aws-crt-cpp_0.39.1.bb
+++ b/recipes-sdk/aws-crt-cpp/aws-crt-cpp_0.39.1.bb
@@ -28,7 +28,7 @@ SRC_URI = "\
     file://002-enable-tests-with-crosscompiling.patch \
     "
 
-SRCREV = "b60cd5c3b27e8eb8bd3769b7b7330eff311f5530"
+SRCREV = "b540e9314f3ecc5a6c592efb07a516a6b20c5bbb"
 
 inherit cmake pkgconfig ptest
 


### PR DESCRIPTION
# Description
Backport of #15749 to `whinlatter-next`.