### PR TITLE
ci: use OEBasicHash fallback when HASHSERV is unavailable

### DIFF
--- a/.github/workflows/build-test-recipe.yml
+++ b/.github/workflows/build-test-recipe.yml
@@ -303,6 +303,8 @@ jobs:
              if [ -n "$HASHSERV" ]; then
                echo BB_HASHSERVE = \"$HASHSERV\" >> conf/local.conf
                echo BB_SIGNATURE_HANDLER = \"OEEquivHash\" >> conf/local.conf
+             else
+               echo BB_SIGNATURE_HANDLER = \"OEBasicHash\" >> conf/local.conf
              fi
              cat conf/local.conf
              export SSTATE_DIR=/sstate-cache
@@ -342,6 +344,8 @@ jobs:
              if [ -n "$HASHSERV" ]; then
                echo BB_HASHSERVE = \"$HASHSERV\" >> conf/local.conf
                echo BB_SIGNATURE_HANDLER = \"OEEquivHash\" >> conf/local.conf
+             else
+               echo BB_SIGNATURE_HANDLER = \"OEBasicHash\" >> conf/local.conf
              fi
              export SSTATE_DIR=/sstate-cache
              export DL_DIR=/downloads


### PR DESCRIPTION
## Problem

After PR #16625 fixed the shell quoting, the `if` block correctly evaluates to false for fork PRs. However, modern OE-core master enables `OEEquivHash` by default. Without explicit `BB_HASHSERVE`, bitbake falls back to a local sqlite DB which fails on the CI NFS-mounted sstate-cache:

```
ERROR: Hash equivalency database location (set via BB_HASHSERVE_DB_DIR to /sstate-cache)
cannot be on a NFS mount due to potential NFS locking issues between sqlite clients
```

## Fix

Add an `else` branch that explicitly sets `BB_SIGNATURE_HANDLER = "OEBasicHash"` to disable hash equivalence entirely for fork PRs.

- **Internal PRs**: `OEEquivHash` + remote hashserv (fast, sstate sharing)
- **Fork PRs**: `OEBasicHash` (no hash equivalence, slower but functional)

Unblocks #16292.