### PR TITLE
[Backport whinlatter-next] aws-sdk-cpp: upgrade to 1.11.865

### DIFF
--- a/recipes-sdk/aws-sdk-cpp/aws-sdk-cpp_1.11.865.bb
+++ b/recipes-sdk/aws-sdk-cpp/aws-sdk-cpp_1.11.865.bb
@@ -19,7 +19,7 @@ SRC_URI = "\
     file://ptest_result.py \
     "
 
-SRCREV = "0740427119fa3737741e42db3733fb1176ccdcca"
+SRCREV = "7463a1ec37f44434d3f9640f4daaa95017fe6150"
 
 inherit cmake ptest pkgconfig
 


### PR DESCRIPTION
Automated backport from master-next PR #16595.

  Recipe: `aws-sdk-cpp`
  Version: `1.11.865`