### PR TITLE
[Backport wrynose-next] 2026-07-28_01-39-58_master-next_python3-boto3

### DIFF
--- a/recipes-devtools/python/python3-boto3_1.43.57.bb
+++ b/recipes-devtools/python/python3-boto3_1.43.57.bb
@@ -12,7 +12,7 @@ SRC_URI = "\
     file://python_dependency_test.py \
     "
 
-SRCREV = "2a09bb61f3d89224a4d9ceea1ac25320052d8592"
+SRCREV = "7b06b40e5bb8ac43a7ee3e4c80a348156cf7d393"
 
 inherit setuptools3 ptest
 


### PR DESCRIPTION
# Description
Backport of #16368 to `wrynose-next`.