### PR TITLE
[Backport whinlatter-next] aws-cli: upgrade to 1.45.59

### DIFF
--- a/recipes-support/aws-cli/aws-cli_1.45.59.bb
+++ b/recipes-support/aws-cli/aws-cli_1.45.59.bb
@@ -9,7 +9,7 @@ SRC_URI = "\
     file://run-ptest \
 "
 
-SRCREV = "87131e25748c0d52d6033ad47a2ec1f057ba7a83"
+SRCREV = "50eea2bcbd2265b7ec73137df9f4a65e9736027d"
 
 # version 2.x has got library link issues - so stick to version 1.x for now
 UPSTREAM_CHECK_GITTAGREGEX = "(?P<pver>1\.\d+(\.\d+)+)"


### PR DESCRIPTION
Automated backport from master-next PR #16456.

  Recipe: `aws-cli`
  Version: `1.45.59`