### PR TITLE
[Backport whinlatter-next] aws-cli: upgrade to 1.46.0

### DIFF
--- a/recipes-support/aws-cli/aws-cli_1.46.0.bb
+++ b/recipes-support/aws-cli/aws-cli_1.46.0.bb
@@ -9,7 +9,7 @@ SRC_URI = "\
     file://run-ptest \
 "
 
-SRCREV = "1402a3a3300f8979760e9da7283567dfba90a680"
+SRCREV = "8233a63cd1e50e8c36da109bb624cb832942a32b"
 
 # version 2.x has got library link issues - so stick to version 1.x for now
 UPSTREAM_CHECK_GITTAGREGEX = "(?P<pver>1\.\d+(\.\d+)+)"


### PR DESCRIPTION
Automated backport from master-next PR #16563.

  Recipe: `aws-cli`
  Version: `1.46.0`