### PR TITLE
[Backport scarthgap-next] aws-crt-python: upgrade to 0.36.2

### DIFF
--- a/recipes-sdk/aws-crt-python/aws-crt-python_0.36.2.bb
+++ b/recipes-sdk/aws-crt-python/aws-crt-python_0.36.2.bb
@@ -37,7 +37,7 @@ SRC_URI = "\
     file://run-ptest \
     "
 
-SRCREV = "bf57332e2a38e8a8477ea1fe2f1c47e4f98e5875"
+SRCREV = "241be07f82ebd3031a812492443d545676cb2018"
 UPSTREAM_CHECK_GITTAGREGEX = "v(?P<pver>.*)"
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
Automated backport from master-next PR #16663.

  Recipe: `aws-crt-python`
  Version: `0.36.2`