### PR TITLE
[Backport scarthgap-next] aws-sdk-cpp: upgrade to 1.11.862

### DIFF
--- a/recipes-sdk/aws-sdk-cpp/aws-sdk-cpp_1.11.862.bb
+++ b/recipes-sdk/aws-sdk-cpp/aws-sdk-cpp_1.11.862.bb
@@ -21,7 +21,7 @@ SRC_URI = "\
     file://ptest_result.py \
     "
 
-SRCREV = "e71b2d4e6407fdb90f973ac10186c73d702f965a"
+SRCREV = "b4acc626b3288db1e2704351430507c19e542a6d"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Automated backport from master-next PR #16505.

  Recipe: `aws-sdk-cpp`
  Version: `1.11.862`