### PR TITLE
[Backport wrynose-next] aws-sdk-cpp: upgrade to 1.11.863

### DIFF
--- a/recipes-sdk/aws-sdk-cpp/aws-sdk-cpp_1.11.863.bb
+++ b/recipes-sdk/aws-sdk-cpp/aws-sdk-cpp_1.11.863.bb
@@ -19,7 +19,7 @@ SRC_URI = "\
     file://ptest_result.py \
     "
 
-SRCREV = "b4acc626b3288db1e2704351430507c19e542a6d"
+SRCREV = "467ffba301fb93681d95187847a4f8f2cbc6b22a"
 
 inherit cmake ptest pkgconfig
 


### PR DESCRIPTION
Automated backport from master-next PR #16541.

  Recipe: `aws-sdk-cpp`
  Version: `1.11.863`