### PR TITLE
[Backport scarthgap-next] amazon-ssm-agent: upgrade to 3.3.5068.0

### DIFF
--- a/recipes-support/amazon-ssm-agent/amazon-ssm-agent_3.3.5068.0.bb
+++ b/recipes-support/amazon-ssm-agent/amazon-ssm-agent_3.3.5068.0.bb
@@ -13,7 +13,7 @@ SRC_URI = "\
     file://run-ptest \
     "
 
-SRCREV = "b47799d07ddf776df1689165aedf21e68bbc3d0f"
+SRCREV = "11eb6116d914772f67086d73b8007424cfb7b158"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Automated backport from master-next PR #16598.

  Recipe: `amazon-ssm-agent`
  Version: `3.3.5068.0`