### PR TITLE
[Backport whinlatter-next] python3-boto3: upgrade to 1.43.64

### DIFF
--- a/recipes-devtools/python/python3-boto3_1.43.64.bb
+++ b/recipes-devtools/python/python3-boto3_1.43.64.bb
@@ -12,7 +12,7 @@ SRC_URI = "\
     file://python_dependency_test.py \
     "
 
-SRCREV = "7b06b40e5bb8ac43a7ee3e4c80a348156cf7d393"
+SRCREV = "06a2e1b6c2aaa242692f7695374afa98b7edd279"
 
 inherit setuptools3 ptest
 


### PR DESCRIPTION
Automated backport from master-next PR #16535.

  Recipe: `python3-boto3`
  Version: `1.43.64`