### PR TITLE
[Backport whinlatter-next] 2026-07-28_01-39-58_master-next_python3-botocore

### DIFF
--- a/recipes-devtools/python/python3-botocore_1.43.57.bb
+++ b/recipes-devtools/python/python3-botocore_1.43.57.bb
@@ -12,7 +12,7 @@ SRC_URI = "\
     file://python_dependency_test.py \
     "
 
-SRCREV = "b71d5637f58df4bc61953b80902b3c040c7af889"
+SRCREV = "1ea0781bbf381e600a82c275219a7c88c1984b80"
 
 inherit setuptools3 ptest
 


### PR DESCRIPTION
# Description
Backport of #16371 to `whinlatter-next`.