### PR TITLE
aws-crt-cpp: insane skip 32bit-time for dbg package

### DIFF
--- a/recipes-sdk/aws-crt-cpp/aws-crt-cpp_0.39.1.bb
+++ b/recipes-sdk/aws-crt-cpp/aws-crt-cpp_0.39.1.bb
@@ -96,5 +96,7 @@ OECMAKE_CXX_FLAGS += "${@bb.utils.contains('PACKAGECONFIG', 'sanitize', '-fsanit
 
 # nooelint: oelint.vars.insaneskip:INSANE_SKIP
 INSANE_SKIP:${PN} += "32bit-time"
+# nooelint: oelint.vars.insaneskip:INSANE_SKIP
+INSANE_SKIP:${PN}-dbg += "32bit-time"
 
 BRANCH = "main"


### PR DESCRIPTION
Rebased version of #15696 by @hongxu-jia onto the current recipe (0.39.1). The original PR conflicts because the recipe was auto-upgraded from 0.38.7 to 0.39.1.

## Problem
When `DEBUG_BUILD = "1"`, the `-dbg` package triggers a QA 32bit-time warning on 32-bit architectures. The main package already has the skip, but the dbg package does not.

## Fix
Add `INSANE_SKIP:${PN}-dbg += "32bit-time"`

Original author credited in the commit.

Supersedes #15696.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.