### PR TITLE
[Backport wrynose-next] 2026-07-15_01-39-53_master-next_python3-s3transfer

### DIFF
--- a/recipes-devtools/python/python3-s3transfer_0.19.1.bb
+++ b/recipes-devtools/python/python3-s3transfer_0.19.1.bb
@@ -11,7 +11,7 @@ SRC_URI = "\
     file://run-ptest \
     file://python_dependency_test.py \
     "
-SRCREV = "dc9d496cd2757e418618d546a65ab1e16fc35736"
+SRCREV = "71bdbb734446e228df5892397f2a84f31beb9128"
 
 
 inherit setuptools3 ptest


### PR DESCRIPTION
# Description
Backport of #16149 to `wrynose-next`.