### PR TITLE
[Backport whinlatter-next] 2026-07-17_01-40-54_master-next_aws-crt-python

### DIFF
--- a/recipes-sdk/aws-crt-python/aws-crt-python_0.36.0.bb
+++ b/recipes-sdk/aws-crt-python/aws-crt-python_0.36.0.bb
@@ -36,7 +36,7 @@ SRC_URI = "\
     file://run-ptest \
     "
 
-SRCREV = "c8c605c8f988470f5ac4dafd34ded2cdd153d85d"
+SRCREV = "5e7eef180f56818a3777d644f97b5478f02bd7c9"
 UPSTREAM_CHECK_GITTAGREGEX = "v(?P<pver>.*)"
 
 inherit setuptools3_legacy ptest

--- a/recipes-sdk/aws-crt-python/files/001-fix-cross-compilation-support.patch
+++ b/recipes-sdk/aws-crt-python/files/001-fix-cross-compilation-support.patch
@@ -1,4 +1,4 @@
-From 787fd526bf1328ea21c9fb14eebe238e082cb4c9 Mon Sep 17 00:00:00 2001
+From 0741b2981e773670f2b605b3adc67be8c39a7ab6 Mon Sep 17 00:00:00 2001
 From: AWS Meta Layer <meta-aws@amazon.com>
 Date: Thu, 24 Jul 2025 12:00:00 +0000
 Subject: [PATCH] Fix cross-compilation support


### PR DESCRIPTION
# Description
Backport of #16207 to `whinlatter-next`.