### PR TITLE
[Backport wrynose-next] aws-c-sdkutils: upgrade to 0.2.8

### DIFF
--- a/recipes-sdk/aws-c-sdkutils/aws-c-sdkutils_0.2.8.bb
+++ b/recipes-sdk/aws-c-sdkutils/aws-c-sdkutils_0.2.8.bb
@@ -15,7 +15,7 @@ SRC_URI = "\
     file://run-ptest \
     file://001-enable-tests-with-crosscompiling.patch \
     "
-SRCREV = "f678bda9e21f7217e4bbf35e0d1ea59540687933"
+SRCREV = "528b9dfff4a804b334875ecf8a0471f7d1366f24"
 
 inherit cmake ptest pkgconfig
 


### PR DESCRIPTION
Automated backport from master-next PR #16457.

  Recipe: `aws-c-sdkutils`
  Version: `0.2.8`