### PR TITLE
Release: merge whinlatter-next to whinlatter (2026-W24)

### DIFF
--- a/.github/workflows/auto-approve-and-enable-auto-merge.yml
+++ b/.github/workflows/auto-approve-and-enable-auto-merge.yml
@@ -7,8 +7,6 @@ on:
       - '*-next'
 
 permissions: {}
-
-permissions: {}
 jobs:
   auto-approve-and-merge:
     runs-on: ubuntu-22.04

--- a/.github/workflows/build-test-recipe.yml
+++ b/.github/workflows/build-test-recipe.yml
@@ -160,7 +160,7 @@ jobs:
           export RECIPES=$( echo "${{ needs.changed.outputs.diff }}" | tr ' ' '\n' | grep '\.bb.*$' | sed 's!.*/!!' | sed 's!.bb!!' | sed 's!_.*!!' | sort | uniq | sed -z $'s/\\\n/ /g')
           if [ "" == "$RECIPES" ]; then
             echo "No changed recipes, adding everything with a ptest to test, build"
-            THINGS_TO_EXCLUDE="! -name aws-lc* ! -name neo-ai-tv* ! -name corretto-17-bin* ! -name corretto-21-bin* ! -name corretto-8-bin* ! -name corretto-25-bin* ! -name firecracker-bin* ! -name jailer-bin* ! -name amazon-kvs-producer-sdk-c* ! -name  aws-cli-v2* ! -name  aws-iot-device-sdk-embedded-c* ! -name greengrass_* ! -name greengrass-bin* "
+            THINGS_TO_EXCLUDE="! -name aws-lc* ! -name neo-ai-tv* ! -name amazon-kvs-producer-sdk-c* ! -name aws-cli-v2* ! -name aws-iot-device-sdk-embedded-c* ! -name greengrass_* ! -name greengrass-bin* "
             export RECIPES=$(find meta-aws/ -name *.bb -type f \( ${THINGS_TO_EXCLUDE} \) -print | xargs grep -l 'inherit.*ptest.*'| sed 's!.*/!!' | sed 's!.bb!!' | sed 's!_.*!!' | sort | uniq | sed -z $'s/\\\n/ /g')
             echo THINGS_TO_EXCLUDE: $THINGS_TO_EXCLUDE
           fi
@@ -181,13 +181,13 @@ jobs:
               SKIP_RECIPE=true
             fi
 
-            # Check for default COMPATIBLE_MACHINE = "null" without override for this arch
-            if echo "$RECIPE_FILES" | xargs grep -q "^COMPATIBLE_MACHINE[[:space:]]*=[[:space:]]*\"null\"" 2>/dev/null; then
+            # Check for default COMPATIBLE_MACHINE = "null" or "(^$)" without override for this arch
+            if echo "$RECIPE_FILES" | xargs grep -qE 'COMPATIBLE_MACHINE[[:space:]]*=[[:space:]]*"(null|\(\^)' 2>/dev/null; then
               # Check if there's an override for this specific architecture
               case "${{ matrix.machine }}" in
                 qemuarm)
-                  if ! echo "$RECIPE_FILES" | xargs grep -q "COMPATIBLE_MACHINE:armv7[av][[:space:]]*=[[:space:]]*\"(.*)\"" 2>/dev/null; then
-                    echo "Skipping $recipe: COMPATIBLE_MACHINE = null (no armv7 override)"
+                  if ! echo "$RECIPE_FILES" | xargs grep -qE "COMPATIBLE_MACHINE:(arm|armv7[ave]*)[[:space:]]*=[[:space:]]*\"\(.\?\*\)\"" 2>/dev/null; then
+                    echo "Skipping $recipe: COMPATIBLE_MACHINE default blocks, no arm/armv7 override"
                     SKIP_RECIPE=true
                   fi
                   ;;
@@ -238,6 +238,13 @@ jobs:
           if echo "$RECIPES" | grep -qw "aws-cli-v2" && echo "$RECIPES" | grep -qw "aws-cli"; then
             RECIPES=$(echo "$RECIPES" | tr ' ' '\n' | grep -v '^aws-cli$' | tr '\n' ' ')
             echo "Excluded aws-cli (v1) due to conflict with aws-cli-v2"
+          fi
+
+          # Handle mutually exclusive corretto versions - keep only corretto-11-bin
+          if echo "$RECIPES" | grep -qw "corretto-11-bin"; then
+            RECIPES=$(echo "$RECIPES" | tr ' ' '\n' | grep -v '^corretto-[0-9]*-bin$' | tr '\n' ' ')
+            RECIPES="$RECIPES corretto-11-bin"
+            echo "Kept only corretto-11-bin (corretto versions are mutually exclusive)"
           fi
 
           echo RECIPES to build, test: "$RECIPES"

--- a/recipes-containers/firecracker-bin/firecracker-bin_1.16.0.bb
+++ b/recipes-containers/firecracker-bin/firecracker-bin_1.16.0.bb
@@ -18,8 +18,8 @@ COMPATIBLE_HOST:arm = "null"
 # nooelint: oelint.vars.srcurichecksum
 SRC_URI = "https://github.com/firecracker-microvm/firecracker/releases/download/v${PV}/firecracker-v${PV}-${ARCH_DIR}.tgz;name=${ARCH_DIR}"
 
-SRC_URI[x86_64.sha256sum] = "d4a32ab2322d887ca1bc4a4e7afa9cc35393e6362dfc2b3becb389d362e4275a"
-SRC_URI[aarch64.sha256sum] = "00654ac1e702a22744121ea9f10a4f792ebd7c3a744cba587dfac9fcb79b41a5"
+SRC_URI[x86_64.sha256sum] = "bd04e26952d4e158085778c6230a0b383d2619c319182e27eaa9d61a212e92d6"
+SRC_URI[aarch64.sha256sum] = "531c713cdbc37d4b8bc2533d851aabc0267096afa1768086a37672abb668efd7"
 
 UPGRADE_ARCHS = "x86_64 aarch64"
 RECIPE_UPGRADE_EXTRA_TASKS = "update_other_arch_checksum"

--- a/recipes-containers/firecracker-bin/jailer-bin_1.16.0.bb
+++ b/recipes-containers/firecracker-bin/jailer-bin_1.16.0.bb
@@ -18,8 +18,8 @@ COMPATIBLE_HOST:arm = "null"
 # nooelint: oelint.vars.srcurichecksum
 SRC_URI = "https://github.com/firecracker-microvm/firecracker/releases/download/v${PV}/firecracker-v${PV}-${ARCH_DIR}.tgz;name=${ARCH_DIR}"
 
-SRC_URI[x86_64.sha256sum] = "d4a32ab2322d887ca1bc4a4e7afa9cc35393e6362dfc2b3becb389d362e4275a"
-SRC_URI[aarch64.sha256sum] = "00654ac1e702a22744121ea9f10a4f792ebd7c3a744cba587dfac9fcb79b41a5"
+SRC_URI[x86_64.sha256sum] = "bd04e26952d4e158085778c6230a0b383d2619c319182e27eaa9d61a212e92d6"
+SRC_URI[aarch64.sha256sum] = "531c713cdbc37d4b8bc2533d851aabc0267096afa1768086a37672abb668efd7"
 
 UPGRADE_ARCHS = "x86_64 aarch64"
 RECIPE_UPGRADE_EXTRA_TASKS = "update_other_arch_checksum"

--- a/recipes-sdk/aws-c-s3/aws-c-s3_0.12.5.bb
+++ b/recipes-sdk/aws-c-s3/aws-c-s3_0.12.5.bb
@@ -19,7 +19,7 @@ SRC_URI = "\
     git://github.com/awslabs/aws-c-s3.git;protocol=https;branch=${BRANCH} \
     file://run-ptest \
     "
-SRCREV = "f1a52b5e960c06bd9392cb5e982c6fe04f1ce253"
+SRCREV = "dd71b3be7d2545d1470cd20464742fef297d50d3"
 
 inherit cmake ptest pkgconfig
 

--- a/recipes-sdk/aws-c-sdkutils/aws-c-sdkutils_0.2.5.bb
+++ b/recipes-sdk/aws-c-sdkutils/aws-c-sdkutils_0.2.5.bb
@@ -15,7 +15,7 @@ SRC_URI = "\
     file://run-ptest \
     file://001-enable-tests-with-crosscompiling.patch \
     "
-SRCREV = "f678bda9e21f7217e4bbf35e0d1ea59540687933"
+SRCREV = "c70418c17d8f970ff1d80d88d08beeccd425a887"
 
 inherit cmake ptest pkgconfig
 

--- a/recipes-sdk/aws-c-sdkutils/files/001-enable-tests-with-crosscompiling.patch
+++ b/recipes-sdk/aws-c-sdkutils/files/001-enable-tests-with-crosscompiling.patch
@@ -1,15 +1,21 @@
-This enable the tests even when crosscompiling.
+From e01ddc18867253e389f19aeb7e8e49422b4d6e09 Mon Sep 17 00:00:00 2001
+From: Thomas Roos <throos@amazon.de>
+Date: Mon, 29 Sep 2025 12:51:03 +0000
+Subject: [PATCH] This enable the tests even when crosscompiling.
 
 Upstream-Status: Inappropriate [oe specific]
+---
+ CMakeLists.txt | 2 --
+ 1 file changed, 2 deletions(-)
 
-Index: aws-c-sdkutils-0.2.4/CMakeLists.txt
-===================================================================
---- aws-c-sdkutils-0.2.4.orig/CMakeLists.txt
-+++ aws-c-sdkutils-0.2.4/CMakeLists.txt
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 0457e0f..b42625f 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
 @@ -90,9 +90,7 @@ install(FILES ${EXPORT_MODULES}
          DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}/modules"
          COMPONENT Development)
-
+ 
 -if (NOT CMAKE_CROSSCOMPILING)
      include(CTest)
      if (BUILD_TESTING)

--- a/recipes-sdk/aws-crt-cpp/aws-crt-cpp/001-shared-static-crt-libs.patch
+++ b/recipes-sdk/aws-crt-cpp/aws-crt-cpp/001-shared-static-crt-libs.patch
@@ -1,4 +1,4 @@
-From 77b249dbc3258423412f956d35981c3e72aebbdc Mon Sep 17 00:00:00 2001
+From ef9d8437d6b5b0306c29f32d43e98c752af9d497 Mon Sep 17 00:00:00 2001
 From: Thomas Roos <throos@amazon.de>
 Date: Tue, 20 May 2025 08:45:29 +0000
 Subject: [PATCH] aws-crt-cpp: change to build-deps as default
@@ -13,7 +13,7 @@ Upstream-Status: Inappropriate [oe specific]
  1 file changed, 2 insertions(+)
 
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index e9a3827..83bc66b 100644
+index a907b35..d003cab 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -48,6 +48,7 @@ set(GENERATED_CONFIG_HEADER "${GENERATED_INCLUDE_DIR}/aws/crt/Config.h")
@@ -24,7 +24,7 @@ index e9a3827..83bc66b 100644
      list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/crt/aws-c-common/cmake")
  
      include(AwsFindPackage)
-@@ -129,6 +130,7 @@ if(BUILD_DEPS)
+@@ -143,6 +144,7 @@ if(BUILD_DEPS)
      add_subdirectory(crt/aws-c-event-stream)
      add_subdirectory(crt/aws-c-s3)
      set(BUILD_TESTING ${BUILD_TESTING_PREV})

--- a/recipes-sdk/aws-crt-cpp/aws-crt-cpp/002-enable-tests-with-crosscompiling.patch
+++ b/recipes-sdk/aws-crt-cpp/aws-crt-cpp/002-enable-tests-with-crosscompiling.patch
@@ -1,4 +1,4 @@
-From b4726f63e1494496122496ee0a8eaa68bb6fba39 Mon Sep 17 00:00:00 2001
+From 696c3694a3da4fb307d0a695bac84f65506e1a83 Mon Sep 17 00:00:00 2001
 From: Thomas Roos <throos@amazon.de>
 Date: Mon, 29 Sep 2025 12:51:03 +0000
 Subject: [PATCH] This enable the tests even when crosscompiling.
@@ -9,10 +9,10 @@ Upstream-Status: Inappropriate [oe specific]
  1 file changed, 2 deletions(-)
 
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 83bc66b..6862d8c 100644
+index d003cab..e10bf79 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -412,7 +412,6 @@ install(FILES "${GENERATED_ROOT_DIR}/${PROJECT_NAME}-config-version.cmake"
+@@ -426,7 +426,6 @@ install(FILES "${GENERATED_ROOT_DIR}/${PROJECT_NAME}-config-version.cmake"
      DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}/"
      COMPONENT Development)
  
@@ -20,7 +20,7 @@ index 83bc66b..6862d8c 100644
      if(BUILD_TESTING)
          add_subdirectory(tests)
  
-@@ -422,4 +421,3 @@ if(NOT CMAKE_CROSSCOMPILING)
+@@ -436,4 +435,3 @@ if(NOT CMAKE_CROSSCOMPILING)
              add_subdirectory(bin/mqtt5_canary)
          endif()
      endif()

--- a/recipes-sdk/aws-crt-cpp/aws-crt-cpp_0.40.0.bb
+++ b/recipes-sdk/aws-crt-cpp/aws-crt-cpp_0.40.0.bb
@@ -28,7 +28,7 @@ SRC_URI = "\
     file://002-enable-tests-with-crosscompiling.patch \
     "
 
-SRCREV = "b540e9314f3ecc5a6c592efb07a516a6b20c5bbb"
+SRCREV = "091de3758f5a2c64a68157ba2e9b98c8463a1f5a"
 
 inherit cmake pkgconfig ptest
 

--- a/recipes-sdk/aws-crt-python/aws-crt-python_0.34.0.bb
+++ b/recipes-sdk/aws-crt-python/aws-crt-python_0.34.0.bb
@@ -36,7 +36,7 @@ SRC_URI = "\
     file://run-ptest \
     "
 
-SRCREV = "74f88049cd779becbc93bbd5cd32b709d0a40420"
+SRCREV = "75c0c571973d9c4bbb37f10ac0701de04e30a1dd"
 UPSTREAM_CHECK_GITTAGREGEX = "v(?P<pver>.*)"
 
 inherit setuptools3_legacy ptest

--- a/recipes-sdk/aws-crt-python/aws-crt-python_0.34.1.bb
+++ b/recipes-sdk/aws-crt-python/aws-crt-python_0.34.1.bb
@@ -36,7 +36,7 @@ SRC_URI = "\
     file://run-ptest \
     "
 
-SRCREV = "75c0c571973d9c4bbb37f10ac0701de04e30a1dd"
+SRCREV = "f78d829f8cd5d2ccff7cd2498a1b16d38cefcc95"
 UPSTREAM_CHECK_GITTAGREGEX = "v(?P<pver>.*)"
 
 inherit setuptools3_legacy ptest

--- a/recipes-sdk/aws-crt-python/files/001-fix-cross-compilation-support.patch
+++ b/recipes-sdk/aws-crt-python/files/001-fix-cross-compilation-support.patch
@@ -1,4 +1,4 @@
-From dcb43e704bd69c762f2c4eecae0a7f3541ca8ec6 Mon Sep 17 00:00:00 2001
+From a05d186e1f5ed431e507cc214a3a9284ddec28e7 Mon Sep 17 00:00:00 2001
 From: AWS Meta Layer <meta-aws@amazon.com>
 Date: Thu, 24 Jul 2025 12:00:00 +0000
 Subject: [PATCH] Fix cross-compilation support

--- a/recipes-sdk/aws-crt-python/files/001-fix-cross-compilation-support.patch
+++ b/recipes-sdk/aws-crt-python/files/001-fix-cross-compilation-support.patch
@@ -1,4 +1,4 @@
-From 622237504a99dbe13f28d785e650e36adf39a5fa Mon Sep 17 00:00:00 2001
+From dcb43e704bd69c762f2c4eecae0a7f3541ca8ec6 Mon Sep 17 00:00:00 2001
 From: AWS Meta Layer <meta-aws@amazon.com>
 Date: Thu, 24 Jul 2025 12:00:00 +0000
 Subject: [PATCH] Fix cross-compilation support
@@ -15,7 +15,7 @@ Signed-off-by: AWS Meta Layer <meta-aws@amazon.com>
  1 file changed, 12 insertions(+)
 
 diff --git a/setup.py b/setup.py
-index 380e5e9..9dfd6ea 100644
+index 032bff8..c4ba4f7 100644
 --- a/setup.py
 +++ b/setup.py
 @@ -370,12 +370,24 @@ class awscrt_build_ext(setuptools.command.build_ext.build_ext):

--- a/recipes-sdk/s2n/s2n_1.7.4.bb
+++ b/recipes-sdk/s2n/s2n_1.7.4.bb
@@ -17,7 +17,7 @@ SRC_URI = "\
     file://run-ptest \
     "
 
-SRCREV = "211695cb91f5b74b64a81ebb3045ec3d7d5ab264"
+SRCREV = "eaf2c08a78f7fca6279e3704d3fa1c4e6c9a6abc"
 UPSTREAM_CHECK_GITTAGREGEX = "v(?P<pver>.*)"
 
 inherit cmake ptest pkgconfig

--- a/recipes-support/amazon-ssm-agent/amazon-ssm-agent_3.3.4624.0.bb
+++ b/recipes-support/amazon-ssm-agent/amazon-ssm-agent_3.3.4624.0.bb
@@ -13,7 +13,7 @@ SRC_URI = "\
     file://run-ptest \
     "
 
-SRCREV = "b8acce1284383abb5ee86089912968b9af7c4025"
+SRCREV = "61d87901c7abf20ce052b07e7bd6407d6248cd35"
 
 GO_IMPORT = ""
 


### PR DESCRIPTION
## Weekly Release Merge (2026-W24)

Merge `whinlatter-next` into `whinlatter` for the week 24 release.

### Recipe Upgrades
- amazon-ssm-agent: 3.3.4515.0 → 3.3.4624.0
- aws-crt-cpp: 0.39.1 → 0.40.0
- aws-crt-python: 0.33.0 → 0.34.1
- aws-c-s3: 0.12.4 → 0.12.5
- aws-c-sdkutils: 0.2.4 → 0.2.5
- firecracker-bin: 1.15.1 → 1.16.0
- jailer-bin: 1.15.1 → 1.16.0
- s2n: 1.7.3 → 1.7.4

### Other Changes
- ci: fix duplicate permissions in auto-approve workflow
- ci: fix COMPATIBLE_MACHINE filtering + corretto mutual exclusion

**Note:** Whinlatter (Yocto 5.3) has reached EOL. This is one of the final releases.

### Post-merge actions
1. Tag release: `whinlatter-2026.24.0`
2. Rebase whinlatter-next onto whinlatter

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.