### PR TITLE
[Backport whinlatter-next] python3-s3transfer: upgrade to 0.19.2

### DIFF
--- a/recipes-devtools/python/python3-s3transfer_0.19.2.bb
+++ b/recipes-devtools/python/python3-s3transfer_0.19.2.bb
@@ -11,7 +11,7 @@ SRC_URI = "\
     file://run-ptest \
     file://python_dependency_test.py \
     "
-SRCREV = "5a988c8357d24a5fc3b49eea07e762d1dee27904"
+SRCREV = "467a75265eca43937a760c2c169488954df44246"
 
 
 inherit setuptools3 ptest


### PR DESCRIPTION
Automated backport

  Recipe: `python3-s3transfer`
  Version: `0.19.2`