### PR TITLE
[Backport scarthgap-next] 2026-06-04_01-59-22_master-next_aws-crt-python

### DIFF
--- a/recipes-sdk/aws-crt-python/aws-crt-python_0.34.0.bb
+++ b/recipes-sdk/aws-crt-python/aws-crt-python_0.34.0.bb
@@ -37,7 +37,7 @@ SRC_URI = "\
     file://run-ptest \
     "
 
-SRCREV = "74f88049cd779becbc93bbd5cd32b709d0a40420"
+SRCREV = "75c0c571973d9c4bbb37f10ac0701de04e30a1dd"
 UPSTREAM_CHECK_GITTAGREGEX = "v(?P<pver>.*)"
 
 S = "${WORKDIR}/git"

--- a/recipes-sdk/aws-crt-python/files/001-fix-cross-compilation-support.patch
+++ b/recipes-sdk/aws-crt-python/files/001-fix-cross-compilation-support.patch
@@ -1,4 +1,4 @@
-From 622237504a99dbe13f28d785e650e36adf39a5fa Mon Sep 17 00:00:00 2001
+From dcb43e704bd69c762f2c4eecae0a7f3541ca8ec6 Mon Sep 17 00:00:00 2001
 From: AWS Meta Layer <meta-aws@amazon.com>
 Date: Thu, 24 Jul 2025 12:00:00 +0000
 Subject: [PATCH] Fix cross-compilation support
@@ -15,7 +15,7 @@ Signed-off-by: AWS Meta Layer <meta-aws@amazon.com>
  1 file changed, 12 insertions(+)
 
 diff --git a/setup.py b/setup.py
-index 380e5e9..9dfd6ea 100644
+index 032bff8..c4ba4f7 100644
 --- a/setup.py
 +++ b/setup.py
 @@ -370,12 +370,24 @@ class awscrt_build_ext(setuptools.command.build_ext.build_ext):


### PR DESCRIPTION
# Description
Backport of #15811 to `scarthgap-next`.