### PR TITLE
amazon-ssm-agent: upgrade 3.3.1957.0 -> 3.3.4515.0

### DIFF
--- a/recipes-support/amazon-ssm-agent/amazon-ssm-agent_3.3.4515.0.bb
+++ b/recipes-support/amazon-ssm-agent/amazon-ssm-agent_3.3.4515.0.bb
@@ -13,7 +13,7 @@ SRC_URI = "\
     file://run-ptest \
     "
 
-SRCREV = "b47799d07ddf776df1689165aedf21e68bbc3d0f"
+SRCREV = "b8acce1284383abb5ee86089912968b9af7c4025"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-support/amazon-ssm-agent/amazon-ssm-agent_3.3.4515.0.bb
+++ b/recipes-support/amazon-ssm-agent/amazon-ssm-agent_3.3.4515.0.bb
@@ -11,6 +11,7 @@ LIC_FILES_CHKSUM = "\
 SRC_URI = "\
     git://github.com/aws/amazon-ssm-agent.git;protocol=https;branch=mainline \
     file://run-ptest \
+    file://0001-go.mod-remove-go-1.25-godebug-directive.patch \
     "
 
 SRCREV = "b8acce1284383abb5ee86089912968b9af7c4025"

--- a/recipes-support/amazon-ssm-agent/files/0001-go.mod-remove-go-1.25-godebug-directive.patch
+++ b/recipes-support/amazon-ssm-agent/files/0001-go.mod-remove-go-1.25-godebug-directive.patch
@@ -1,0 +1,92 @@
+From: meta-aws maintainers <meta-aws-maintainer@users.noreply.github.com>
+Subject: [PATCH] Downgrade go version requirements for Go 1.22 compatibility
+
+Scarthgap ships Go 1.22 which does not support the godebug block syntax
+in go.mod, nor will it build vendored modules declaring go > 1.22.
+
+The godebug directive sets containermaxprocs=0 which is a workaround for a
+bug introduced in Go 1.25 related to cgroup CPU limit detection. This is
+irrelevant for embedded Linux targets that do not run in containers.
+
+The vendor/modules.txt version constraints are metadata only - the vendored
+source is already present and compatible with Go 1.22.
+
+This patch should be removed once scarthgap upgrades to Go 1.25 or newer.
+
+Upstream-Status: Inappropriate [scarthgap Go toolchain limitation]
+Signed-off-by: meta-aws maintainers <meta-aws-maintainer@users.noreply.github.com>
+---
+diff --git a/go.mod b/go.mod
+index 7e7261e3..e9fcde50 100644
+--- a/go.mod
++++ b/go.mod
+@@ -1,14 +1,11 @@
+ module github.com/aws/amazon-ssm-agent
+ 
+-go 1.25
++go 1.22
+ 
+ replace github.com/aws/aws-sdk-go => ./extra/aws-sdk-go
+ 
+ replace github.com/nightlyone/lockfile => ./extra/lockfile
+ 
+-godebug (
+-    containermaxprocs=0 // disable consideration of cgroup limits
+-)
+ 
+ require (
+ 	github.com/Jeffail/gabs v1.0.0
+diff --git a/vendor/modules.txt b/vendor/modules.txt
+index 468d149c..4799fce6 100644
+--- a/vendor/modules.txt
++++ b/vendor/modules.txt
+@@ -170,7 +170,7 @@ github.com/go-git/gcfg/scanner
+ github.com/go-git/gcfg/token
+ github.com/go-git/gcfg/types
+ # github.com/go-git/go-billy/v5 v5.8.0
+-## explicit; go 1.24.0
++## explicit; go 1.22.0
+ github.com/go-git/go-billy/v5
+ github.com/go-git/go-billy/v5/helper/chroot
+ github.com/go-git/go-billy/v5/helper/polyfill
+@@ -178,7 +178,7 @@ github.com/go-git/go-billy/v5/memfs
+ github.com/go-git/go-billy/v5/osfs
+ github.com/go-git/go-billy/v5/util
+ # github.com/go-git/go-git/v5 v5.17.1
+-## explicit; go 1.24.0
++## explicit; go 1.22.0
+ github.com/go-git/go-git/v5
+ github.com/go-git/go-git/v5/config
+ github.com/go-git/go-git/v5/internal/path_util
+@@ -315,7 +315,7 @@ go.nanomsg.org/mangos/v3/protocol/surveyor
+ go.nanomsg.org/mangos/v3/transport
+ go.nanomsg.org/mangos/v3/transport/ipc
+ # golang.org/x/crypto v0.50.0
+-## explicit; go 1.25.0
++## explicit; go 1.22.0
+ golang.org/x/crypto/argon2
+ golang.org/x/crypto/blake2b
+ golang.org/x/crypto/blowfish
+@@ -333,19 +333,19 @@ golang.org/x/crypto/ssh/agent
+ golang.org/x/crypto/ssh/internal/bcrypt_pbkdf
+ golang.org/x/crypto/ssh/knownhosts
+ # golang.org/x/net v0.53.0
+-## explicit; go 1.25.0
++## explicit; go 1.22.0
+ golang.org/x/net/context
+ golang.org/x/net/internal/socks
+ golang.org/x/net/proxy
+ # golang.org/x/oauth2 v0.28.0
+-## explicit; go 1.23.0
++## explicit; go 1.22.0
+ golang.org/x/oauth2
+ golang.org/x/oauth2/internal
+ # golang.org/x/sync v0.10.0
+ ## explicit; go 1.18
+ golang.org/x/sync/errgroup
+ # golang.org/x/sys v0.43.0
+-## explicit; go 1.25.0
++## explicit; go 1.22.0
+ golang.org/x/sys/cpu
+ golang.org/x/sys/execabs
+ golang.org/x/sys/unix


### PR DESCRIPTION
## amazon-ssm-agent: upgrade 3.3.1957.0 → 3.3.4515.0

Upgrade amazon-ssm-agent to match the current master version.

### Why this is needed

The auto-backport system (cherry-pick from master-next) cannot upgrade this recipe on scarthgap-next because:
1. The scarthgap recipe uses `S = "${WORKDIR}/git"` and `fetcher.unpack(d.getVar('WORKDIR'))` (Yocto 5.0/scarthgap semantics)
2. Master uses `UNPACKDIR` (Yocto 5.3+/master semantics)
3. Cherry-picks fail due to file rename conflicts (scarthgap has a much older version filename than what the cherry-pick expects to delete)

Additionally, the direct `auto-recipe-update.yml` on scarthgap-next appears broken (references old bot credentials and incorrect Poky branch name).

### Changes
- Rename `amazon-ssm-agent_3.3.1957.0.bb` → `amazon-ssm-agent_3.3.4515.0.bb`
- Update SRCREV to `b8acce1284383abb5ee86089912968b9af7c4025`
- Preserves scarthgap-specific recipe structure (`S = "${WORKDIR}/git"`, `WORKDIR` unpack path)

### References
- PR #14705: Last direct scarthgap-next auto-upgrade attempt (Jan 2026, closed without merge)
- PR #15473: Manual bulk sync (Apr 2026, merged but later lost to branch reset)
- Master version: 3.3.4515.0 (PR #15804, Jun 3 2026)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.