### PR TITLE
[Backport wrynose-next] 2026-07-14_01-40-31_master-next_aws-c-auth

### DIFF
--- a/recipes-sdk/aws-c-auth/aws-c-auth_0.10.4.bb
+++ b/recipes-sdk/aws-c-auth/aws-c-auth_0.10.4.bb
@@ -23,7 +23,7 @@ SRC_URI = "\
     git://github.com/awslabs/aws-c-auth.git;protocol=https;branch=${BRANCH} \
     file://run-ptest \
     "
-SRCREV = "4cb7127fc2fe402310f9b2ccd7719baa348b2a19"
+SRCREV = "4b5d524bf1a511b05e0fffe5bdc51800770b9427"
 
 inherit cmake ptest pkgconfig
 


### PR DESCRIPTION
# Description
Backport of #16134 to `wrynose-next`.