### PR TITLE
[Backport whinlatter-next] python3-botocore: upgrade to 1.43.64

### DIFF
--- a/recipes-devtools/python/python3-botocore_1.43.64.bb
+++ b/recipes-devtools/python/python3-botocore_1.43.64.bb
@@ -12,7 +12,7 @@ SRC_URI = "\
     file://python_dependency_test.py \
     "
 
-SRCREV = "9e1c25a1cfed8a07391fae330f9d97e5f1bbf6dd"
+SRCREV = "7451e27f30cafff2b3c40aac721fe4c971ec9fe0"
 
 inherit setuptools3 ptest
 


### PR DESCRIPTION
Automated backport from master-next PR #16536.

  Recipe: `python3-botocore`
  Version: `1.43.64`