### PR TITLE
[Backport whinlatter-next] aws-crt-cpp: upgrade to 0.43.0

### DIFF
--- a/recipes-sdk/aws-crt-cpp/aws-crt-cpp_0.43.0.bb
+++ b/recipes-sdk/aws-crt-cpp/aws-crt-cpp_0.43.0.bb
@@ -28,7 +28,7 @@ SRC_URI = "\
     file://002-enable-tests-with-crosscompiling.patch \
     "
 
-SRCREV = "2992d25f38b9b4388a85748e850df62f437cae1c"
+SRCREV = "34cb7f08514241059458dad06f4de66749fc9241"
 
 inherit cmake pkgconfig ptest
 


### PR DESCRIPTION
Automated backport

  Recipe: `aws-crt-cpp`
  Version: `0.43.0`