### PR TITLE
auto-backport: fix conflict_resolution to use experimental input

### DIFF
--- a/.github/workflows/auto-backport.yml
+++ b/.github/workflows/auto-backport.yml
@@ -26,4 +26,4 @@ jobs:
           # copy all labels (backport labels are automatically skipped)
           copy_labels_pattern: .+
           github_token: ${{ secrets.MAINTAINER_TOKEN }}
-          conflict_resolution: draft_commit_conflicts
+          experimental: '{"conflict_resolution": "draft_commit_conflicts"}'


### PR DESCRIPTION
The `conflict_resolution` option must be nested inside the `experimental` JSON input for `korthout/backport-action@v4`. The previous top-level config was silently ignored, causing backports with cherry-pick conflicts (rename/rename from version upgrades) to be skipped entirely.

This is why wrynose-next has not been receiving recipe upgrades — its base versions differ from master-next, so cherry-picks conflict, and without proper conflict resolution the backport is simply dropped.

With this fix, conflicting backports will create **draft PRs** with the conflicts committed, allowing manual resolution instead of silent failure.