### PR TITLE
[Backport whinlatter-next] python3-botocore: upgrade to 1.43.60

### DIFF
--- a/recipes-devtools/python/python3-botocore_1.43.60.bb
+++ b/recipes-devtools/python/python3-botocore_1.43.60.bb
@@ -12,7 +12,7 @@ SRC_URI = "\
     file://python_dependency_test.py \
     "
 
-SRCREV = "391890844b9a97fb9bc5351b33d5a25c16836402"
+SRCREV = "c60f41e416915fca3df0390b9b33666cdf8f3c0f"
 
 inherit setuptools3 ptest
 


### PR DESCRIPTION
Automated backport from master-next PR #16490.

  Recipe: `python3-botocore`
  Version: `1.43.60`