### PR TITLE
[Backport scarthgap-next] aws-cli-v2: upgrade to 2.36.15

### DIFF
--- a/recipes-support/aws-cli-v2/aws-cli-v2_2.36.15.bb
+++ b/recipes-support/aws-cli-v2/aws-cli-v2_2.36.15.bb
@@ -32,7 +32,7 @@ SRC_URI = "\
     file://run-ptest \
 "
 
-SRCREV = "8a3ae4edca7fb73b66a9a0f06c440df54c92227a"
+SRCREV = "616abc435d88288ffc306085c876e03b53530d66"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Automated backport from master-next PR #16507.

  Recipe: `aws-cli-v2`
  Version: `2.36.15`