### PR TITLE
[Backport wrynose-next] 2026-07-24_01-40-57_master-next_python3-s3transfer

### DIFF
--- a/recipes-devtools/python/python3-s3transfer_0.19.2.bb
+++ b/recipes-devtools/python/python3-s3transfer_0.19.2.bb
@@ -11,7 +11,7 @@ SRC_URI = "\
     file://run-ptest \
     file://python_dependency_test.py \
     "
-SRCREV = "71bdbb734446e228df5892397f2a84f31beb9128"
+SRCREV = "467a75265eca43937a760c2c169488954df44246"
 
 
 inherit setuptools3 ptest


### PR DESCRIPTION
# Description
Backport of #16301 to `wrynose-next`.