### PR TITLE
ci: fix BB_HASHSERVE variable lookup case mismatch

### DIFF
--- a/.github/workflows/build-test-recipe.yml
+++ b/.github/workflows/build-test-recipe.yml
@@ -79,6 +79,9 @@ jobs:
             RELEASE=$(echo "$REF_NAME" | cut -d- -f1)
             ;;
         esac
+        # Uppercase to match repository variable names (e.g. HASHSERV_MASTER)
+        # which are accessed via case-sensitive bracket notation in expressions.
+        RELEASE=$(echo "$RELEASE" | tr '[:lower:]' '[:upper:]')
         echo "Determined release: $RELEASE"
         echo "release=${RELEASE}" >> $GITHUB_OUTPUT
   build-test:


### PR DESCRIPTION
## Problem

The `build-test-recipe` workflow fails on all machines with:
```
ERROR: OEEquivHash requires BB_HASHSERVE to be set
```

The workflow derives a release name from the branch (e.g., `master-next` → `master`) and uses it to look up repository variables via bracket notation:
```yaml
${{ vars[format('HASHSERV_{0}', needs.changed.outputs.release)] }}
```

This produces `vars['HASHSERV_master']`, but GitHub stores variable names uppercased (`HASHSERV_MASTER`). **Bracket notation access is case-sensitive**, so the lookup returns empty string.

## Fix

Uppercase the release name (`tr '[:lower:]' '[:upper:]'`) before setting the output, so the format produces `HASHSERV_MASTER` which matches the stored variable.

## Testing

The job name will now display as `Build, Test qemuarm64 MASTER` instead of `Build, Test qemuarm64 master` — cosmetic only.

This unblocks all PRs currently failing CI (e.g., #16292).