### PR TITLE
[Backport wrynose-next] aws-sdk-cpp: upgrade to 1.11.864

### DIFF
--- a/recipes-sdk/aws-sdk-cpp/aws-sdk-cpp_1.11.864.bb
+++ b/recipes-sdk/aws-sdk-cpp/aws-sdk-cpp_1.11.864.bb
@@ -19,7 +19,7 @@ SRC_URI = "\
     file://ptest_result.py \
     "
 
-SRCREV = "467ffba301fb93681d95187847a4f8f2cbc6b22a"
+SRCREV = "0740427119fa3737741e42db3733fb1176ccdcca"
 
 inherit cmake ptest pkgconfig
 


### PR DESCRIPTION
Automated backport from master-next PR #16568.

  Recipe: `aws-sdk-cpp`
  Version: `1.11.864`