### PR TITLE
aws-c-s3: upgrade to 0.13.1

### DIFF
--- a/recipes-sdk/aws-c-s3/aws-c-s3_0.13.1.bb
+++ b/recipes-sdk/aws-c-s3/aws-c-s3_0.13.1.bb
@@ -19,7 +19,7 @@ SRC_URI = "\
     git://github.com/awslabs/aws-c-s3.git;protocol=https;branch=${BRANCH} \
     file://run-ptest \
     "
-SRCREV = "f1a52b5e960c06bd9392cb5e982c6fe04f1ce253"
+SRCREV = "1f29ef8871a27dc8b90325418780659bac534d71"
 
 inherit cmake ptest pkgconfig
 


### PR DESCRIPTION
Automated backport

  Recipe: `aws-c-s3`
  Version: `0.13.1`