### PR TITLE
[Backport scarthgap-next] python3-boto3: upgrade to 1.43.57

### DIFF
--- a/recipes-devtools/python/python3-boto3_1.43.57.bb
+++ b/recipes-devtools/python/python3-boto3_1.43.57.bb
@@ -12,7 +12,7 @@ SRC_URI = "\
     file://python_dependency_test.py \
     "
 
-SRCREV = "2a09bb61f3d89224a4d9ceea1ac25320052d8592"
+SRCREV = "7b06b40e5bb8ac43a7ee3e4c80a348156cf7d393"
 S = "${WORKDIR}/git"
 
 inherit setuptools3 ptest


### PR DESCRIPTION
Automated backport

  Recipe: `python3-boto3`
  Version: `1.43.57`