### PR TITLE
[Backport wrynose-next] python3-botocore: upgrade to 1.43.66

### DIFF
--- a/recipes-devtools/python/python3-botocore_1.43.66.bb
+++ b/recipes-devtools/python/python3-botocore_1.43.66.bb
@@ -12,7 +12,7 @@ SRC_URI = "\
     file://python_dependency_test.py \
     "
 
-SRCREV = "f0f52802993561c41cfac2fe3e80136370eb5642"
+SRCREV = "32fa450297443b91f092207dc191723fa5c19d00"
 
 inherit setuptools3 ptest
 


### PR DESCRIPTION
Automated backport from master-next PR #16594.

  Recipe: `python3-botocore`
  Version: `1.43.66`