### PR TITLE
[Backport whinlatter-next] 2026-07-28_01-39-58_master-next_aws-c-cal

### DIFF
--- a/recipes-sdk/aws-c-cal/aws-c-cal_0.9.15.bb
+++ b/recipes-sdk/aws-c-cal/aws-c-cal_0.9.15.bb
@@ -21,7 +21,7 @@ SRC_URI = "\
     file://run-ptest \
     "
 
-SRCREV = "9edd8eac2b21ca6a04535b91d60d361c2f1bb60f"
+SRCREV = "8aa2a48a09f93c65d4cf06388e143a6584de6321"
 
 inherit cmake ptest pkgconfig
 

--- a/recipes-sdk/aws-c-cal/files/001-enable-tests-with-crosscompiling.patch
+++ b/recipes-sdk/aws-c-cal/files/001-enable-tests-with-crosscompiling.patch
@@ -1,4 +1,4 @@
-From ae9b50671e120cf1bf9e120f93a636e95a9a42af Mon Sep 17 00:00:00 2001
+From 4473e388162951461439ea407040a96b97f04cf9 Mon Sep 17 00:00:00 2001
 From: Thomas Roos <throos@amazon.de>
 Date: Mon, 29 Sep 2025 12:51:03 +0000
 Subject: [PATCH] This enable the tests even when crosscompiling.


### PR DESCRIPTION
# Description
Backport of #16366 to `whinlatter-next`.