### PR TITLE
[Backport whinlatter-next] python3-botocore: upgrade to 1.43.68

### DIFF
--- a/recipes-devtools/python/python3-botocore_1.43.68.bb
+++ b/recipes-devtools/python/python3-botocore_1.43.68.bb
@@ -12,7 +12,7 @@ SRC_URI = "\
     file://python_dependency_test.py \
     "
 
-SRCREV = "32fa450297443b91f092207dc191723fa5c19d00"
+SRCREV = "7fb8da7848707d52fbf544f097d51a4045d59aba"
 
 inherit setuptools3 ptest
 


### PR DESCRIPTION
Automated backport from master-next PR #16634.

  Recipe: `python3-botocore`
  Version: `1.43.68`