### PR TITLE
[Backport scarthgap-next] python3-botocore: upgrade to 1.43.63

### DIFF
--- a/recipes-devtools/python/python3-botocore_1.43.63.bb
+++ b/recipes-devtools/python/python3-botocore_1.43.63.bb
@@ -12,7 +12,7 @@ SRC_URI = "\
     file://python_dependency_test.py \
     "
 
-SRCREV = "c60f41e416915fca3df0390b9b33666cdf8f3c0f"
+SRCREV = "9e1c25a1cfed8a07391fae330f9d97e5f1bbf6dd"
 S = "${WORKDIR}/git"
 
 inherit setuptools3 ptest


### PR DESCRIPTION
Automated backport from master-next PR #16500.

  Recipe: `python3-botocore`
  Version: `1.43.63`