### PR TITLE
[Backport whinlatter-next] python3-botocore: upgrade to 1.43.55

### DIFF
--- a/recipes-devtools/python/python3-botocore_1.43.55.bb
+++ b/recipes-devtools/python/python3-botocore_1.43.55.bb
@@ -12,7 +12,7 @@ SRC_URI = "\
     file://python_dependency_test.py \
     "
 
-SRCREV = "20bd7a81afb0f4ff002496db547f04430f65519b"
+SRCREV = "b71d5637f58df4bc61953b80902b3c040c7af889"
 
 inherit setuptools3 ptest
 


### PR DESCRIPTION
Automated backport

  Recipe: `python3-botocore`
  Version: `1.43.55`