### PR TITLE
ci: set BB_HASHSERVE_DB_DIR to local path (avoid EFS/NFS error)

### DIFF
--- a/.github/workflows/build-test-recipe.yml
+++ b/.github/workflows/build-test-recipe.yml
@@ -306,6 +306,7 @@ jobs:
                echo BB_HASHSERVE = \"auto\" >> conf/local.conf
              fi
              echo BB_SIGNATURE_HANDLER = \"OEEquivHash\" >> conf/local.conf
+             echo BB_HASHSERVE_DB_DIR = \"/tmp/hashserv-db\" >> conf/local.conf
              cat conf/local.conf
              export SSTATE_DIR=/sstate-cache
              export DL_DIR=/downloads
@@ -347,6 +348,7 @@ jobs:
                echo BB_HASHSERVE = \"auto\" >> conf/local.conf
              fi
              echo BB_SIGNATURE_HANDLER = \"OEEquivHash\" >> conf/local.conf
+             echo BB_HASHSERVE_DB_DIR = \"/tmp/hashserv-db\" >> conf/local.conf
              export SSTATE_DIR=/sstate-cache
              export DL_DIR=/downloads
              export BB_ENV_PASSTHROUGH_ADDITIONS="$BB_ENV_PASSTHROUGH_ADDITIONS SSTATE_DIR DL_DIR"


### PR DESCRIPTION
## Problem

`BB_HASHSERVE = "auto"` starts a local hash equivalency server but still needs a sqlite database on disk. `BB_HASHSERVE_DB_DIR` defaults to `SSTATE_DIR` which is `/sstate-cache` — an **AWS EFS mount** (NFS protocol). Bitbake rejects this:

```
ERROR: Hash equivalency database location (set via BB_HASHSERVE_DB_DIR to /sstate-cache)
cannot be on a NFS mount due to potential NFS locking issues between sqlite clients
```

## Fix

Set `BB_HASHSERVE_DB_DIR = "/tmp/hashserv-db"` which is always local to the CodeBuild runner instance.

This applies to both internal and fork PRs — the NFS mount issue is a property of the CI runner environment, not the GitHub security context.

Unblocks #16292.