### PR TITLE
Release whinlatter-2026.25.0: merge whinlatter-next to whinlatter

### DIFF
--- a/recipes-sdk/aws-c-s3/aws-c-s3_0.12.6.bb
+++ b/recipes-sdk/aws-c-s3/aws-c-s3_0.12.6.bb
@@ -19,7 +19,7 @@ SRC_URI = "\
     git://github.com/awslabs/aws-c-s3.git;protocol=https;branch=${BRANCH} \
     file://run-ptest \
     "
-SRCREV = "dd71b3be7d2545d1470cd20464742fef297d50d3"
+SRCREV = "e8bf59aaa77442d7f066a2df05604f40889f044a"
 
 inherit cmake ptest pkgconfig
 

--- a/recipes-sdk/aws-crt-cpp/aws-crt-cpp/001-shared-static-crt-libs.patch
+++ b/recipes-sdk/aws-crt-cpp/aws-crt-cpp/001-shared-static-crt-libs.patch
@@ -1,4 +1,4 @@
-From ef9d8437d6b5b0306c29f32d43e98c752af9d497 Mon Sep 17 00:00:00 2001
+From d8d9b9aad0111630030fbfb526accb0a93d251f3 Mon Sep 17 00:00:00 2001
 From: Thomas Roos <throos@amazon.de>
 Date: Tue, 20 May 2025 08:45:29 +0000
 Subject: [PATCH] aws-crt-cpp: change to build-deps as default

--- a/recipes-sdk/aws-crt-cpp/aws-crt-cpp/002-enable-tests-with-crosscompiling.patch
+++ b/recipes-sdk/aws-crt-cpp/aws-crt-cpp/002-enable-tests-with-crosscompiling.patch
@@ -1,4 +1,4 @@
-From 696c3694a3da4fb307d0a695bac84f65506e1a83 Mon Sep 17 00:00:00 2001
+From 37ddd83833678643b899f5789e15038cfd4affb9 Mon Sep 17 00:00:00 2001
 From: Thomas Roos <throos@amazon.de>
 Date: Mon, 29 Sep 2025 12:51:03 +0000
 Subject: [PATCH] This enable the tests even when crosscompiling.

--- a/recipes-sdk/aws-crt-cpp/aws-crt-cpp_0.40.1.bb
+++ b/recipes-sdk/aws-crt-cpp/aws-crt-cpp_0.40.1.bb
@@ -28,7 +28,7 @@ SRC_URI = "\
     file://002-enable-tests-with-crosscompiling.patch \
     "
 
-SRCREV = "091de3758f5a2c64a68157ba2e9b98c8463a1f5a"
+SRCREV = "64429d60265ee8c30ae1c8f2ff8e1b9474eea455"
 
 inherit cmake pkgconfig ptest
 

--- a/recipes-sdk/aws-iot-device-sdk-python-v2/aws-iot-device-sdk-python-v2_1.30.0.bb
+++ b/recipes-sdk/aws-iot-device-sdk-python-v2/aws-iot-device-sdk-python-v2_1.30.0.bb
@@ -8,7 +8,7 @@ SRC_URI = "\
         git://github.com/aws/aws-iot-device-sdk-python-v2.git;protocol=https;branch=${BRANCH} \
         file://run-ptest\
         "
-SRCREV = "bb7ceeaaba160e9a1efff7eea7c771fec3006c4b"
+SRCREV = "4d0a4e72391fb0640d9def07130af04a31587cfc"
 
 inherit setuptools3 ptest
 


### PR DESCRIPTION
Weekly release merge of `whinlatter-next` into `whinlatter` for release `whinlatter-2026.25.0`.

3 commits since last release.