### PR TITLE
[Backport scarthgap-next] greengrass-lite: upgrade 2.4.0 -> 2.5.1

### DIFF
--- a/recipes-iot/aws-iot-greengrass/greengrass-lite/002-fix-maybe-uninitialized.patch
+++ b/recipes-iot/aws-iot-greengrass/greengrass-lite/002-fix-maybe-uninitialized.patch
@@ -1,0 +1,36 @@
+From: Greg Breen <gregbreen@github.com>
+Subject: [PATCH] iotcored: fix maybe-uninitialized warnings in set_proxy_args
+
+GCC with LTO detects that proxy_uri.data and no_proxy.data may be used
+uninitialized when ggl_gg_config_read_str does not return GG_ERR_OK.
+Initialize both GgBuffer variables to zero at declaration.
+
+Upstream-Status: Pending [fix confirmed for next release]
+
+Signed-off-by: Greg Breen <gregbreen@github.com>
+---
+ modules/iotcored/src/entry.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/modules/iotcored/src/entry.c b/modules/iotcored/src/entry.c
+index 1234567..abcdefg 100644
+--- a/modules/iotcored/src/entry.c
++++ b/modules/iotcored/src/entry.c
+@@ -131,7 +131,7 @@ static void set_proxy_args(IotcoredArgs *args) {
+         GgArena alloc = gg_arena_init(gg_buffer_substr(
+             GG_BUF(proxy_uri_mem), 0, sizeof(proxy_uri_mem) - 1
+         ));
+-        GgBuffer proxy_uri;
++        GgBuffer proxy_uri = { 0 };
+         GgError ret = ggl_gg_config_read_str(
+             GG_BUF_LIST(
+                 GG_STR("services"),
+@@ -163,7 +163,7 @@ static void set_proxy_args(IotcoredArgs *args) {
+         GgArena alloc = gg_arena_init(
+             gg_buffer_substr(GG_BUF(no_proxy_mem), 0, sizeof(no_proxy_mem) - 1)
+         );
+-        GgBuffer no_proxy;
++        GgBuffer no_proxy = { 0 };
+         GgError ret = ggl_gg_config_read_str(
+             GG_BUF_LIST(
+                 GG_STR("services"),

--- a/recipes-iot/aws-iot-greengrass/greengrass-lite_2.4.0.bb
+++ b/recipes-iot/aws-iot-greengrass/greengrass-lite_2.4.0.bb
@@ -36,6 +36,7 @@ SRC_URI = "\
     ${@'' if d.getVar('DISABLE_FETCHCONTENT') else 'git://github.com/aws/SigV4-for-AWS-IoT-embedded-sdk.git;protocol=https;branch=main;name=sigv4;destsuffix=${S}/thirdparty/aws_sigv4'} \
     ${@'' if d.getVar('DISABLE_FETCHCONTENT') else 'git://github.com/aws-greengrass/aws-greengrass-component-sdk.git;protocol=https;nobranch=1;name=sdk;destsuffix=${S}/thirdparty/gg_sdk'} \
     file://001-disable_strip.patch \
+    file://002-fix-maybe-uninitialized.patch \
     file://greengrass-lite.yaml \
     file://run-ptest \
     ${@bb.utils.contains('PACKAGECONFIG','localdeployment','file://ggl.local-deployment.service','',d)} \


### PR DESCRIPTION
# Description
Backport of #15776 to `scarthgap-next`.