### PR TITLE
[Backport scarthgap-next] python3-boto3: upgrade to 1.43.69

### DIFF
--- a/recipes-devtools/python/python3-boto3_1.43.69.bb
+++ b/recipes-devtools/python/python3-boto3_1.43.69.bb
@@ -12,7 +12,7 @@ SRC_URI = "\
     file://python_dependency_test.py \
     "
 
-SRCREV = "f53e30a443e0fb5f71b8765658c0ef0a9206ef2b"
+SRCREV = "d59250146a750354ebe83f5f93ca19bc399d22ba"
 S = "${WORKDIR}/git"
 
 inherit setuptools3 ptest


### PR DESCRIPTION
Automated backport from master-next PR #16661.

  Recipe: `python3-boto3`
  Version: `1.43.69`