### PR TITLE
aws-crt-cpp: upgrade to 0.42.3

### DIFF
--- a/recipes-sdk/aws-crt-cpp/aws-crt-cpp_0.42.3.bb
+++ b/recipes-sdk/aws-crt-cpp/aws-crt-cpp_0.42.3.bb
@@ -28,7 +28,7 @@ SRC_URI = "\
     file://002-enable-tests-with-crosscompiling.patch \
     "
 
-SRCREV = "b540e9314f3ecc5a6c592efb07a516a6b20c5bbb"
+SRCREV = "2992d25f38b9b4388a85748e850df62f437cae1c"
 
 inherit cmake pkgconfig ptest
 


### PR DESCRIPTION
Automated backport

  Recipe: `aws-crt-cpp`
  Version: `0.42.3`