### PR TITLE
[Backport scarthgap-next] python3-boto3: upgrade to 1.43.59

### DIFF
--- a/recipes-devtools/python/python3-boto3_1.43.59.bb
+++ b/recipes-devtools/python/python3-boto3_1.43.59.bb
@@ -12,7 +12,7 @@ SRC_URI = "\
     file://python_dependency_test.py \
     "
 
-SRCREV = "7b06b40e5bb8ac43a7ee3e4c80a348156cf7d393"
+SRCREV = "5595e623f8aed0f6cd2b49a82ae38697261b1cd2"
 S = "${WORKDIR}/git"
 
 inherit setuptools3 ptest


### PR DESCRIPTION
Automated backport from master-next PR #16455.

  Recipe: `python3-boto3`
  Version: `1.43.59`