### PR TITLE
[Backport whinlatter-next] aws-c-common: upgrade to 0.14.3

### DIFF
--- a/recipes-sdk/aws-c-common/aws-c-common_0.14.3.bb
+++ b/recipes-sdk/aws-c-common/aws-c-common_0.14.3.bb
@@ -14,7 +14,7 @@ SRC_URI = "\
     file://ptest_result.py \
     file://0001-skip-iso8601-tests-on-32bit.patch \
 "
-SRCREV = "7f18168e834b2abf276c6f92ae3b27af494fcca1"
+SRCREV = "3c69b871dfa1815231802febf1bb6899f84cccdb"
 
 # will match only x.x.x for auto upgrades, because: https://github.com/awslabs/aws-c-common/issues/1025
 UPSTREAM_CHECK_GITTAGREGEX = "(?P<pver>\d\.\d+(\.\d+)+)"


### PR DESCRIPTION
Automated backport

  Recipe: `aws-c-common`
  Version: `0.14.3`