### PR TITLE
[Backport whinlatter-next] amazon-kvs-webrtc-sdk: upgrade to 1.19.2

### DIFF
--- a/recipes-sdk/amazon-kvs-webrtc-sdk/amazon-kvs-webrtc-sdk_1.19.2.bb
+++ b/recipes-sdk/amazon-kvs-webrtc-sdk/amazon-kvs-webrtc-sdk_1.19.2.bb
@@ -26,7 +26,7 @@ SRC_URI = "\
     file://ptest_result.py \
 "
 
-SRCREV = "ef4649473b2d1dc25215eca9d21cda6c802c06f2"
+SRCREV = "66563e6c05ccc81c478bfe995be3c6addf6c6f2c"
 
 inherit cmake pkgconfig ptest
 


### PR DESCRIPTION
Automated backport

  Recipe: `amazon-kvs-webrtc-sdk`
  Version: `1.19.2`