### PR TITLE
[Backport whinlatter-next] aws-sdk-cpp: upgrade to 1.11.856

### DIFF
--- a/recipes-sdk/aws-sdk-cpp/aws-sdk-cpp_1.11.856.bb
+++ b/recipes-sdk/aws-sdk-cpp/aws-sdk-cpp_1.11.856.bb
@@ -19,7 +19,7 @@ SRC_URI = "\
     file://ptest_result.py \
     "
 
-SRCREV = "c9539d3ee8574d115248c73e0c435c925c7eb148"
+SRCREV = "519f224bb6fa29a1147228c01769511c6b5df762"
 
 inherit cmake ptest pkgconfig
 


### PR DESCRIPTION
Automated backport

  Recipe: `aws-sdk-cpp`
  Version: `1.11.856`