### PR TITLE
[Backport whinlatter-next] aws-c-sdkutils: upgrade to 0.2.9

### DIFF
--- a/recipes-sdk/aws-c-sdkutils/aws-c-sdkutils_0.2.9.bb
+++ b/recipes-sdk/aws-c-sdkutils/aws-c-sdkutils_0.2.9.bb
@@ -15,7 +15,7 @@ SRC_URI = "\
     file://run-ptest \
     file://001-enable-tests-with-crosscompiling.patch \
     "
-SRCREV = "528b9dfff4a804b334875ecf8a0471f7d1366f24"
+SRCREV = "a1cc19f53b63658f1b1400b36f199eafeeb895a6"
 
 inherit cmake ptest pkgconfig
 


### PR DESCRIPTION
Automated backport from master-next PR #16533.

  Recipe: `aws-c-sdkutils`
  Version: `0.2.9`