### PR TITLE
[Backport scarthgap-next] aws-c-mqtt: upgrade to 0.16.1

### DIFF
--- a/recipes-sdk/aws-c-mqtt/aws-c-mqtt_0.16.1.bb
+++ b/recipes-sdk/aws-c-mqtt/aws-c-mqtt_0.16.1.bb
@@ -23,7 +23,7 @@ SRC_URI = "\
     file://run-ptest \
     "
 
-SRCREV = "2ef9605ec9c50bea3f921e08022ddd57eed70901"
+SRCREV = "e35b9ca3f9fcbf1a972c831c5e79046ce56959d1"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Automated backport from master-next PR #16502.

  Recipe: `aws-c-mqtt`
  Version: `0.16.1`