### PR TITLE
greengrass-lite: add Unity test framework as FetchContent dependency

### DIFF
--- a/recipes-iot/aws-iot-greengrass/greengrass-lite_2.5.1.bb
+++ b/recipes-iot/aws-iot-greengrass/greengrass-lite_2.5.1.bb
@@ -35,6 +35,7 @@ SRC_URI = "\
     ${@'' if d.getVar('DISABLE_FETCHCONTENT') else 'git://github.com/FreeRTOS/coreMQTT.git;protocol=https;branch=main;name=mqtt;destsuffix=${S}/thirdparty/core_mqtt'} \
     ${@'' if d.getVar('DISABLE_FETCHCONTENT') else 'git://github.com/aws/SigV4-for-AWS-IoT-embedded-sdk.git;protocol=https;branch=main;name=sigv4;destsuffix=${S}/thirdparty/aws_sigv4'} \
     ${@'' if d.getVar('DISABLE_FETCHCONTENT') else 'git://github.com/aws-greengrass/aws-greengrass-component-sdk.git;protocol=https;nobranch=1;name=sdk;destsuffix=${S}/thirdparty/gg_sdk'} \
+    ${@'' if d.getVar('DISABLE_FETCHCONTENT') else 'git://github.com/ThrowTheSwitch/Unity.git;protocol=https;branch=master;name=unity;destsuffix=${S}/thirdparty/unity'} \
     file://001-disable_strip.patch \
     file://002-fix-maybe-uninitialized.patch \
     file://greengrass-lite.yaml \
@@ -57,21 +58,27 @@ SRCREV_mqtt = "bda794aa54785aa96224f19e37d2e19e66bcd7ab"
 SRCREV_sigv4 = "v1.3.1"
 # nooelint: oelint.vars.specific
 SRCREV_sdk = "v1.0.3"
+# nooelint: oelint.vars.specific
+SRCREV_unity = "cbcd08fa7de711053a3deec6339ee89cad5d2697"
 
 EXTRA_OECMAKE:append = " \
     ${@'' if d.getVar('DISABLE_FETCHCONTENT') else '-DFETCHCONTENT_SOURCE_DIR_CORE_MQTT=${S}/thirdparty/core_mqtt'} \
     ${@'' if d.getVar('DISABLE_FETCHCONTENT') else '-DFETCHCONTENT_SOURCE_DIR_AWS_SIGV4=${S}/thirdparty/aws_sigv4'} \
     ${@'' if d.getVar('DISABLE_FETCHCONTENT') else '-DFETCHCONTENT_SOURCE_DIR_GG_SDK=${S}/thirdparty/gg_sdk'} \
+    ${@'' if d.getVar('DISABLE_FETCHCONTENT') else '-DFETCHCONTENT_SOURCE_DIR_UNITY=${S}/thirdparty/unity'} \
     ${@'-DFETCHCONTENT_FULLY_DISCONNECTED=OFF' if d.getVar('DISABLE_FETCHCONTENT') else ''} \
     "
 
-SRCREV_FORMAT .= "_ggl_core_mqtt_aws_sigv4_gg_sdk"
+SRCREV_FORMAT .= "_ggl_core_mqtt_aws_sigv4_gg_sdk_unity"
 
 do_configure:prepend() {
     # verify that all dependencies have correct version
     grep -q ${SRCREV_mqtt} ${S}/fc_deps.json || bbfatal "ERROR: dependency version mismatch, please update 'SRCREV_mqtt'!"
     grep -q ${SRCREV_sigv4} ${S}/fc_deps.json || bbfatal "ERROR: dependency version mismatch, please update 'SRCREV_sigv4'!"
     grep -q ${SRCREV_sdk} ${S}/fc_deps.json || bbfatal "ERROR: dependency version mismatch, please update 'SRCREV_sdk'!"
+    if grep -q '"unity"' ${S}/fc_deps.json 2>/dev/null; then
+        grep -q ${SRCREV_unity} ${S}/fc_deps.json || bbfatal "ERROR: dependency version mismatch, please update 'SRCREV_unity'!"
+    fi
 }
 
 do_configure[network] = "${@'1' if d.getVar('DISABLE_FETCHCONTENT') else '0'}"


### PR DESCRIPTION
## Problem

greengrass-lite 2.6.0 (PR #16292) added Unity (ThrowTheSwitch/Unity) to its `fc_deps.json` for ptest/unit testing. Without pre-fetching the Unity source, the CI build fails:

```
fatal error: unity_internals.h: No such file or directory
fatal error: unity.h: No such file or directory
```

## Fix

Add Unity to the recipe following the same FetchContent pattern as the other dependencies:
- `SRC_URI`: fetch from `github.com/ThrowTheSwitch/Unity.git`
- `SRCREV_unity`: pinned to `cbcd08fa7de711053a3deec6339ee89cad5d2697` (matching fc_deps.json)
- `EXTRA_OECMAKE`: `-DFETCHCONTENT_SOURCE_DIR_UNITY=${S}/thirdparty/unity`
- `SRCREV_FORMAT`: appended `_unity`

The version check in `do_configure:prepend` is conditional — only validates the Unity SRCREV if `fc_deps.json` contains a `"unity"` entry (compatible with both 2.5.1 and 2.6.0+).

Once merged, PR #16292 can be rebased on top without conflicts (Greg's PR renames the file and updates SRCREVs).