### PR TITLE
ci: replace bitbake -f with cleansstate for recipe builds

### DIFF
--- a/.github/workflows/build-test-recipe.yml
+++ b/.github/workflows/build-test-recipe.yml
@@ -302,7 +302,8 @@ jobs:
              export SSTATE_DIR=/sstate-cache
              export DL_DIR=/downloads
              export BB_ENV_PASSTHROUGH_ADDITIONS="$BB_ENV_PASSTHROUGH_ADDITIONS SSTATE_DIR DL_DIR"
-             bitbake $RECIPES -f -k | tee -a ${{ matrix.machine }}-build.log'
+             bitbake $RECIPES -c cleansstate
+             bitbake $RECIPES -k | tee -a ${{ matrix.machine }}-build.log'
            set -e
            echo RECIPES to build: $RECIPES
            if [ -e "${BUILD_DIR}/build/${{ matrix.machine }}-build.log" ]; then


### PR DESCRIPTION
The `-f` flag forces rebuild of the entire dependency tree, causing recipes with heavy dependencies (e.g., fleetwise-edge: boost, protobuf, abseil, aws-sdk-cpp) to exceed the 4-hour CI timeout.

Replace with `bitbake $RECIPES -c cleansstate` followed by a normal `bitbake $RECIPES -k`. This cleans only the changed recipes' sstate (ensuring they rebuild from source) while allowing their dependencies to be served from sstate cache.

The `-f -c testimage` for the ptest step is left unchanged since forcing a single task re-run is appropriate there.

Fixes: aws-iot-fleetwise-edge PR #15866 timing out after 4+ hours.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.