### PR TITLE
[Backport scarthgap-next] aws-crt-cpp: upgrade to 0.43.3

### DIFF
--- a/recipes-sdk/aws-crt-cpp/aws-crt-cpp_0.43.3.bb
+++ b/recipes-sdk/aws-crt-cpp/aws-crt-cpp_0.43.3.bb
@@ -28,7 +28,7 @@ SRC_URI = "\
     file://002-enable-tests-with-crosscompiling.patch \
     "
 
-SRCREV = "0463563f9f656a493ec22ca962c2464bc8b831ab"
+SRCREV = "1a7a1907b6cdd5d795c03736bdd5d3926ea977e3"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Automated backport from master-next PR #16508.

  Recipe: `aws-crt-cpp`
  Version: `0.43.3`