### PR TITLE
[Backport wrynose-next] aws-sdk-cpp: upgrade to 1.11.867

### DIFF
--- a/recipes-sdk/aws-sdk-cpp/aws-sdk-cpp_1.11.867.bb
+++ b/recipes-sdk/aws-sdk-cpp/aws-sdk-cpp_1.11.867.bb
@@ -19,7 +19,7 @@ SRC_URI = "\
     file://ptest_result.py \
     "
 
-SRCREV = "7463a1ec37f44434d3f9640f4daaa95017fe6150"
+SRCREV = "7d268fdfb104a27507449953999cee19b6859a63"
 
 inherit cmake ptest pkgconfig
 


### PR DESCRIPTION
Automated backport from master-next PR #16636.

  Recipe: `aws-sdk-cpp`
  Version: `1.11.867`