### PR TITLE
[Backport wrynose-next] python3-boto3: upgrade to 1.43.66

### DIFF
--- a/recipes-devtools/python/python3-boto3_1.43.66.bb
+++ b/recipes-devtools/python/python3-boto3_1.43.66.bb
@@ -12,7 +12,7 @@ SRC_URI = "\
     file://python_dependency_test.py \
     "
 
-SRCREV = "b74eb20c9eaab074e80ba68ab30c5dd165f9943f"
+SRCREV = "f53e30a443e0fb5f71b8765658c0ef0a9206ef2b"
 
 inherit setuptools3 ptest
 


### PR DESCRIPTION
Automated backport from master-next PR #16599.

  Recipe: `python3-boto3`
  Version: `1.43.66`