### PR TITLE
[Backport wrynose-next] 2026-07-22_01-41-11_master-next_aws-lc

### DIFF
--- a/recipes-sdk/aws-lc/aws-lc_5.3.0.bb
+++ b/recipes-sdk/aws-lc/aws-lc_5.3.0.bb
@@ -878,7 +878,7 @@ SRC_URI = "\
     git://github.com/awslabs/aws-lc.git;protocol=https;branch=${BRANCH} \
     file://run-ptest \
     "
-SRCREV = "683ebde4bf3bcc016a9a710ad6b49c0c91b59161"
+SRCREV = "970583b1061b407d09b5fc1f18bbba38690e1684"
 UPSTREAM_CHECK_GITTAGREGEX = "v(?P<pver>.*)"
 
 # nooelint: oelint.vars.specific


### PR DESCRIPTION
# Description
Backport of #16254 to `wrynose-next`.