### PR TITLE
[Backport wrynose-next] python3-botocore: upgrade to 1.43.59

### DIFF
--- a/recipes-devtools/python/python3-botocore_1.43.59.bb
+++ b/recipes-devtools/python/python3-botocore_1.43.59.bb
@@ -12,7 +12,7 @@ SRC_URI = "\
     file://python_dependency_test.py \
     "
 
-SRCREV = "1ea0781bbf381e600a82c275219a7c88c1984b80"
+SRCREV = "391890844b9a97fb9bc5351b33d5a25c16836402"
 
 inherit setuptools3 ptest
 


### PR DESCRIPTION
Automated backport from master-next PR #16451.

  Recipe: `python3-botocore`
  Version: `1.43.59`