### PR TITLE
[Backport wrynose-next] aws-cli-v2: upgrade to 2.36.17

### DIFF
--- a/recipes-support/aws-cli-v2/aws-cli-v2_2.36.17.bb
+++ b/recipes-support/aws-cli-v2/aws-cli-v2_2.36.17.bb
@@ -32,7 +32,7 @@ SRC_URI = "\
     file://run-ptest \
 "
 
-SRCREV = "4b247bb245c3d8aee69efb7bc6cae1046bc790e2"
+SRCREV = "fff1d6fbbb2aa9c361371c8155122828c39a0ec4"
 
 # version 2.x
 UPSTREAM_CHECK_GITTAGREGEX = "(?P<pver>2\.\d+(\.\d+)+)"


### PR DESCRIPTION
Automated backport from master-next PR #16571.

  Recipe: `aws-cli-v2`
  Version: `2.36.17`