### PR TITLE
[Backport whinlatter-next] 2026-05-27_01-49-32_master-next_python3-s3transfer

### DIFF
--- a/recipes-devtools/python/python3-s3transfer_0.17.1.bb
+++ b/recipes-devtools/python/python3-s3transfer_0.17.1.bb
@@ -11,7 +11,7 @@ SRC_URI = "\
     file://run-ptest \
     file://python_dependency_test.py \
     "
-SRCREV = "28fe009e64b8041b41624d289b804eb78fe0b8ef"
+SRCREV = "5a988c8357d24a5fc3b49eea07e762d1dee27904"
 
 
 inherit setuptools3 ptest


### PR DESCRIPTION
# Description
Backport of #15759 to `whinlatter-next`.