### PR TITLE
[Backport whinlatter-next] aws-c-auth: upgrade to 0.10.4

### DIFF
--- a/recipes-sdk/aws-c-auth/aws-c-auth_0.10.4.bb
+++ b/recipes-sdk/aws-c-auth/aws-c-auth_0.10.4.bb
@@ -23,7 +23,7 @@ SRC_URI = "\
     git://github.com/awslabs/aws-c-auth.git;protocol=https;branch=${BRANCH} \
     file://run-ptest \
     "
-SRCREV = "4b5cf14bfbb7d402ed89c7d614d77e924a65321f"
+SRCREV = "4b5d524bf1a511b05e0fffe5bdc51800770b9427"
 
 inherit cmake ptest pkgconfig
 


### PR DESCRIPTION
Automated backport

  Recipe: `aws-c-auth`
  Version: `0.10.4`