### PR TITLE
[Backport scarthgap-next] 2026-07-22_01-41-11_master-next_aws-c-common

### DIFF
--- a/recipes-sdk/aws-c-common/aws-c-common_0.14.3.bb
+++ b/recipes-sdk/aws-c-common/aws-c-common_0.14.3.bb
@@ -14,7 +14,7 @@ SRC_URI = "\
     file://ptest_result.py \
     file://0001-skip-iso8601-tests-on-32bit.patch \
 "
-SRCREV = "a9d57d2d372582fa18bf1d81741e107c59a23226"
+SRCREV = "3c69b871dfa1815231802febf1bb6899f84cccdb"
 
 # will match only x.x.x for auto upgrades, because: https://github.com/awslabs/aws-c-common/issues/1025
 UPSTREAM_CHECK_GITTAGREGEX = "(?P<pver>\d\.\d+(\.\d+)+)"

--- a/recipes-sdk/aws-c-common/files/0001-skip-iso8601-tests-on-32bit.patch
+++ b/recipes-sdk/aws-c-common/files/0001-skip-iso8601-tests-on-32bit.patch
@@ -1,4 +1,4 @@
-From ac776217b9600a0ef0d0a8101da39f07eec561ce Mon Sep 17 00:00:00 2001
+From ae4663a59a638087d13322a150c7cacab873c9cf Mon Sep 17 00:00:00 2001
 From: Thomas Roos <throos@amazon.de>
 Date: Tue, 12 Aug 2025 08:51:48 +0000
 Subject: [PATCH] Skip ISO8601 parsing tests on 32-bit architectures due to


### PR DESCRIPTION
# Description
Backport of #16243 to `scarthgap-next`.