### PR TITLE
[Backport wrynose-next] 2026-07-28_01-39-58_master-next_aws-crt-cpp

### DIFF
--- a/recipes-sdk/aws-crt-cpp/aws-crt-cpp/001-shared-static-crt-libs.patch
+++ b/recipes-sdk/aws-crt-cpp/aws-crt-cpp/001-shared-static-crt-libs.patch
@@ -1,4 +1,8 @@
+<<<<<<< HEAD
 From 77b249dbc3258423412f956d35981c3e72aebbdc Mon Sep 17 00:00:00 2001
+=======
+From d5f4442ed8347b168e306322390cf4aafb94cc95 Mon Sep 17 00:00:00 2001
+>>>>>>> 8802900a4 (aws-crt-cpp: upgrade 0.42.3 -> 0.43.0)
 From: Thomas Roos <throos@amazon.de>
 Date: Tue, 20 May 2025 08:45:29 +0000
 Subject: [PATCH] aws-crt-cpp: change to build-deps as default
@@ -13,7 +17,11 @@ Upstream-Status: Inappropriate [oe specific]
  1 file changed, 2 insertions(+)
 
 diff --git a/CMakeLists.txt b/CMakeLists.txt
+<<<<<<< HEAD
 index e9a3827..83bc66b 100644
+=======
+index cf04642..0d5d2e5 100644
+>>>>>>> 8802900a4 (aws-crt-cpp: upgrade 0.42.3 -> 0.43.0)
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -48,6 +48,7 @@ set(GENERATED_CONFIG_HEADER "${GENERATED_INCLUDE_DIR}/aws/crt/Config.h")

--- a/recipes-sdk/aws-crt-cpp/aws-crt-cpp/002-enable-tests-with-crosscompiling.patch
+++ b/recipes-sdk/aws-crt-cpp/aws-crt-cpp/002-enable-tests-with-crosscompiling.patch
@@ -1,4 +1,8 @@
+<<<<<<< HEAD
 From b4726f63e1494496122496ee0a8eaa68bb6fba39 Mon Sep 17 00:00:00 2001
+=======
+From 4f9061326cad9131d591e757b75db9c7f645ccbb Mon Sep 17 00:00:00 2001
+>>>>>>> 8802900a4 (aws-crt-cpp: upgrade 0.42.3 -> 0.43.0)
 From: Thomas Roos <throos@amazon.de>
 Date: Mon, 29 Sep 2025 12:51:03 +0000
 Subject: [PATCH] This enable the tests even when crosscompiling.
@@ -9,7 +13,11 @@ Upstream-Status: Inappropriate [oe specific]
  1 file changed, 2 deletions(-)
 
 diff --git a/CMakeLists.txt b/CMakeLists.txt
+<<<<<<< HEAD
 index 83bc66b..6862d8c 100644
+=======
+index 0d5d2e5..6746fa4 100644
+>>>>>>> 8802900a4 (aws-crt-cpp: upgrade 0.42.3 -> 0.43.0)
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -412,7 +412,6 @@ install(FILES "${GENERATED_ROOT_DIR}/${PROJECT_NAME}-config-version.cmake"

--- a/recipes-sdk/aws-crt-cpp/aws-crt-cpp_0.43.0.bb
+++ b/recipes-sdk/aws-crt-cpp/aws-crt-cpp_0.43.0.bb
@@ -28,7 +28,7 @@ SRC_URI = "\
     file://002-enable-tests-with-crosscompiling.patch \
     "
 
-SRCREV = "2992d25f38b9b4388a85748e850df62f437cae1c"
+SRCREV = "34cb7f08514241059458dad06f4de66749fc9241"
 
 inherit cmake pkgconfig ptest
 


### PR DESCRIPTION
# Description
Backport of #16377 to `wrynose-next`.