### PR TITLE
[Backport wrynose-next] aws-cli-v2: upgrade to 2.36.7

### DIFF
--- a/recipes-support/aws-cli-v2/aws-cli-v2_2.36.7.bb
+++ b/recipes-support/aws-cli-v2/aws-cli-v2_2.36.7.bb
@@ -32,7 +32,7 @@ SRC_URI = "\
     file://run-ptest \
 "
 
-SRCREV = "8c8ddd99f9c1ca7b6c95a0f2772a729716e39132"
+SRCREV = "73fb33bb171ace3e9eaa03308f76e5de50c21393"
 
 # version 2.x
 UPSTREAM_CHECK_GITTAGREGEX = "(?P<pver>2\.\d+(\.\d+)+)"


### PR DESCRIPTION
Automated backport

  Recipe: `aws-cli-v2`
  Version: `2.36.7`