### PR TITLE
[Backport wrynose-next] 2026-06-17_01-57-26_master-next_python3-s3transfer

### DIFF
--- a/recipes-devtools/python/python3-s3transfer_0.19.0.bb
+++ b/recipes-devtools/python/python3-s3transfer_0.19.0.bb
@@ -11,7 +11,7 @@ SRC_URI = "\
     file://run-ptest \
     file://python_dependency_test.py \
     "
-SRCREV = "7ae4c0eae26bdd987749e52b2e5dbeed0a45260d"
+SRCREV = "dc9d496cd2757e418618d546a65ab1e16fc35736"
 
 
 inherit setuptools3 ptest


### PR DESCRIPTION
# Description
Backport of #15893 to `wrynose-next`.