### PR TITLE
[Backport scarthgap-next] 2026-07-15_01-39-53_master-next_aws-c-common

### DIFF
--- a/recipes-sdk/aws-c-common/aws-c-common_0.14.2.bb
+++ b/recipes-sdk/aws-c-common/aws-c-common_0.14.2.bb
@@ -14,7 +14,7 @@ SRC_URI = "\
     file://ptest_result.py \
     file://0001-skip-iso8601-tests-on-32bit.patch \
 "
-SRCREV = "2b4c620fecec43fb847da3d2064ce023ebfd3ef9"
+SRCREV = "a9d57d2d372582fa18bf1d81741e107c59a23226"
 
 # will match only x.x.x for auto upgrades, because: https://github.com/awslabs/aws-c-common/issues/1025
 UPSTREAM_CHECK_GITTAGREGEX = "(?P<pver>\d\.\d+(\.\d+)+)"

--- a/recipes-sdk/aws-c-common/files/0001-skip-iso8601-tests-on-32bit.patch
+++ b/recipes-sdk/aws-c-common/files/0001-skip-iso8601-tests-on-32bit.patch
@@ -1,4 +1,4 @@
-From a3f0da25c69fa14c7f2ac71bd27869cad43e4ac8 Mon Sep 17 00:00:00 2001
+From ac776217b9600a0ef0d0a8101da39f07eec561ce Mon Sep 17 00:00:00 2001
 From: Thomas Roos <throos@amazon.de>
 Date: Tue, 12 Aug 2025 08:51:48 +0000
 Subject: [PATCH] Skip ISO8601 parsing tests on 32-bit architectures due to
@@ -13,7 +13,7 @@ Upstream-Status: Submitted [https://github.com/awslabs/aws-c-common/issues/1204]
  1 file changed, 24 insertions(+)
 
 diff --git a/tests/date_time_test.c b/tests/date_time_test.c
-index 69f0417f..2210981c 100644
+index 69f0417..2210981 100644
 --- a/tests/date_time_test.c
 +++ b/tests/date_time_test.c
 @@ -287,6 +287,7 @@ AWS_TEST_CASE(rfc822_invalid_auto_format, s_test_rfc822_invalid_auto_format_fn)


### PR DESCRIPTION
# Description
Backport of #16144 to `scarthgap-next`.