### PR TITLE
[Backport wrynose-next] 2026-07-02_01-48-37_master-next_aws-iot-securetunneling-localproxy

### DIFF
--- a/recipes-iot/aws-iot-securetunneling-localproxy/aws-iot-securetunneling-localproxy_git.bb
+++ b/recipes-iot/aws-iot-securetunneling-localproxy/aws-iot-securetunneling-localproxy_git.bb
@@ -25,7 +25,7 @@ SRC_URI = "\
     file://0005-fix-boost-system-header-only.patch \
     file://run-ptest \
     "
-SRCREV = "af317a404065e148a724e7ab4717c0e64cbff963"
+SRCREV = "11995d0fd70edf33d01f9706ae48d2036eb92359"
 
 UPSTREAM_CHECK_COMMITS = "1"
 

--- a/recipes-iot/aws-iot-securetunneling-localproxy/files/0001-boost-support-any.patch
+++ b/recipes-iot/aws-iot-securetunneling-localproxy/files/0001-boost-support-any.patch
@@ -1,4 +1,4 @@
-From d152274bc2c303d6c626189fd0157207f3be2594 Mon Sep 17 00:00:00 2001
+From 944382fc9e165b87008fd7227b6fced8e21f7ea8 Mon Sep 17 00:00:00 2001
 From: Thomas Roos <throos@amazon.de>
 Date: Fri, 10 Mar 2023 12:46:05 +0000
 Subject: [PATCH] aws-iot-securetunneling-localproxy: support any boost version

--- a/recipes-iot/aws-iot-securetunneling-localproxy/files/0002-remove-cxx-standard.patch
+++ b/recipes-iot/aws-iot-securetunneling-localproxy/files/0002-remove-cxx-standard.patch
@@ -1,4 +1,4 @@
-From 4c6dd0e5ceb1131d8c2d164d3af99ef340098ef2 Mon Sep 17 00:00:00 2001
+From ff117676ccfc720027855f08e4700ffc212ad701 Mon Sep 17 00:00:00 2001
 From: Thomas Roos <throos@amazon.de>
 Date: Tue, 9 Jan 2024 14:34:32 +0000
 Subject: [PATCH] aws-iot-securetunneling-localproxy: remove setting of

--- a/recipes-iot/aws-iot-securetunneling-localproxy/files/0004-cmake-version.patch
+++ b/recipes-iot/aws-iot-securetunneling-localproxy/files/0004-cmake-version.patch
@@ -1,4 +1,4 @@
-From af10b0cd669296894abaa578127bb6a89ba688e0 Mon Sep 17 00:00:00 2001
+From 4717823794b71acc32ce6d279441029758feaf8e Mon Sep 17 00:00:00 2001
 From: OpenEmbedded <oe.patch@oe>
 Date: Tue, 22 Oct 2024 02:00:39 +0000
 Subject: [PATCH] aws-iot-securetunneling-localproxy: upgrade git -> new

--- a/recipes-iot/aws-iot-securetunneling-localproxy/files/0005-fix-boost-system-header-only.patch
+++ b/recipes-iot/aws-iot-securetunneling-localproxy/files/0005-fix-boost-system-header-only.patch
@@ -1,4 +1,4 @@
-From bf11e90a5cf41ccec45256930ab40c98c2b71b9c Mon Sep 17 00:00:00 2001
+From 85bd80c8b7dfb9c6b8f12b637643accc824e7b48 Mon Sep 17 00:00:00 2001
 From: Yocto Build System <yocto@example.com>
 Date: Mon, 9 Sep 2024 11:30:00 +0000
 Subject: [PATCH] Fix Boost compatibility for Boost 1.89+


### PR DESCRIPTION
# Description
Backport of #15991 to `wrynose-next`.