### PR TITLE
[Backport wrynose-next] aws-c-io: upgrade to 0.27.5

### DIFF
--- a/recipes-sdk/aws-c-io/aws-c-io_0.27.5.bb
+++ b/recipes-sdk/aws-c-io/aws-c-io_0.27.5.bb
@@ -23,7 +23,7 @@ SRC_URI = "\
     file://001-enable-tests-with-crosscompiling.patch \
     file://run-ptest \
     "
-SRCREV = "54350963b64dfc6c4b0ea623b08aa252aae3d7d7"
+SRCREV = "e2946c99521fa12d285c9a0829c92b1bf713922b"
 
 inherit cmake ptest pkgconfig
 


### PR DESCRIPTION
Automated backport

  Recipe: `aws-c-io`
  Version: `0.27.5`