### PR TITLE
ci: use BB_HASHSERVE=auto fallback for fork PRs

### DIFF
--- a/.github/workflows/build-test-recipe.yml
+++ b/.github/workflows/build-test-recipe.yml
@@ -302,10 +302,10 @@ jobs:
              HASHSERV=${{ vars[format('HASHSERV_{0}', needs.changed.outputs.release)] }}
              if [ -n "$HASHSERV" ]; then
                echo BB_HASHSERVE = \"$HASHSERV\" >> conf/local.conf
-               echo BB_SIGNATURE_HANDLER = \"OEEquivHash\" >> conf/local.conf
              else
-               echo BB_SIGNATURE_HANDLER = \"OEBasicHash\" >> conf/local.conf
+               echo BB_HASHSERVE = \"auto\" >> conf/local.conf
              fi
+             echo BB_SIGNATURE_HANDLER = \"OEEquivHash\" >> conf/local.conf
              cat conf/local.conf
              export SSTATE_DIR=/sstate-cache
              export DL_DIR=/downloads
@@ -343,10 +343,10 @@ jobs:
              HASHSERV=${{ vars[format('HASHSERV_{0}', needs.changed.outputs.release)] }}
              if [ -n "$HASHSERV" ]; then
                echo BB_HASHSERVE = \"$HASHSERV\" >> conf/local.conf
-               echo BB_SIGNATURE_HANDLER = \"OEEquivHash\" >> conf/local.conf
              else
-               echo BB_SIGNATURE_HANDLER = \"OEBasicHash\" >> conf/local.conf
+               echo BB_HASHSERVE = \"auto\" >> conf/local.conf
              fi
+             echo BB_SIGNATURE_HANDLER = \"OEEquivHash\" >> conf/local.conf
              export SSTATE_DIR=/sstate-cache
              export DL_DIR=/downloads
              export BB_ENV_PASSTHROUGH_ADDITIONS="$BB_ENV_PASSTHROUGH_ADDITIONS SSTATE_DIR DL_DIR"


### PR DESCRIPTION
## Problem

OE-core master now enables `OEEquivHash` at the **distro level** (not just local.conf). Previous fix attempts:
- Setting `BB_SIGNATURE_HANDLER = "OEBasicHash"` → doesn't override distro-level config
- Not setting `BB_HASHSERVE` → bitbake defaults to local sqlite DB at `SSTATE_DIR` which fails on NFS

Result:
```
ERROR: Hash equivalency database location (set via BB_HASHSERVE_DB_DIR to /sstate-cache)
cannot be on a NFS mount due to potential NFS locking issues
```

## Fix

Use `BB_HASHSERVE = "auto"` as the fallback. This tells bitbake to start a **local in-memory hash equivalency server** within the process itself — no NFS DB, no network dependency, no external server needed.

| Context | BB_HASHSERVE | Effect |
|---------|-------------|--------|
| Internal PRs | `hashserv-<release>.internal:8686` | Remote shared server, full sstate sharing |
| Fork PRs | `auto` | Local in-memory server, no sharing but functional |

Both always use `BB_SIGNATURE_HANDLER = "OEEquivHash"` since the distro mandates it.

Unblocks #16292.