### PR TITLE
[Backport wrynose-next] aws-crt-cpp: upgrade to 0.43.5

### DIFF
--- a/recipes-sdk/aws-crt-cpp/aws-crt-cpp_0.43.5.bb
+++ b/recipes-sdk/aws-crt-cpp/aws-crt-cpp_0.43.5.bb
@@ -28,7 +28,7 @@ SRC_URI = "\
     file://002-enable-tests-with-crosscompiling.patch \
     "
 
-SRCREV = "851d8d003c9d5150edab56807e2393013f3771de"
+SRCREV = "1f333376b2b2801bb3844ce5c315d3a87ecacd4b"
 
 inherit cmake pkgconfig ptest
 


### PR DESCRIPTION
Automated backport from master-next PR #16658.

  Recipe: `aws-crt-cpp`
  Version: `0.43.5`