### PR TITLE
[Backport whinlatter-next] 2026-07-24_01-40-57_master-next_aws-crt-python

### DIFF
--- a/recipes-sdk/aws-crt-python/aws-crt-python_0.36.1.bb
+++ b/recipes-sdk/aws-crt-python/aws-crt-python_0.36.1.bb
@@ -36,7 +36,7 @@ SRC_URI = "\
     file://run-ptest \
     "
 
-SRCREV = "5e7eef180f56818a3777d644f97b5478f02bd7c9"
+SRCREV = "bf57332e2a38e8a8477ea1fe2f1c47e4f98e5875"
 UPSTREAM_CHECK_GITTAGREGEX = "v(?P<pver>.*)"
 
 inherit setuptools3_legacy ptest

--- a/recipes-sdk/aws-crt-python/files/001-fix-cross-compilation-support.patch
+++ b/recipes-sdk/aws-crt-python/files/001-fix-cross-compilation-support.patch
@@ -1,4 +1,4 @@
-From 0741b2981e773670f2b605b3adc67be8c39a7ab6 Mon Sep 17 00:00:00 2001
+From 8a689919bbeffc55a973e0aa7736bcfb1cd1b098 Mon Sep 17 00:00:00 2001
 From: AWS Meta Layer <meta-aws@amazon.com>
 Date: Thu, 24 Jul 2025 12:00:00 +0000
 Subject: [PATCH] Fix cross-compilation support


### PR DESCRIPTION
# Description
Backport of #16293 to `whinlatter-next`.