### PR TITLE
[Backport scarthgap-next] 2026-07-22_01-41-11_master-next_corretto-17-bin

### DIFF
--- a/recipes-devtools/amazon-corretto/corretto-17-bin_17.0.20.8.1.bb
+++ b/recipes-devtools/amazon-corretto/corretto-17-bin_17.0.20.8.1.bb
@@ -8,8 +8,8 @@ SRC_URI:append:aarch64 = " https://corretto.aws/downloads/resources/${PV}/amazon
 SRC_URI:append:x86-64 = " https://corretto.aws/downloads/resources/${PV}/amazon-corretto-${PV}-linux-x64.tar.gz;name=x86-64"
 
 # you can find checksum here: https://github.com/corretto/corretto-17/releases since devtool upgrade can only do one arch atm.
-SRC_URI[x86-64.sha256sum] = "d0f1b880445691425511c3aa62cb89889f03a71c2a43597a3df174fc01d3f3a0"
-SRC_URI[aarch64.sha256sum] = "1b9f75b5a2f740ab3305577858e2fc87dad827b60678d4573234d6357be59fa8"
+SRC_URI[x86-64.sha256sum] = "89b50d4ef5d27ce1f8e5cad616525e14f7665b7b4a1ffca85381b0e21401034f"
+SRC_URI[aarch64.sha256sum] = "7e3f37d58e39f5879e3c10412177b75ccbf85b54b267b1c06d7da19a28cf9cfc"
 
 # also available in master (not kirkstone) in classes-recipe: github-releases
 UPSTREAM_CHECK_REGEX ?= "releases/tag/v?(?P<pver>\d+(\.\d+)+)"


### PR DESCRIPTION
# Description
Backport of #16253 to `scarthgap-next`.