### PR TITLE
[Backport whinlatter-next] aws-cli-v2: upgrade to 2.36.7

### DIFF
--- a/recipes-support/aws-cli-v2/aws-cli-v2_2.36.7.bb
+++ b/recipes-support/aws-cli-v2/aws-cli-v2_2.36.7.bb
@@ -32,7 +32,7 @@ SRC_URI = "\
     file://run-ptest \
 "
 
-SRCREV = "1cc7be1dd47d8367a92f2563963c1a03304a1225"
+SRCREV = "73fb33bb171ace3e9eaa03308f76e5de50c21393"
 
 # version 2.x
 UPSTREAM_CHECK_GITTAGREGEX = "(?P<pver>2\.\d+(\.\d+)+)"


### PR DESCRIPTION
Automated backport

  Recipe: `aws-cli-v2`
  Version: `2.36.7`