### PR TITLE
[Backport wrynose-next] python3-botocore: upgrade to 1.43.65

### DIFF
--- a/recipes-devtools/python/python3-botocore_1.43.65.bb
+++ b/recipes-devtools/python/python3-botocore_1.43.65.bb
@@ -12,7 +12,7 @@ SRC_URI = "\
     file://python_dependency_test.py \
     "
 
-SRCREV = "7451e27f30cafff2b3c40aac721fe4c971ec9fe0"
+SRCREV = "f0f52802993561c41cfac2fe3e80136370eb5642"
 
 inherit setuptools3 ptest
 


### PR DESCRIPTION
Automated backport from master-next PR #16569.

  Recipe: `python3-botocore`
  Version: `1.43.65`