### PR TITLE
[Backport whinlatter-next] 2026-07-07_01-42-10_master-next_aws-crt-cpp

### DIFF
--- a/recipes-sdk/aws-crt-cpp/aws-crt-cpp/001-shared-static-crt-libs.patch
+++ b/recipes-sdk/aws-crt-cpp/aws-crt-cpp/001-shared-static-crt-libs.patch
@@ -1,4 +1,4 @@
-From d8d9b9aad0111630030fbfb526accb0a93d251f3 Mon Sep 17 00:00:00 2001
+From fc7b934469a2350fa9405aa59b54efbcef787575 Mon Sep 17 00:00:00 2001
 From: Thomas Roos <throos@amazon.de>
 Date: Tue, 20 May 2025 08:45:29 +0000
 Subject: [PATCH] aws-crt-cpp: change to build-deps as default

--- a/recipes-sdk/aws-crt-cpp/aws-crt-cpp/002-enable-tests-with-crosscompiling.patch
+++ b/recipes-sdk/aws-crt-cpp/aws-crt-cpp/002-enable-tests-with-crosscompiling.patch
@@ -1,4 +1,4 @@
-From 37ddd83833678643b899f5789e15038cfd4affb9 Mon Sep 17 00:00:00 2001
+From d09f0414b6b3981b008823e76cd230ac13a2053b Mon Sep 17 00:00:00 2001
 From: Thomas Roos <throos@amazon.de>
 Date: Mon, 29 Sep 2025 12:51:03 +0000
 Subject: [PATCH] This enable the tests even when crosscompiling.

--- a/recipes-sdk/aws-crt-cpp/aws-crt-cpp_0.41.0.bb
+++ b/recipes-sdk/aws-crt-cpp/aws-crt-cpp_0.41.0.bb
@@ -28,7 +28,7 @@ SRC_URI = "\
     file://002-enable-tests-with-crosscompiling.patch \
     "
 
-SRCREV = "64429d60265ee8c30ae1c8f2ff8e1b9474eea455"
+SRCREV = "d8ee6b6912c196e574be10f207868721117dd397"
 
 inherit cmake pkgconfig ptest
 


### PR DESCRIPTION
# Description
Backport of #16053 to `whinlatter-next`.