### PR TITLE
ci: skip OEEquivHash when HASHSERV variable is unavailable (fork PRs)

### DIFF
--- a/.github/workflows/build-test-recipe.yml
+++ b/.github/workflows/build-test-recipe.yml
@@ -299,8 +299,10 @@ jobs:
              echo TEST_SUITES = \" ping ssh ptest parselogs\" >> conf/local.conf
              # this will allow - running testimage cmd: bitbake core-image-minimal -c testimage
              echo IMAGE_CLASSES += \"testimage\" >> conf/local.conf
-             echo BB_HASHSERVE = \"${{ vars[format('HASHSERV_{0}', needs.changed.outputs.release)] }}\" >> conf/local.conf
-             echo BB_SIGNATURE_HANDLER = \"OEEquivHash\" >> conf/local.conf
+             if [ -n \"${{ vars[format('HASHSERV_{0}', needs.changed.outputs.release)] }}\" ]; then
+               echo BB_HASHSERVE = \"${{ vars[format('HASHSERV_{0}', needs.changed.outputs.release)] }}\" >> conf/local.conf
+               echo BB_SIGNATURE_HANDLER = \"OEEquivHash\" >> conf/local.conf
+             fi
              cat conf/local.conf
              export SSTATE_DIR=/sstate-cache
              export DL_DIR=/downloads
@@ -335,8 +337,10 @@ jobs:
              for recipe in $RECIPES; do PUT+="${recipe}-ptest "; done
              echo IMAGE_INSTALL:append = \" ptest-runner ssh ${PUT}\" >> conf/local.conf
              echo IMAGE_FEATURES:append = \" allow-empty-password empty-root-password allow-root-login\" >> conf/local.conf
-             echo BB_HASHSERVE = \"${{ vars[format('HASHSERV_{0}', needs.changed.outputs.release)] }}\" >> conf/local.conf
-             echo BB_SIGNATURE_HANDLER = \"OEEquivHash\" >> conf/local.conf
+             if [ -n \"${{ vars[format('HASHSERV_{0}', needs.changed.outputs.release)] }}\" ]; then
+               echo BB_HASHSERVE = \"${{ vars[format('HASHSERV_{0}', needs.changed.outputs.release)] }}\" >> conf/local.conf
+               echo BB_SIGNATURE_HANDLER = \"OEEquivHash\" >> conf/local.conf
+             fi
              export SSTATE_DIR=/sstate-cache
              export DL_DIR=/downloads
              export BB_ENV_PASSTHROUGH_ADDITIONS="$BB_ENV_PASSTHROUGH_ADDITIONS SSTATE_DIR DL_DIR"


### PR DESCRIPTION
## Problem

PR #16623 fixed the case-sensitivity issue for `vars[]` lookup, but fork PRs (like #16292) still fail because **GitHub Actions does not expose repository variables to workflows triggered by fork PRs** (`pull_request` event). The `vars` context is completely empty in that security context.

Result:
```
echo BB_HASHSERVE = "" >> conf/local.conf
ERROR: OEEquivHash requires BB_HASHSERVE to be set
```

## Fix

Make the `BB_HASHSERVE` + `BB_SIGNATURE_HANDLER` configuration conditional — only set them when the variable resolves to a non-empty value.

For fork PRs, this means bitbake runs **without hash equivalence** (no sstate cache sharing with the hash server), which is slower but functional. Internal PRs still get the full hashserv optimization.

## Affected

All fork PRs that trigger `build-test-recipe` — currently #16292 (greengrass-lite).