### PR TITLE
[Backport whinlatter-next] 2026-07-22_01-41-11_master-next_aws-crt-cpp

### DIFF
--- a/recipes-sdk/aws-crt-cpp/aws-crt-cpp/001-shared-static-crt-libs.patch
+++ b/recipes-sdk/aws-crt-cpp/aws-crt-cpp/001-shared-static-crt-libs.patch
@@ -1,4 +1,4 @@
-From c9c65a9644bc441a1fac8d18f3a03cb52676e860 Mon Sep 17 00:00:00 2001
+From ecb3e9280c19d296ecccae06db7859b9e3fdba81 Mon Sep 17 00:00:00 2001
 From: Thomas Roos <throos@amazon.de>
 Date: Tue, 20 May 2025 08:45:29 +0000
 Subject: [PATCH] aws-crt-cpp: change to build-deps as default

--- a/recipes-sdk/aws-crt-cpp/aws-crt-cpp/002-enable-tests-with-crosscompiling.patch
+++ b/recipes-sdk/aws-crt-cpp/aws-crt-cpp/002-enable-tests-with-crosscompiling.patch
@@ -1,4 +1,4 @@
-From 70e1056f4e140a00c113780e09ef974420685663 Mon Sep 17 00:00:00 2001
+From 9776ead6c429a87b5f34d4b49c69c6544f259549 Mon Sep 17 00:00:00 2001
 From: Thomas Roos <throos@amazon.de>
 Date: Mon, 29 Sep 2025 12:51:03 +0000
 Subject: [PATCH] This enable the tests even when crosscompiling.

--- a/recipes-sdk/aws-crt-cpp/aws-crt-cpp_0.42.3.bb
+++ b/recipes-sdk/aws-crt-cpp/aws-crt-cpp_0.42.3.bb
@@ -28,7 +28,7 @@ SRC_URI = "\
     file://002-enable-tests-with-crosscompiling.patch \
     "
 
-SRCREV = "4bc47ee0c30a482831f809769a2421385c192a6d"
+SRCREV = "2992d25f38b9b4388a85748e850df62f437cae1c"
 
 inherit cmake pkgconfig ptest
 


### PR DESCRIPTION
# Description
Backport of #16245 to `whinlatter-next`.