### PR TITLE
[Backport whinlatter-next] aws-c-sdkutils: upgrade to 0.2.8

### DIFF
--- a/recipes-sdk/aws-c-sdkutils/aws-c-sdkutils_0.2.8.bb
+++ b/recipes-sdk/aws-c-sdkutils/aws-c-sdkutils_0.2.8.bb
@@ -15,7 +15,7 @@ SRC_URI = "\
     file://run-ptest \
     file://001-enable-tests-with-crosscompiling.patch \
     "
-SRCREV = "cb14fea362c82c995eebd34e2e96590ab4e0ed58"
+SRCREV = "528b9dfff4a804b334875ecf8a0471f7d1366f24"
 
 inherit cmake ptest pkgconfig
 


### PR DESCRIPTION
Automated backport from master-next PR #16457.

  Recipe: `aws-c-sdkutils`
  Version: `0.2.8`