### PR TITLE
aws-cli: upgrade to 1.45.55

### DIFF
--- a/recipes-support/aws-cli/aws-cli_1.45.55.bb
+++ b/recipes-support/aws-cli/aws-cli_1.45.55.bb
@@ -9,7 +9,7 @@ SRC_URI = "\
     file://run-ptest \
 "
 
-SRCREV = "0379c76c3d408a34f482298ace5dbc2a7f6d4b14"
+SRCREV = "0e8a84237aff3d59ca4fc571145cb7d86568eac9"
 
 # version 2.x has got library link issues - so stick to version 1.x for now
 UPSTREAM_CHECK_GITTAGREGEX = "(?P<pver>1\.\d+(\.\d+)+)"


### PR DESCRIPTION
Automated backport

  Recipe: `aws-cli`
  Version: `1.45.55`