### PR TITLE
[Backport whinlatter-next] python3-boto3: upgrade to 1.43.68

### DIFF
--- a/recipes-devtools/python/python3-boto3_1.43.68.bb
+++ b/recipes-devtools/python/python3-boto3_1.43.68.bb
@@ -12,7 +12,7 @@ SRC_URI = "\
     file://python_dependency_test.py \
     "
 
-SRCREV = "f53e30a443e0fb5f71b8765658c0ef0a9206ef2b"
+SRCREV = "64ffe2afa675a6d65e61121732ec5d3ec6c63a92"
 
 inherit setuptools3 ptest
 


### PR DESCRIPTION
Automated backport from master-next PR #16633.

  Recipe: `python3-boto3`
  Version: `1.43.68`