### PR TITLE
[Backport scarthgap-next] 2026-06-30_14-39-03_master-next_aws-c-common

### DIFF
--- a/recipes-sdk/aws-c-common/aws-c-common_0.14.1.bb
+++ b/recipes-sdk/aws-c-common/aws-c-common_0.14.1.bb
@@ -14,7 +14,7 @@ SRC_URI = "\
     file://ptest_result.py \
     file://0001-skip-iso8601-tests-on-32bit.patch \
 "
-SRCREV = "48dd6cdff7bac0005a9c6b49c15a0765622c0e70"
+SRCREV = "2b4c620fecec43fb847da3d2064ce023ebfd3ef9"
 
 # will match only x.x.x for auto upgrades, because: https://github.com/awslabs/aws-c-common/issues/1025
 UPSTREAM_CHECK_GITTAGREGEX = "(?P<pver>\d\.\d+(\.\d+)+)"

--- a/recipes-sdk/aws-c-common/files/0001-skip-iso8601-tests-on-32bit.patch
+++ b/recipes-sdk/aws-c-common/files/0001-skip-iso8601-tests-on-32bit.patch
@@ -1,4 +1,4 @@
-From d2069635c6e3b44b879b1daefa8ea4803cc7acc9 Mon Sep 17 00:00:00 2001
+From a3f0da25c69fa14c7f2ac71bd27869cad43e4ac8 Mon Sep 17 00:00:00 2001
 From: Thomas Roos <throos@amazon.de>
 Date: Tue, 12 Aug 2025 08:51:48 +0000
 Subject: [PATCH] Skip ISO8601 parsing tests on 32-bit architectures due to


### PR DESCRIPTION
# Description
Backport of #15932 to `scarthgap-next`.