### PR TITLE
[Backport whinlatter-next] aws-cli-v2: upgrade to 2.36.11

### DIFF
--- a/recipes-support/aws-cli-v2/aws-cli-v2_2.36.11.bb
+++ b/recipes-support/aws-cli-v2/aws-cli-v2_2.36.11.bb
@@ -32,7 +32,7 @@ SRC_URI = "\
     file://run-ptest \
 "
 
-SRCREV = "49704b034263aab4228580f6b7280bf9faa1bf1c"
+SRCREV = "8a3ae4edca7fb73b66a9a0f06c440df54c92227a"
 
 # version 2.x
 UPSTREAM_CHECK_GITTAGREGEX = "(?P<pver>2\.\d+(\.\d+)+)"


### PR DESCRIPTION
Automated backport from master-next PR #16453.

  Recipe: `aws-cli-v2`
  Version: `2.36.11`