### PR TITLE
ci: fix BB_HASHSERVE conditional quoting inside bash -c

### DIFF
--- a/.github/workflows/build-test-recipe.yml
+++ b/.github/workflows/build-test-recipe.yml
@@ -299,8 +299,9 @@ jobs:
              echo TEST_SUITES = \" ping ssh ptest parselogs\" >> conf/local.conf
              # this will allow - running testimage cmd: bitbake core-image-minimal -c testimage
              echo IMAGE_CLASSES += \"testimage\" >> conf/local.conf
-             if [ -n \"${{ vars[format('HASHSERV_{0}', needs.changed.outputs.release)] }}\" ]; then
-               echo BB_HASHSERVE = \"${{ vars[format('HASHSERV_{0}', needs.changed.outputs.release)] }}\" >> conf/local.conf
+             HASHSERV=${{ vars[format('HASHSERV_{0}', needs.changed.outputs.release)] }}
+             if [ -n "$HASHSERV" ]; then
+               echo BB_HASHSERVE = \"$HASHSERV\" >> conf/local.conf
                echo BB_SIGNATURE_HANDLER = \"OEEquivHash\" >> conf/local.conf
              fi
              cat conf/local.conf
@@ -337,8 +338,9 @@ jobs:
              for recipe in $RECIPES; do PUT+="${recipe}-ptest "; done
              echo IMAGE_INSTALL:append = \" ptest-runner ssh ${PUT}\" >> conf/local.conf
              echo IMAGE_FEATURES:append = \" allow-empty-password empty-root-password allow-root-login\" >> conf/local.conf
-             if [ -n \"${{ vars[format('HASHSERV_{0}', needs.changed.outputs.release)] }}\" ]; then
-               echo BB_HASHSERVE = \"${{ vars[format('HASHSERV_{0}', needs.changed.outputs.release)] }}\" >> conf/local.conf
+             HASHSERV=${{ vars[format('HASHSERV_{0}', needs.changed.outputs.release)] }}
+             if [ -n "$HASHSERV" ]; then
+               echo BB_HASHSERVE = \"$HASHSERV\" >> conf/local.conf
                echo BB_SIGNATURE_HANDLER = \"OEEquivHash\" >> conf/local.conf
              fi
              export SSTATE_DIR=/sstate-cache


### PR DESCRIPTION
## Problem

PR #16624 attempted to make `BB_HASHSERVE`/`OEEquivHash` conditional for fork PRs, but the fix didn't work because of **shell quoting inside `bash -c '...'`**.

The workflow uses `sudo ... bash -c '...'` with single quotes. Inside this, the escaped quotes `\"\"` produce literal quote characters — so:
```bash
if [ -n \"\" ]; then   # tests string '""' (two chars) → NON-EMPTY → TRUE!
```

This means the block **always executes**, writing an empty `BB_HASHSERVE` + `OEEquivHash` even for fork PRs.

## Fix

Assign the GitHub expression to a shell variable first, then use proper shell variable expansion in the test:
```bash
HASHSERV=${{ vars[format('HASHSERV_{0}', ...)] }}
if [ -n "\$HASHSERV" ]; then
  echo BB_HASHSERVE = \"\$HASHSERV\" >> conf/local.conf
  echo BB_SIGNATURE_HANDLER = \"OEEquivHash\" >> conf/local.conf
fi
```

When the expression is empty (fork PRs), `HASHSERV` is empty, and `[ -n "\$HASHSERV" ]` correctly evaluates to **false**.

Unblocks fork PRs like #16292 (greengrass-lite).