### PR TITLE
[Backport whinlatter-next] 2026-06-30_14-39-03_master-next_aws-crt-python

### DIFF
--- a/recipes-sdk/aws-crt-python/aws-crt-python_0.35.0.bb
+++ b/recipes-sdk/aws-crt-python/aws-crt-python_0.35.0.bb
@@ -36,7 +36,7 @@ SRC_URI = "\
     file://run-ptest \
     "
 
-SRCREV = "f78d829f8cd5d2ccff7cd2498a1b16d38cefcc95"
+SRCREV = "c8c605c8f988470f5ac4dafd34ded2cdd153d85d"
 UPSTREAM_CHECK_GITTAGREGEX = "v(?P<pver>.*)"
 
 inherit setuptools3_legacy ptest

--- a/recipes-sdk/aws-crt-python/files/001-fix-cross-compilation-support.patch
+++ b/recipes-sdk/aws-crt-python/files/001-fix-cross-compilation-support.patch
@@ -1,4 +1,4 @@
-From a05d186e1f5ed431e507cc214a3a9284ddec28e7 Mon Sep 17 00:00:00 2001
+From 787fd526bf1328ea21c9fb14eebe238e082cb4c9 Mon Sep 17 00:00:00 2001
 From: AWS Meta Layer <meta-aws@amazon.com>
 Date: Thu, 24 Jul 2025 12:00:00 +0000
 Subject: [PATCH] Fix cross-compilation support
@@ -15,10 +15,10 @@ Signed-off-by: AWS Meta Layer <meta-aws@amazon.com>
  1 file changed, 12 insertions(+)
 
 diff --git a/setup.py b/setup.py
-index 032bff8..c4ba4f7 100644
+index bcf0b04..a3ed1d3 100644
 --- a/setup.py
 +++ b/setup.py
-@@ -370,12 +370,24 @@ class awscrt_build_ext(setuptools.command.build_ext.build_ext):
+@@ -373,12 +373,24 @@ class awscrt_build_ext(setuptools.command.build_ext.build_ext):
              f'-DCMAKE_BUILD_TYPE={build_type}',
          ])
  


### PR DESCRIPTION
# Description
Backport of #15925 to `whinlatter-next`.