### PR TITLE
[Backport scarthgap-next] python3-botocore: upgrade to 1.43.69

### DIFF
--- a/recipes-devtools/python/python3-botocore_1.43.69.bb
+++ b/recipes-devtools/python/python3-botocore_1.43.69.bb
@@ -12,7 +12,7 @@ SRC_URI = "\
     file://python_dependency_test.py \
     "
 
-SRCREV = "7fb8da7848707d52fbf544f097d51a4045d59aba"
+SRCREV = "88995d62c31cfec6b7727c3e9f14bc960b5999a9"
 S = "${WORKDIR}/git"
 
 inherit setuptools3 ptest


### PR DESCRIPTION
Automated backport from master-next PR #16660.

  Recipe: `python3-botocore`
  Version: `1.43.69`