### PR TITLE
[Backport whinlatter-next] aws-crt-cpp: upgrade to 0.43.4

### DIFF
--- a/recipes-sdk/aws-crt-cpp/aws-crt-cpp_0.43.4.bb
+++ b/recipes-sdk/aws-crt-cpp/aws-crt-cpp_0.43.4.bb
@@ -28,7 +28,7 @@ SRC_URI = "\
     file://002-enable-tests-with-crosscompiling.patch \
     "
 
-SRCREV = "1a7a1907b6cdd5d795c03736bdd5d3926ea977e3"
+SRCREV = "851d8d003c9d5150edab56807e2393013f3771de"
 
 inherit cmake pkgconfig ptest
 


### PR DESCRIPTION
Automated backport from master-next PR #16572.

  Recipe: `aws-crt-cpp`
  Version: `0.43.4`