### PR TITLE
[Backport whinlatter-next] aws-cli-v2: upgrade to 2.36.18

### DIFF
--- a/recipes-support/aws-cli-v2/aws-cli-v2_2.36.18.bb
+++ b/recipes-support/aws-cli-v2/aws-cli-v2_2.36.18.bb
@@ -32,7 +32,7 @@ SRC_URI = "\
     file://run-ptest \
 "
 
-SRCREV = "fff1d6fbbb2aa9c361371c8155122828c39a0ec4"
+SRCREV = "140745d91ad24c7b2b74287d3788bb8d0fda2912"
 
 # version 2.x
 UPSTREAM_CHECK_GITTAGREGEX = "(?P<pver>2\.\d+(\.\d+)+)"


### PR DESCRIPTION
Automated backport from master-next PR #16602.

  Recipe: `aws-cli-v2`
  Version: `2.36.18`