### PR TITLE
ci: use per-release hash equivalence servers

### DIFF
--- a/.github/workflows/build-test-recipe.yml
+++ b/.github/workflows/build-test-recipe.yml
@@ -296,7 +296,7 @@ jobs:
              echo TEST_SUITES = \" ping ssh ptest parselogs\" >> conf/local.conf
              # this will allow - running testimage cmd: bitbake core-image-minimal -c testimage
              echo IMAGE_CLASSES += \"testimage\" >> conf/local.conf
-             echo BB_HASHSERVE = \"hashserv.internal:8686\" >> conf/local.conf
+             echo BB_HASHSERVE = \"${{ vars[format('HASHSERV_{0}', needs.changed.outputs.release)] }}\" >> conf/local.conf
              echo BB_SIGNATURE_HANDLER = \"OEEquivHash\" >> conf/local.conf
              cat conf/local.conf
              export SSTATE_DIR=/sstate-cache
@@ -332,7 +332,7 @@ jobs:
              for recipe in $RECIPES; do PUT+="${recipe}-ptest "; done
              echo IMAGE_INSTALL:append = \" ptest-runner ssh ${PUT}\" >> conf/local.conf
              echo IMAGE_FEATURES:append = \" allow-empty-password empty-root-password allow-root-login\" >> conf/local.conf
-             echo BB_HASHSERVE = \"hashserv.internal:8686\" >> conf/local.conf
+             echo BB_HASHSERVE = \"${{ vars[format('HASHSERV_{0}', needs.changed.outputs.release)] }}\" >> conf/local.conf
              echo BB_SIGNATURE_HANDLER = \"OEEquivHash\" >> conf/local.conf
              export SSTATE_DIR=/sstate-cache
              export DL_DIR=/downloads


### PR DESCRIPTION
## Per-release hashserv isolation

Each Yocto release now gets its own hash equivalence server instance, eliminating cross-release contamination and reducing single-server load.

**Infrastructure deployed:**
- `hashserv-master.internal:8686`
- `hashserv-scarthgap.internal:8686`
- `hashserv-whinlatter.internal:8686`
- `hashserv-wrynose.internal:8686`

**GitHub variables configured:**
- `HASHSERV_master`, `HASHSERV_scarthgap`, `HASHSERV_whinlatter`, `HASHSERV_wrynose`

**Workflow change:**
Replaces hardcoded `hashserv.internal:8686` with dynamic lookup:
```
vars[format('HASHSERV_{0}', needs.changed.outputs.release)]
```

Adding a new release only requires deploying a new Fargate task and setting the corresponding variable — no workflow code change needed.

**Companion to:** #16384 (remove cleansstate)