### PR TITLE
[Backport wrynose-next] 2026-07-01_01-52-51_master-next_aws-iot-securetunneling-localproxy

### DIFF
--- a/recipes-iot/aws-iot-securetunneling-localproxy/aws-iot-securetunneling-localproxy_git.bb
+++ b/recipes-iot/aws-iot-securetunneling-localproxy/aws-iot-securetunneling-localproxy_git.bb
@@ -25,7 +25,7 @@ SRC_URI = "\
     file://0005-fix-boost-system-header-only.patch \
     file://run-ptest \
     "
-SRCREV = "18f6bc3593423dac85349a23467675783a9e7619"
+SRCREV = "af317a404065e148a724e7ab4717c0e64cbff963"
 
 UPSTREAM_CHECK_COMMITS = "1"
 

--- a/recipes-iot/aws-iot-securetunneling-localproxy/files/0001-boost-support-any.patch
+++ b/recipes-iot/aws-iot-securetunneling-localproxy/files/0001-boost-support-any.patch
@@ -1,4 +1,4 @@
-From d37019c884a9bcb20f843a247a3e2fb99430c560 Mon Sep 17 00:00:00 2001
+From d152274bc2c303d6c626189fd0157207f3be2594 Mon Sep 17 00:00:00 2001
 From: Thomas Roos <throos@amazon.de>
 Date: Fri, 10 Mar 2023 12:46:05 +0000
 Subject: [PATCH] aws-iot-securetunneling-localproxy: support any boost version

--- a/recipes-iot/aws-iot-securetunneling-localproxy/files/0002-remove-cxx-standard.patch
+++ b/recipes-iot/aws-iot-securetunneling-localproxy/files/0002-remove-cxx-standard.patch
@@ -1,4 +1,4 @@
-From 0532785d055d5ffa45f5e91166b0264f2f71fd68 Mon Sep 17 00:00:00 2001
+From 4c6dd0e5ceb1131d8c2d164d3af99ef340098ef2 Mon Sep 17 00:00:00 2001
 From: Thomas Roos <throos@amazon.de>
 Date: Tue, 9 Jan 2024 14:34:32 +0000
 Subject: [PATCH] aws-iot-securetunneling-localproxy: remove setting of

--- a/recipes-iot/aws-iot-securetunneling-localproxy/files/0004-cmake-version.patch
+++ b/recipes-iot/aws-iot-securetunneling-localproxy/files/0004-cmake-version.patch
@@ -1,4 +1,4 @@
-From 471279093ce8d188e80d3626020227343aa3cea8 Mon Sep 17 00:00:00 2001
+From af10b0cd669296894abaa578127bb6a89ba688e0 Mon Sep 17 00:00:00 2001
 From: OpenEmbedded <oe.patch@oe>
 Date: Tue, 22 Oct 2024 02:00:39 +0000
 Subject: [PATCH] aws-iot-securetunneling-localproxy: upgrade git -> new

--- a/recipes-iot/aws-iot-securetunneling-localproxy/files/0005-fix-boost-system-header-only.patch
+++ b/recipes-iot/aws-iot-securetunneling-localproxy/files/0005-fix-boost-system-header-only.patch
@@ -1,4 +1,4 @@
-From a44c3265d899e0e6e78e88175b7bd6c6a3692e92 Mon Sep 17 00:00:00 2001
+From bf11e90a5cf41ccec45256930ab40c98c2b71b9c Mon Sep 17 00:00:00 2001
 From: Yocto Build System <yocto@example.com>
 Date: Mon, 9 Sep 2024 11:30:00 +0000
 Subject: [PATCH] Fix Boost compatibility for Boost 1.89+


### PR DESCRIPTION
# Description
Backport of #15966 to `wrynose-next`.