### PR TITLE
[Backport scarthgap-next] aws-sdk-cpp: upgrade to 1.11.847

### DIFF
--- a/recipes-sdk/aws-sdk-cpp/aws-sdk-cpp_1.11.847.bb
+++ b/recipes-sdk/aws-sdk-cpp/aws-sdk-cpp_1.11.847.bb
@@ -21,7 +21,7 @@ SRC_URI = "\
     file://ptest_result.py \
     "
 
-SRCREV = "7fe885d2fd5fae774f0e5f0821b76d0faea20c69"
+SRCREV = "1777328572ce4ec9e5326cfc2c51690813389620"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Automated backport

  Recipe: `aws-sdk-cpp`
  Version: `1.11.847`