### PR TITLE
[Backport scarthgap-next] aws-cli: upgrade to 1.45.63

### DIFF
--- a/recipes-support/aws-cli/aws-cli_1.45.63.bb
+++ b/recipes-support/aws-cli/aws-cli_1.45.63.bb
@@ -9,7 +9,7 @@ SRC_URI = "\
     file://run-ptest \
 "
 
-SRCREV = "50eea2bcbd2265b7ec73137df9f4a65e9736027d"
+SRCREV = "1f816e4bc23111c8d7c5a38e9557f9fbe20dd453"
 
 # version 2.x has got library link issues - so stick to version 1.x for now
 UPSTREAM_CHECK_GITTAGREGEX = "(?P<pver>1\.\d+(\.\d+)+)"


### PR DESCRIPTION
Automated backport from master-next PR #16506.

  Recipe: `aws-cli`
  Version: `1.45.63`