### PR TITLE
ci: add wrynose-next to auto-backport targets

### DIFF
--- a/.github/workflows/auto-backport.yml
+++ b/.github/workflows/auto-backport.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Create backport pull requests
         uses: korthout/backport-action@v4
         with:
-          target_branches: scarthgap-next whinlatter-next
+          target_branches: scarthgap-next whinlatter-next wrynose-next
           # copy all labels (backport labels are automatically skipped)
           copy_labels_pattern: .+
           github_token: ${{ secrets.MAINTAINER_TOKEN }}


### PR DESCRIPTION
Yocto 6.0 (wrynose) has been officially released. Add `wrynose-next` to the auto-backport workflow so version upgrades merged to master-next are automatically backported.

Branches created:
- `wrynose` — from master HEAD (release `master-2026.23.0`)
- `wrynose-next` — from wrynose

Closes #15775