### PR TITLE
[Backport whinlatter-next] python3-boto3: upgrade to 1.43.66

### DIFF
--- a/recipes-devtools/python/python3-boto3_1.43.66.bb
+++ b/recipes-devtools/python/python3-boto3_1.43.66.bb
@@ -12,7 +12,7 @@ SRC_URI = "\
     file://python_dependency_test.py \
     "
 
-SRCREV = "7b06b40e5bb8ac43a7ee3e4c80a348156cf7d393"
+SRCREV = "f53e30a443e0fb5f71b8765658c0ef0a9206ef2b"
 
 inherit setuptools3 ptest
 


### PR DESCRIPTION
Automated backport from master-next PR #16599.

  Recipe: `python3-boto3`
  Version: `1.43.66`