### PR TITLE
[Backport scarthgap-next] aws-cli-v2: upgrade to 2.36.20

### DIFF
--- a/recipes-support/aws-cli-v2/aws-cli-v2_2.36.20.bb
+++ b/recipes-support/aws-cli-v2/aws-cli-v2_2.36.20.bb
@@ -32,7 +32,7 @@ SRC_URI = "\
     file://run-ptest \
 "
 
-SRCREV = "140745d91ad24c7b2b74287d3788bb8d0fda2912"
+SRCREV = "70da93ccdec4e61a97b50ec7e9414776601cd89d"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Automated backport from master-next PR #16635.

  Recipe: `aws-cli-v2`
  Version: `2.36.20`