### PR TITLE
aws-lc: bump ALTERNATIVE_PRIORITY to resolve postinst conflict

### DIFF
--- a/recipes-sdk/aws-lc/aws-lc_5.0.0.bb
+++ b/recipes-sdk/aws-lc/aws-lc_5.0.0.bb
@@ -938,7 +938,7 @@ FILES_SOLIBSDEV = ""
 BBCLASSEXTEND = "native nativesdk"
 
 inherit update-alternatives
-ALTERNATIVE_PRIORITY = "100"
+ALTERNATIVE_PRIORITY = "200"
 ALTERNATIVE:${PN} = "openssl"
 
 ALTERNATIVE_TARGET[openssl] = "${bindir}/openssl"


### PR DESCRIPTION
aws-lc and openssl both register an `openssl` alternative at priority 100, causing postinst failure during `do_rootfs` when both are installed in the same image (happens during ptest CI).

Bump aws-lc to priority 200 so `update-alternatives` resolves deterministically. aws-lc is a drop-in replacement for the openssl CLI; higher priority is appropriate when explicitly installed.

Discovered while preparing the whinlatter release (PR #15796 failed on qemuarm64/riscv64/x86-64).