### PR TITLE
[Backport wrynose-next] 2026-07-24_01-40-57_master-next_aws-sdk-cpp

### DIFF
--- a/recipes-sdk/aws-sdk-cpp/aws-sdk-cpp_1.11.854.bb
+++ b/recipes-sdk/aws-sdk-cpp/aws-sdk-cpp_1.11.854.bb
@@ -19,7 +19,7 @@ SRC_URI = "\
     file://ptest_result.py \
     "
 
-SRCREV = "1777328572ce4ec9e5326cfc2c51690813389620"
+SRCREV = "c9539d3ee8574d115248c73e0c435c925c7eb148"
 
 inherit cmake ptest pkgconfig
 


### PR DESCRIPTION
# Description
Backport of #16299 to `wrynose-next`.