### PR TITLE
[Backport scarthgap-next] 2026-07-28_01-39-58_master-next_aws-cli-v2

### DIFF
--- a/recipes-support/aws-cli-v2/aws-cli-v2_2.36.9.bb
+++ b/recipes-support/aws-cli-v2/aws-cli-v2_2.36.9.bb
@@ -32,7 +32,7 @@ SRC_URI = "\
     file://run-ptest \
 "
 
-SRCREV = "73fb33bb171ace3e9eaa03308f76e5de50c21393"
+SRCREV = "49704b034263aab4228580f6b7280bf9faa1bf1c"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
# Description
Backport of #16373 to `scarthgap-next`.