### PR TITLE
[Backport whinlatter-next] aws-lc: upgrade to 5.5.0

### DIFF
--- a/recipes-sdk/aws-lc/aws-lc_5.5.0.bb
+++ b/recipes-sdk/aws-lc/aws-lc_5.5.0.bb
@@ -878,7 +878,7 @@ SRC_URI = "\
     git://github.com/awslabs/aws-lc.git;protocol=https;branch=${BRANCH} \
     file://run-ptest \
     "
-SRCREV = "f6acf748df0ea6157d55e640730b38d21a7751cd"
+SRCREV = "991e67ff4cf04df4dd89e407f8b920c6936cb56a"
 UPSTREAM_CHECK_GITTAGREGEX = "v(?P<pver>.*)"
 
 # nooelint: oelint.vars.specific


### PR DESCRIPTION
Automated backport from master-next PR #16565.

  Recipe: `aws-lc`
  Version: `5.5.0`