### PR TITLE
[Backport whinlatter-next] amazon-ssm-agent: upgrade to 3.3.5068.0

### DIFF
--- a/recipes-support/amazon-ssm-agent/amazon-ssm-agent_3.3.5068.0.bb
+++ b/recipes-support/amazon-ssm-agent/amazon-ssm-agent_3.3.5068.0.bb
@@ -13,7 +13,7 @@ SRC_URI = "\
     file://run-ptest \
     "
 
-SRCREV = "e5ff032880c19bac9b1a0f37a7448a9b573721de"
+SRCREV = "11eb6116d914772f67086d73b8007424cfb7b158"
 
 GO_IMPORT = ""
 


### PR DESCRIPTION
Automated backport from master-next PR #16598.

  Recipe: `amazon-ssm-agent`
  Version: `3.3.5068.0`