### PR TITLE
[Backport scarthgap-next] 2026-06-05_01-50-52_master-next_aws-crt-python

### DIFF
--- a/recipes-sdk/aws-crt-python/aws-crt-python_0.34.1.bb
+++ b/recipes-sdk/aws-crt-python/aws-crt-python_0.34.1.bb
@@ -37,7 +37,7 @@ SRC_URI = "\
     file://run-ptest \
     "
 
-SRCREV = "75c0c571973d9c4bbb37f10ac0701de04e30a1dd"
+SRCREV = "f78d829f8cd5d2ccff7cd2498a1b16d38cefcc95"
 UPSTREAM_CHECK_GITTAGREGEX = "v(?P<pver>.*)"
 
 S = "${WORKDIR}/git"

--- a/recipes-sdk/aws-crt-python/files/001-fix-cross-compilation-support.patch
+++ b/recipes-sdk/aws-crt-python/files/001-fix-cross-compilation-support.patch
@@ -1,4 +1,4 @@
-From dcb43e704bd69c762f2c4eecae0a7f3541ca8ec6 Mon Sep 17 00:00:00 2001
+From a05d186e1f5ed431e507cc214a3a9284ddec28e7 Mon Sep 17 00:00:00 2001
 From: AWS Meta Layer <meta-aws@amazon.com>
 Date: Thu, 24 Jul 2025 12:00:00 +0000
 Subject: [PATCH] Fix cross-compilation support


### PR DESCRIPTION
# Description
Backport of #15827 to `scarthgap-next`.