### PR TITLE
aws-lc: bump ALTERNATIVE_PRIORITY to resolve postinst conflict

### DIFF
--- a/recipes-sdk/aws-lc/aws-lc_5.0.0.bb
+++ b/recipes-sdk/aws-lc/aws-lc_5.0.0.bb
@@ -938,7 +938,7 @@ FILES_SOLIBSDEV = ""
 BBCLASSEXTEND = "native nativesdk"
 
 inherit update-alternatives
-ALTERNATIVE_PRIORITY = "100"
+ALTERNATIVE_PRIORITY = "200"
 ALTERNATIVE:${PN} = "openssl"
 
 ALTERNATIVE_TARGET[openssl] = "${bindir}/openssl"


### PR DESCRIPTION
Backport of #15797 to whinlatter-next.

Fixes do_rootfs failure when aws-lc and openssl are both in the image (ptest CI scenario). Needed for the whinlatter release.