### PR TITLE
[Backport whinlatter-next] 2026-07-02_01-48-37_master-next_aws-c-sdkutils

### DIFF
--- a/recipes-sdk/aws-c-sdkutils/aws-c-sdkutils_0.2.7.bb
+++ b/recipes-sdk/aws-c-sdkutils/aws-c-sdkutils_0.2.7.bb
@@ -15,7 +15,7 @@ SRC_URI = "\
     file://run-ptest \
     file://001-enable-tests-with-crosscompiling.patch \
     "
-SRCREV = "727df06fc0e998e673de70fb69e5a634fe4979bc"
+SRCREV = "cb14fea362c82c995eebd34e2e96590ab4e0ed58"
 
 inherit cmake ptest pkgconfig
 

--- a/recipes-sdk/aws-c-sdkutils/files/001-enable-tests-with-crosscompiling.patch
+++ b/recipes-sdk/aws-c-sdkutils/files/001-enable-tests-with-crosscompiling.patch
@@ -1,4 +1,4 @@
-From f7462344018e8654fa862bbb8ddb9af2a0f74fc0 Mon Sep 17 00:00:00 2001
+From c76c5e4181ebda95ddcbeef44d6681b6b68c0a92 Mon Sep 17 00:00:00 2001
 From: Thomas Roos <throos@amazon.de>
 Date: Mon, 29 Sep 2025 12:51:03 +0000
 Subject: [PATCH] This enable the tests even when crosscompiling.


### PR DESCRIPTION
# Description
Backport of #15989 to `whinlatter-next`.