### PR TITLE
aws-lc: fix postinst failure — replace update-alternatives with RCONFLICTS

### DIFF
--- a/.github/workflows/build-test-recipe.yml
+++ b/.github/workflows/build-test-recipe.yml
@@ -304,6 +304,10 @@ jobs:
              # PUT = package under test
              for recipe in $RECIPES; do PUT+="${recipe}-ptest "; done
              echo IMAGE_INSTALL:append = \" ptest-runner ssh ${PUT}\" >> conf/local.conf
+             # aws-lc conflicts with openssl; use dropbear for SSH when testing aws-lc
+             if echo "$RECIPES" | grep -qw "aws-lc"; then
+               echo "PREFERRED_PROVIDER_virtual/ssh = \"dropbear\"" >> conf/local.conf
+             fi
              echo IMAGE_FEATURES:append = \" allow-empty-password empty-root-password allow-root-login\" >> conf/local.conf
              echo BB_HASHSERVE = \"hashserv.internal:8686\" >> conf/local.conf
              echo BB_SIGNATURE_HANDLER = \"OEEquivHash\" >> conf/local.conf

--- a/recipes-sdk/aws-lc/aws-lc_5.0.0.bb
+++ b/recipes-sdk/aws-lc/aws-lc_5.0.0.bb
@@ -937,8 +937,5 @@ FILES_SOLIBSDEV = ""
 
 BBCLASSEXTEND = "native nativesdk"
 
-inherit update-alternatives
-ALTERNATIVE_PRIORITY = "200"
-ALTERNATIVE:${PN} = "openssl"
-
-ALTERNATIVE_TARGET[openssl] = "${bindir}/openssl"
+# aws-lc provides libssl.so/libcrypto.so which conflict with openssl
+RCONFLICTS:${PN} = "openssl"


### PR DESCRIPTION
The `update-alternatives` block registered an `openssl` binary alternative pointing to `${bindir}/openssl`, but aws-lc never installs such a binary. This caused postinst failure during do_rootfs (previously masked by OE-core deferring to first boot, now strict in whinlatter 5.3.x).

aws-lc provides `libssl.so` and `libcrypto.so` which directly conflict with openssl at the file level. They are mutually exclusive — declare this properly with `RCONFLICTS`.

Also updates CI to use dropbear instead of openssh when testing aws-lc, since openssh depends on openssl which conflicts.

Supersedes the priority-only fix in #15798.