### PR TITLE
[Backport scarthgap-next] aws-sdk-cpp: upgrade to 1.11.854

### DIFF
--- a/recipes-sdk/aws-sdk-cpp/aws-sdk-cpp_1.11.854.bb
+++ b/recipes-sdk/aws-sdk-cpp/aws-sdk-cpp_1.11.854.bb
@@ -21,7 +21,7 @@ SRC_URI = "\
     file://ptest_result.py \
     "
 
-SRCREV = "1777328572ce4ec9e5326cfc2c51690813389620"
+SRCREV = "c9539d3ee8574d115248c73e0c435c925c7eb148"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Automated backport

  Recipe: `aws-sdk-cpp`
  Version: `1.11.854`