### PR TITLE
[Backport scarthgap-next] aws-sdk-cpp: upgrade to 1.11.858

### DIFF
--- a/recipes-sdk/aws-sdk-cpp/aws-sdk-cpp_1.11.858.bb
+++ b/recipes-sdk/aws-sdk-cpp/aws-sdk-cpp_1.11.858.bb
@@ -21,7 +21,7 @@ SRC_URI = "\
     file://ptest_result.py \
     "
 
-SRCREV = "519f224bb6fa29a1147228c01769511c6b5df762"
+SRCREV = "e71b2d4e6407fdb90f973ac10186c73d702f965a"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Automated backport from master-next PR #16452.

  Recipe: `aws-sdk-cpp`
  Version: `1.11.858`