### PR TITLE
[Backport wrynose-next] 2026-07-28_01-39-58_master-next_aws-cli

### DIFF
--- a/recipes-support/aws-cli/aws-cli_1.45.57.bb
+++ b/recipes-support/aws-cli/aws-cli_1.45.57.bb
@@ -9,7 +9,7 @@ SRC_URI = "\
     file://run-ptest \
 "
 
-SRCREV = "0e8a84237aff3d59ca4fc571145cb7d86568eac9"
+SRCREV = "87131e25748c0d52d6033ad47a2ec1f057ba7a83"
 
 # version 2.x has got library link issues - so stick to version 1.x for now
 UPSTREAM_CHECK_GITTAGREGEX = "(?P<pver>1\.\d+(\.\d+)+)"


### PR DESCRIPTION
# Description
Backport of #16369 to `wrynose-next`.