### PR TITLE
[Backport scarthgap-next] aws-c-common: upgrade to 0.14.4

### DIFF
--- a/recipes-sdk/aws-c-common/aws-c-common_0.14.4.bb
+++ b/recipes-sdk/aws-c-common/aws-c-common_0.14.4.bb
@@ -14,7 +14,7 @@ SRC_URI = "\
     file://ptest_result.py \
     file://0001-skip-iso8601-tests-on-32bit.patch \
 "
-SRCREV = "3c69b871dfa1815231802febf1bb6899f84cccdb"
+SRCREV = "3a5e638aee99c9f1d65696f7df8c4e5d3dc5805c"
 
 # will match only x.x.x for auto upgrades, because: https://github.com/awslabs/aws-c-common/issues/1025
 UPSTREAM_CHECK_GITTAGREGEX = "(?P<pver>\d\.\d+(\.\d+)+)"


### PR DESCRIPTION
Automated backport from master-next PR #16459.

  Recipe: `aws-c-common`
  Version: `0.14.4`