### PR TITLE
[Backport whinlatter-next] python3-botocore: upgrade to 1.43.63

### DIFF
--- a/recipes-devtools/python/python3-botocore_1.43.63.bb
+++ b/recipes-devtools/python/python3-botocore_1.43.63.bb
@@ -12,7 +12,7 @@ SRC_URI = "\
     file://python_dependency_test.py \
     "
 
-SRCREV = "391890844b9a97fb9bc5351b33d5a25c16836402"
+SRCREV = "9e1c25a1cfed8a07391fae330f9d97e5f1bbf6dd"
 
 inherit setuptools3 ptest
 


### PR DESCRIPTION
Automated backport from master-next PR #16500.

  Recipe: `python3-botocore`
  Version: `1.43.63`