### PR TITLE
[Backport wrynose-next] 2026-07-28_01-39-58_master-next_aws-c-io

### DIFF
--- a/recipes-sdk/aws-c-io/aws-c-io/001-enable-tests-with-crosscompiling.patch
+++ b/recipes-sdk/aws-c-io/aws-c-io/001-enable-tests-with-crosscompiling.patch
@@ -1,4 +1,8 @@
+<<<<<<< HEAD
 From efafe4796d09e157563418e680eac499c5bb4b95 Mon Sep 17 00:00:00 2001
+=======
+From 869f519a15307e7edb94c3d30a75da991972f742 Mon Sep 17 00:00:00 2001
+>>>>>>> 2e97e088d (aws-c-io: upgrade 0.27.4 -> 0.27.5)
 From: Thomas Roos <throos@amazon.de>
 Date: Mon, 29 Sep 2025 12:51:03 +0000
 Subject: [PATCH] This enable the tests even when crosscompiling.

--- a/recipes-sdk/aws-c-io/aws-c-io_0.27.5.bb
+++ b/recipes-sdk/aws-c-io/aws-c-io_0.27.5.bb
@@ -23,7 +23,7 @@ SRC_URI = "\
     file://001-enable-tests-with-crosscompiling.patch \
     file://run-ptest \
     "
-SRCREV = "54350963b64dfc6c4b0ea623b08aa252aae3d7d7"
+SRCREV = "e2946c99521fa12d285c9a0829c92b1bf713922b"
 
 inherit cmake ptest pkgconfig
 


### PR DESCRIPTION
# Description
Backport of #16370 to `wrynose-next`.