### PR TITLE
ci: use per-release hash equivalence server

### DIFF
--- a/.github/workflows/build-test-recipe.yml
+++ b/.github/workflows/build-test-recipe.yml
@@ -296,7 +296,7 @@ jobs:
              echo TEST_SUITES = \" ping ssh ptest parselogs\" >> conf/local.conf
              # this will allow - running testimage cmd: bitbake core-image-minimal -c testimage
              echo IMAGE_CLASSES += \"testimage\" >> conf/local.conf
-             echo BB_HASHSERVE = \"hashserv.internal:8686\" >> conf/local.conf
+             echo BB_HASHSERVE = \"${{ vars[format('HASHSERV_{0}', needs.changed.outputs.release)] }}\" >> conf/local.conf
              echo BB_SIGNATURE_HANDLER = \"OEEquivHash\" >> conf/local.conf
              cat conf/local.conf
              export SSTATE_DIR=/sstate-cache
@@ -332,7 +332,7 @@ jobs:
              for recipe in $RECIPES; do PUT+="${recipe}-ptest "; done
              echo IMAGE_INSTALL:append = \" ptest-runner ssh ${PUT}\" >> conf/local.conf
              echo IMAGE_FEATURES:append = \" allow-empty-password empty-root-password allow-root-login\" >> conf/local.conf
-             echo BB_HASHSERVE = \"hashserv.internal:8686\" >> conf/local.conf
+             echo BB_HASHSERVE = \"${{ vars[format('HASHSERV_{0}', needs.changed.outputs.release)] }}\" >> conf/local.conf
              echo BB_SIGNATURE_HANDLER = \"OEEquivHash\" >> conf/local.conf
              export SSTATE_DIR=/sstate-cache
              export DL_DIR=/downloads


### PR DESCRIPTION
Fixes build failures caused by decommissioned hashserv.internal:8686.
Uses `vars.HASHSERV_wrynose` (hashserv-wrynose.internal:8686) via repository variable.