### PR TITLE
aws-lc: replace update-alternatives with RCONFLICTS

### DIFF
--- a/recipes-sdk/aws-lc/aws-lc_5.0.0.bb
+++ b/recipes-sdk/aws-lc/aws-lc_5.0.0.bb
@@ -937,8 +937,4 @@ FILES_SOLIBSDEV = ""
 
 BBCLASSEXTEND = "native nativesdk"
 
-inherit update-alternatives
-ALTERNATIVE_PRIORITY = "200"
-ALTERNATIVE:${PN} = "openssl"
-
-ALTERNATIVE_TARGET[openssl] = "${bindir}/openssl"
+RCONFLICTS:${PN} = "openssl"


### PR DESCRIPTION
The `update-alternatives` approach with `ALTERNATIVE_PRIORITY = "200"` fails during `do_rootfs` when both aws-lc and openssl are installed in the test image:

```
ERROR: core-image-minimal-1.0-r0 do_rootfs: Postinstall scriptlets of ['aws-lc'] have failed.
```

Replace with `RCONFLICTS:${PN} = "openssl"` which tells the package manager to remove openssl before installing aws-lc. This matches the working fix already on whinlatter-next.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.