### PR TITLE
ci: fix backport PR title naming convention

### DIFF
--- a/.github/workflows/auto-backport.yml
+++ b/.github/workflows/auto-backport.yml
@@ -184,7 +184,7 @@ jobs:
               --repo "${{ github.repository }}" \
               --base "$branch" \
               --head "$BACKPORT_BRANCH" \
-              --title "$RECIPE: upgrade to $VERSION" \
+              --title "[Backport $branch] $RECIPE: upgrade to $VERSION" \
               --body "$BODY
 
             Recipe: \`$RECIPE\`


### PR DESCRIPTION
Adds `[Backport <branch>]` prefix to auto-backport PR titles to match the existing naming convention.