### PR TITLE
ci: remove cleansstate and force-rebuild flags from build-test

### DIFF
--- a/.github/workflows/build-test-recipe.yml
+++ b/.github/workflows/build-test-recipe.yml
@@ -302,7 +302,6 @@ jobs:
              export SSTATE_DIR=/sstate-cache
              export DL_DIR=/downloads
              export BB_ENV_PASSTHROUGH_ADDITIONS="$BB_ENV_PASSTHROUGH_ADDITIONS SSTATE_DIR DL_DIR"
-             bitbake $RECIPES -c cleansstate
              bitbake $RECIPES -k | tee -a ${{ matrix.machine }}-build.log'
            set -e
            echo RECIPES to build: $RECIPES


### PR DESCRIPTION
## Immediate fix for hashserv instability

Removes `bitbake $RECIPES -c cleansstate` from the build step.

**Problem:** `cleansstate` on shared EFS sstate-cache causes cascading failures:
1. Deletes sstate artifacts other concurrent jobs depend on
2. Overwhelms the single hashserv Fargate instance (0.25 vCPU, SQLite on NFS)
3. Produces `Error contacting Hash Equivalence Server` timeouts
4. Grep pattern catches these as build failures → false positives across all PRs

**Fix:** Just `bitbake $RECIPES -k`. No force flag needed — the recipe's SRCREV/version change means bitbake's hash mechanism already knows to rebuild it. Dependencies served from sstate.

**Follow-up:** Per-release hashserv isolation (separate hashserv + sstate per release branch) planned as infrastructure improvement.