### PR TITLE
ci: fix yocto-check-layer BitBake branch mapping

### DIFF
--- a/.github/workflows/yocto-check-layer.yml
+++ b/.github/workflows/yocto-check-layer.yml
@@ -46,7 +46,35 @@ jobs:
         with:
           path: meta-aws
       - name: Checkout BitBake
-        run: git clone https://git.openembedded.org/bitbake -b ${{steps.get-yocto-release-name.outputs.release}}
+        env:
+          RELEASE: ${{ steps.get-yocto-release-name.outputs.release }}
+        run: |
+          # Map Yocto release codename to BitBake branch version
+          case "$RELEASE" in
+            scarthgap)
+              BITBAKE_BRANCH="2.8"
+              ;;
+            whinlatter)
+              BITBAKE_BRANCH="2.16"
+              ;;
+            wrynose)
+              BITBAKE_BRANCH="2.18"
+              ;;
+            master)
+              BITBAKE_BRANCH="master"
+              ;;
+            *)
+              echo "Unknown release: $RELEASE, falling back to master"
+              BITBAKE_BRANCH="master"
+              ;;
+          esac
+          echo "Cloning BitBake branch: $BITBAKE_BRANCH (for release: $RELEASE)"
+          for i in 1 2 3 4 5; do
+            git clone https://git.openembedded.org/bitbake -b "$BITBAKE_BRANCH" && break
+            echo "Attempt $i failed, retrying in $((i * 30))s..."
+            rm -rf bitbake
+            sleep $((i * 30))
+          done
       - name: Initialize Build Environment
         run: |
           bitbake/bin/bitbake-setup --setting default top-dir-prefix /home/runner \


### PR DESCRIPTION
## Problem

The `yocto-check-layer` workflow uses the Yocto release codename directly as the BitBake git branch name (e.g. `git clone ... -b wrynose`). However, BitBake uses version-number branches, not codenames:

- `scarthgap` → `2.8`
- `whinlatter` → `2.16`
- `wrynose` → `2.18`

This causes **all wrynose-next PR checks to fail** with:
```
fatal: Remote branch wrynose not found in upstream origin
```

## Fix

Add an explicit release-to-branch mapping in the "Checkout BitBake" step, matching the pattern already used (but commented out) in `build-test-recipe.yml`.

Also adds retry logic for the git clone since `git.openembedded.org` has intermittent availability issues (HTTP 520 from Cloudflare).

## Testing

Verified branch `2.18` exists at `git.openembedded.org/bitbake`:
```
$ git ls-remote --heads https://git.openembedded.org/bitbake | grep 2.18
fae9db3168dbff1b8c76fe9c6726a9687ff97514  refs/heads/2.18
```

## Impact

Unblocks yocto-check-layer for all wrynose-next PRs (~14 currently open).