### PR TITLE
[Backport whinlatter-next] 2026-05-26_01-45-40_master-next_aws-crt-python

### DIFF
--- a/recipes-sdk/aws-crt-python/aws-crt-python_0.33.0.bb
+++ b/recipes-sdk/aws-crt-python/aws-crt-python_0.33.0.bb
@@ -36,7 +36,7 @@ SRC_URI = "\
     file://run-ptest \
     "
 
-SRCREV = "3e14d24aa02a9f227eb592b12e682651f9e97aa9"
+SRCREV = "74f88049cd779becbc93bbd5cd32b709d0a40420"
 UPSTREAM_CHECK_GITTAGREGEX = "v(?P<pver>.*)"
 
 inherit setuptools3_legacy ptest

--- a/recipes-sdk/aws-crt-python/files/001-fix-cross-compilation-support.patch
+++ b/recipes-sdk/aws-crt-python/files/001-fix-cross-compilation-support.patch
@@ -1,4 +1,4 @@
-From 53c5b5114303185c8d4a69ec241901835554df33 Mon Sep 17 00:00:00 2001
+From 622237504a99dbe13f28d785e650e36adf39a5fa Mon Sep 17 00:00:00 2001
 From: AWS Meta Layer <meta-aws@amazon.com>
 Date: Thu, 24 Jul 2025 12:00:00 +0000
 Subject: [PATCH] Fix cross-compilation support


### PR DESCRIPTION
# Description
Backport of #15745 to `whinlatter-next`.