### PR TITLE
[Backport scarthgap-next] python3-botocore: upgrade to 1.43.57

### DIFF
--- a/recipes-devtools/python/python3-botocore_1.43.57.bb
+++ b/recipes-devtools/python/python3-botocore_1.43.57.bb
@@ -12,7 +12,7 @@ SRC_URI = "\
     file://python_dependency_test.py \
     "
 
-SRCREV = "b71d5637f58df4bc61953b80902b3c040c7af889"
+SRCREV = "1ea0781bbf381e600a82c275219a7c88c1984b80"
 S = "${WORKDIR}/git"
 
 inherit setuptools3 ptest


### PR DESCRIPTION
Automated backport

  Recipe: `python3-botocore`
  Version: `1.43.57`