### PR TITLE
Release: merge whinlatter-next to whinlatter (2026-W23)

### DIFF
--- a/.github/workflows/build-test-recipe.yml
+++ b/.github/workflows/build-test-recipe.yml
@@ -304,6 +304,10 @@ jobs:
              # PUT = package under test
              for recipe in $RECIPES; do PUT+="${recipe}-ptest "; done
              echo IMAGE_INSTALL:append = \" ptest-runner ssh ${PUT}\" >> conf/local.conf
+             # aws-lc conflicts with openssl; use dropbear for SSH when testing aws-lc
+             if echo "$RECIPES" | grep -qw "aws-lc"; then
+               echo "PREFERRED_PROVIDER_virtual/ssh = \"dropbear\"" >> conf/local.conf
+             fi
              echo IMAGE_FEATURES:append = \" allow-empty-password empty-root-password allow-root-login\" >> conf/local.conf
              echo BB_HASHSERVE = \"hashserv.internal:8686\" >> conf/local.conf
              echo BB_SIGNATURE_HANDLER = \"OEEquivHash\" >> conf/local.conf

--- a/recipes-devtools/python/python3-s3transfer_0.17.1.bb
+++ b/recipes-devtools/python/python3-s3transfer_0.17.1.bb
@@ -11,7 +11,7 @@ SRC_URI = "\
     file://run-ptest \
     file://python_dependency_test.py \
     "
-SRCREV = "28fe009e64b8041b41624d289b804eb78fe0b8ef"
+SRCREV = "5a988c8357d24a5fc3b49eea07e762d1dee27904"
 
 
 inherit setuptools3 ptest

--- a/recipes-iot/aws-iot-greengrass/greengrass-lite/002-fix-maybe-uninitialized.patch
+++ b/recipes-iot/aws-iot-greengrass/greengrass-lite/002-fix-maybe-uninitialized.patch
@@ -1,0 +1,36 @@
+From: Greg Breen <gregbreen@github.com>
+Subject: [PATCH] iotcored: fix maybe-uninitialized warnings in set_proxy_args
+
+GCC with LTO detects that proxy_uri.data and no_proxy.data may be used
+uninitialized when ggl_gg_config_read_str does not return GG_ERR_OK.
+Initialize both GgBuffer variables to zero at declaration.
+
+Upstream-Status: Pending [fix confirmed for next release]
+
+Signed-off-by: Greg Breen <gregbreen@github.com>
+---
+ modules/iotcored/src/entry.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/modules/iotcored/src/entry.c b/modules/iotcored/src/entry.c
+index 1234567..abcdefg 100644
+--- a/modules/iotcored/src/entry.c
++++ b/modules/iotcored/src/entry.c
+@@ -131,7 +131,7 @@ static void set_proxy_args(IotcoredArgs *args) {
+         GgArena alloc = gg_arena_init(gg_buffer_substr(
+             GG_BUF(proxy_uri_mem), 0, sizeof(proxy_uri_mem) - 1
+         ));
+-        GgBuffer proxy_uri;
++        GgBuffer proxy_uri = { 0 };
+         GgError ret = ggl_gg_config_read_str(
+             GG_BUF_LIST(
+                 GG_STR("services"),
+@@ -163,7 +163,7 @@ static void set_proxy_args(IotcoredArgs *args) {
+         GgArena alloc = gg_arena_init(
+             gg_buffer_substr(GG_BUF(no_proxy_mem), 0, sizeof(no_proxy_mem) - 1)
+         );
+-        GgBuffer no_proxy;
++        GgBuffer no_proxy = { 0 };
+         GgError ret = ggl_gg_config_read_str(
+             GG_BUF_LIST(
+                 GG_STR("services"),

--- a/recipes-iot/aws-iot-greengrass/greengrass-lite_2.4.0.bb
+++ b/recipes-iot/aws-iot-greengrass/greengrass-lite_2.4.0.bb
@@ -36,6 +36,7 @@ SRC_URI = "\
     ${@'' if d.getVar('DISABLE_FETCHCONTENT') else 'git://github.com/aws/SigV4-for-AWS-IoT-embedded-sdk.git;protocol=https;branch=main;name=sigv4;destsuffix=${S}/thirdparty/aws_sigv4'} \
     ${@'' if d.getVar('DISABLE_FETCHCONTENT') else 'git://github.com/aws-greengrass/aws-greengrass-component-sdk.git;protocol=https;nobranch=1;name=sdk;destsuffix=${S}/thirdparty/gg_sdk'} \
     file://001-disable_strip.patch \
+    file://002-fix-maybe-uninitialized.patch \
     file://greengrass-lite.yaml \
     file://run-ptest \
     ${@bb.utils.contains('PACKAGECONFIG','localdeployment','file://ggl.local-deployment.service','',d)} \

--- a/recipes-iot/aws-iot-securetunneling-localproxy/aws-iot-securetunneling-localproxy_git.bb
+++ b/recipes-iot/aws-iot-securetunneling-localproxy/aws-iot-securetunneling-localproxy_git.bb
@@ -25,7 +25,7 @@ SRC_URI = "\
     file://0005-fix-boost-system-header-only.patch \
     file://run-ptest \
     "
-SRCREV = "fd04f3d0cb9526a33f89698530392b3568c8fdba"
+SRCREV = "18f6bc3593423dac85349a23467675783a9e7619"
 
 UPSTREAM_CHECK_COMMITS = "1"
 

--- a/recipes-iot/aws-iot-securetunneling-localproxy/files/0001-boost-support-any.patch
+++ b/recipes-iot/aws-iot-securetunneling-localproxy/files/0001-boost-support-any.patch
@@ -1,4 +1,4 @@
-From 1ed7341cf187437d133e33d3be57541dc16b933c Mon Sep 17 00:00:00 2001
+From d37019c884a9bcb20f843a247a3e2fb99430c560 Mon Sep 17 00:00:00 2001
 From: Thomas Roos <throos@amazon.de>
 Date: Fri, 10 Mar 2023 12:46:05 +0000
 Subject: [PATCH] aws-iot-securetunneling-localproxy: support any boost version

--- a/recipes-iot/aws-iot-securetunneling-localproxy/files/0002-remove-cxx-standard.patch
+++ b/recipes-iot/aws-iot-securetunneling-localproxy/files/0002-remove-cxx-standard.patch
@@ -1,4 +1,4 @@
-From 2aa664a7c81c27904cdf0c18c9f4997420b35e9f Mon Sep 17 00:00:00 2001
+From 0532785d055d5ffa45f5e91166b0264f2f71fd68 Mon Sep 17 00:00:00 2001
 From: Thomas Roos <throos@amazon.de>
 Date: Tue, 9 Jan 2024 14:34:32 +0000
 Subject: [PATCH] aws-iot-securetunneling-localproxy: remove setting of

--- a/recipes-iot/aws-iot-securetunneling-localproxy/files/0004-cmake-version.patch
+++ b/recipes-iot/aws-iot-securetunneling-localproxy/files/0004-cmake-version.patch
@@ -1,4 +1,4 @@
-From 2a4e94a2478912d7358092cc7912bd44adce3355 Mon Sep 17 00:00:00 2001
+From 471279093ce8d188e80d3626020227343aa3cea8 Mon Sep 17 00:00:00 2001
 From: OpenEmbedded <oe.patch@oe>
 Date: Tue, 22 Oct 2024 02:00:39 +0000
 Subject: [PATCH] aws-iot-securetunneling-localproxy: upgrade git -> new

--- a/recipes-iot/aws-iot-securetunneling-localproxy/files/0005-fix-boost-system-header-only.patch
+++ b/recipes-iot/aws-iot-securetunneling-localproxy/files/0005-fix-boost-system-header-only.patch
@@ -1,4 +1,4 @@
-From f7e68e696e791f30ca89409016e1e62b92a56e35 Mon Sep 17 00:00:00 2001
+From a44c3265d899e0e6e78e88175b7bd6c6a3692e92 Mon Sep 17 00:00:00 2001
 From: Yocto Build System <yocto@example.com>
 Date: Mon, 9 Sep 2024 11:30:00 +0000
 Subject: [PATCH] Fix Boost compatibility for Boost 1.89+

--- a/recipes-sdk/aws-c-auth/aws-c-auth_0.10.2.bb
+++ b/recipes-sdk/aws-c-auth/aws-c-auth_0.10.2.bb
@@ -23,7 +23,7 @@ SRC_URI = "\
     git://github.com/awslabs/aws-c-auth.git;protocol=https;branch=${BRANCH} \
     file://run-ptest \
     "
-SRCREV = "fc4b87655e5cd3921f18d1859193c74af4102071"
+SRCREV = "4b5cf14bfbb7d402ed89c7d614d77e924a65321f"
 
 inherit cmake ptest pkgconfig
 

--- a/recipes-sdk/aws-c-cal/aws-c-cal_0.9.14.bb
+++ b/recipes-sdk/aws-c-cal/aws-c-cal_0.9.14.bb
@@ -21,7 +21,7 @@ SRC_URI = "\
     file://run-ptest \
     "
 
-SRCREV = "1cb9412158890201a6ffceed779f90fe1f48180c"
+SRCREV = "9edd8eac2b21ca6a04535b91d60d361c2f1bb60f"
 
 inherit cmake ptest pkgconfig
 

--- a/recipes-sdk/aws-c-cal/files/001-enable-tests-with-crosscompiling.patch
+++ b/recipes-sdk/aws-c-cal/files/001-enable-tests-with-crosscompiling.patch
@@ -1,4 +1,4 @@
-From 75dff69bd5595658dfc986cfed4338334b719998 Mon Sep 17 00:00:00 2001
+From ae9b50671e120cf1bf9e120f93a636e95a9a42af Mon Sep 17 00:00:00 2001
 From: Thomas Roos <throos@amazon.de>
 Date: Mon, 29 Sep 2025 12:51:03 +0000
 Subject: [PATCH] This enable the tests even when crosscompiling.

--- a/recipes-sdk/aws-c-common/aws-c-common_0.13.0.bb
+++ b/recipes-sdk/aws-c-common/aws-c-common_0.13.0.bb
@@ -14,7 +14,7 @@ SRC_URI = "\
     file://ptest_result.py \
     file://0001-skip-iso8601-tests-on-32bit.patch \
 "
-SRCREV = "95515a8b1ff40d5bb14f965ca4cbbe99ad1843df"
+SRCREV = "7f18168e834b2abf276c6f92ae3b27af494fcca1"
 
 # will match only x.x.x for auto upgrades, because: https://github.com/awslabs/aws-c-common/issues/1025
 UPSTREAM_CHECK_GITTAGREGEX = "(?P<pver>\d\.\d+(\.\d+)+)"

--- a/recipes-sdk/aws-c-common/files/0001-skip-iso8601-tests-on-32bit.patch
+++ b/recipes-sdk/aws-c-common/files/0001-skip-iso8601-tests-on-32bit.patch
@@ -1,4 +1,4 @@
-From def81943596cf2157918aa309df9a907b2e2603c Mon Sep 17 00:00:00 2001
+From 1a67d3ebcfc74050b63a983468d10d86e793e43c Mon Sep 17 00:00:00 2001
 From: Thomas Roos <throos@amazon.de>
 Date: Tue, 12 Aug 2025 08:51:48 +0000
 Subject: [PATCH] Skip ISO8601 parsing tests on 32-bit architectures due to

--- a/recipes-sdk/aws-c-event-stream/aws-c-event-stream_0.7.1.bb
+++ b/recipes-sdk/aws-c-event-stream/aws-c-event-stream_0.7.1.bb
@@ -20,7 +20,7 @@ SRC_URI = "\
     git://github.com/awslabs/aws-c-event-stream.git;protocol=https;branch=${BRANCH} \
     file://run-ptest \
     "
-SRCREV = "66cafb1d8bb1bfeb62a7601ce03d1a6fcd4798ed"
+SRCREV = "51bef3c44e1058b1689751539170b2e0f589ccdb"
 
 inherit cmake ptest pkgconfig
 

--- a/recipes-sdk/aws-c-http/aws-c-http_0.11.0.bb
+++ b/recipes-sdk/aws-c-http/aws-c-http_0.11.0.bb
@@ -23,7 +23,7 @@ SRC_URI = "\
     file://run-ptest \
     "
 
-SRCREV = "2a22c94f71bfca8dd954ad4fdd96150a3d23efa8"
+SRCREV = "8aefd899fc3210bfd0e3fd414011a3cb708bf6e4"
 
 inherit cmake ptest pkgconfig
 

--- a/recipes-sdk/aws-c-mqtt/aws-c-mqtt_0.16.0.bb
+++ b/recipes-sdk/aws-c-mqtt/aws-c-mqtt_0.16.0.bb
@@ -23,7 +23,7 @@ SRC_URI = "\
     file://run-ptest \
     "
 
-SRCREV = "3c2ceee52b66db42228053a4fb55210c8f8433a0"
+SRCREV = "2ef9605ec9c50bea3f921e08022ddd57eed70901"
 
 inherit cmake ptest
 

--- a/recipes-sdk/aws-c-s3/aws-c-s3_0.12.4.bb
+++ b/recipes-sdk/aws-c-s3/aws-c-s3_0.12.4.bb
@@ -19,7 +19,7 @@ SRC_URI = "\
     git://github.com/awslabs/aws-c-s3.git;protocol=https;branch=${BRANCH} \
     file://run-ptest \
     "
-SRCREV = "a31a657840daffbfa7749b63cd0e2a178a6a5d9e"
+SRCREV = "f1a52b5e960c06bd9392cb5e982c6fe04f1ce253"
 
 inherit cmake ptest pkgconfig
 

--- a/recipes-sdk/aws-crt-cpp/aws-crt-cpp/001-shared-static-crt-libs.patch
+++ b/recipes-sdk/aws-crt-cpp/aws-crt-cpp/001-shared-static-crt-libs.patch
@@ -1,4 +1,4 @@
-From 6d99dbc2c6f54aac9c4ef570330c9726e9226437 Mon Sep 17 00:00:00 2001
+From 77b249dbc3258423412f956d35981c3e72aebbdc Mon Sep 17 00:00:00 2001
 From: Thomas Roos <throos@amazon.de>
 Date: Tue, 20 May 2025 08:45:29 +0000
 Subject: [PATCH] aws-crt-cpp: change to build-deps as default

--- a/recipes-sdk/aws-crt-cpp/aws-crt-cpp/002-enable-tests-with-crosscompiling.patch
+++ b/recipes-sdk/aws-crt-cpp/aws-crt-cpp/002-enable-tests-with-crosscompiling.patch
@@ -1,4 +1,4 @@
-From e9933dd0ed1c299167639c90901a18956302e96a Mon Sep 17 00:00:00 2001
+From b4726f63e1494496122496ee0a8eaa68bb6fba39 Mon Sep 17 00:00:00 2001
 From: Thomas Roos <throos@amazon.de>
 Date: Mon, 29 Sep 2025 12:51:03 +0000
 Subject: [PATCH] This enable the tests even when crosscompiling.

--- a/recipes-sdk/aws-crt-cpp/aws-crt-cpp_0.39.1.bb
+++ b/recipes-sdk/aws-crt-cpp/aws-crt-cpp_0.39.1.bb
@@ -28,7 +28,7 @@ SRC_URI = "\
     file://002-enable-tests-with-crosscompiling.patch \
     "
 
-SRCREV = "b60cd5c3b27e8eb8bd3769b7b7330eff311f5530"
+SRCREV = "b540e9314f3ecc5a6c592efb07a516a6b20c5bbb"
 
 inherit cmake pkgconfig ptest
 

--- a/recipes-sdk/aws-crt-python/aws-crt-python_0.33.0.bb
+++ b/recipes-sdk/aws-crt-python/aws-crt-python_0.33.0.bb
@@ -36,7 +36,7 @@ SRC_URI = "\
     file://run-ptest \
     "
 
-SRCREV = "3e14d24aa02a9f227eb592b12e682651f9e97aa9"
+SRCREV = "74f88049cd779becbc93bbd5cd32b709d0a40420"
 UPSTREAM_CHECK_GITTAGREGEX = "v(?P<pver>.*)"
 
 inherit setuptools3_legacy ptest

--- a/recipes-sdk/aws-crt-python/files/001-fix-cross-compilation-support.patch
+++ b/recipes-sdk/aws-crt-python/files/001-fix-cross-compilation-support.patch
@@ -1,4 +1,4 @@
-From 53c5b5114303185c8d4a69ec241901835554df33 Mon Sep 17 00:00:00 2001
+From 622237504a99dbe13f28d785e650e36adf39a5fa Mon Sep 17 00:00:00 2001
 From: AWS Meta Layer <meta-aws@amazon.com>
 Date: Thu, 24 Jul 2025 12:00:00 +0000
 Subject: [PATCH] Fix cross-compilation support

--- a/recipes-sdk/aws-lc/aws-lc_5.0.0.bb
+++ b/recipes-sdk/aws-lc/aws-lc_5.0.0.bb
@@ -878,7 +878,7 @@ SRC_URI = "\
     git://github.com/awslabs/aws-lc.git;protocol=https;branch=${BRANCH} \
     file://run-ptest \
     "
-SRCREV = "44766fa7daa88e5afc7fc6de3311c48eeeb02f39"
+SRCREV = "6f246af4cd1de8cee8c62d76139bcda299c1aa00"
 UPSTREAM_CHECK_GITTAGREGEX = "v(?P<pver>.*)"
 
 # nooelint: oelint.vars.specific

--- a/recipes-sdk/aws-lc/aws-lc_5.0.0.bb
+++ b/recipes-sdk/aws-lc/aws-lc_5.0.0.bb
@@ -938,7 +938,7 @@ FILES_SOLIBSDEV = ""
 BBCLASSEXTEND = "native nativesdk"
 
 inherit update-alternatives
-ALTERNATIVE_PRIORITY = "100"
+ALTERNATIVE_PRIORITY = "200"
 ALTERNATIVE:${PN} = "openssl"
 
 ALTERNATIVE_TARGET[openssl] = "${bindir}/openssl"

--- a/recipes-sdk/aws-lc/aws-lc_5.0.0.bb
+++ b/recipes-sdk/aws-lc/aws-lc_5.0.0.bb
@@ -937,8 +937,5 @@ FILES_SOLIBSDEV = ""
 
 BBCLASSEXTEND = "native nativesdk"
 
-inherit update-alternatives
-ALTERNATIVE_PRIORITY = "200"
-ALTERNATIVE:${PN} = "openssl"
-
-ALTERNATIVE_TARGET[openssl] = "${bindir}/openssl"
+# aws-lc provides libssl.so/libcrypto.so which conflict with openssl
+RCONFLICTS:${PN} = "openssl"

--- a/recipes-support/amazon-ssm-agent/amazon-ssm-agent_3.3.4515.0.bb
+++ b/recipes-support/amazon-ssm-agent/amazon-ssm-agent_3.3.4515.0.bb
@@ -13,7 +13,7 @@ SRC_URI = "\
     file://run-ptest \
     "
 
-SRCREV = "0421963b5ad118a7afb5cce11b0566faa4d96fe0"
+SRCREV = "b8acce1284383abb5ee86089912968b9af7c4025"
 
 GO_IMPORT = ""
 


### PR DESCRIPTION
## Release Merge

Merge `whinlatter-next` into `whinlatter` for the week 23 release.

### Changes
- aws-c-auth, aws-c-cal, aws-c-common, aws-c-event-stream, aws-c-http, aws-c-mqtt, aws-c-s3: version upgrades
- aws-crt-cpp, aws-crt-python: version upgrades
- python3-s3transfer: version upgrade
- amazon-ssm-agent: version upgrade
- aws-iot-securetunneling-localproxy: version upgrade
- greengrass-lite: upgrade 2.4.0 → 2.5.1
- aws-lc: fix postinst failure — replace broken update-alternatives with RCONFLICTS (#15800)
- ci: use dropbear when testing aws-lc to avoid openssl conflict

No conflicts.

**Note:** Whinlatter (Yocto 5.3) reaches EOL this month. This may be one of the final releases.