### PR TITLE
[Backport scarthgap-next] aws-sdk-cpp: upgrade to 1.11.868

### DIFF
--- a/recipes-sdk/aws-sdk-cpp/aws-sdk-cpp_1.11.868.bb
+++ b/recipes-sdk/aws-sdk-cpp/aws-sdk-cpp_1.11.868.bb
@@ -21,7 +21,7 @@ SRC_URI = "\
     file://ptest_result.py \
     "
 
-SRCREV = "7d268fdfb104a27507449953999cee19b6859a63"
+SRCREV = "69ee6af945be7c3f9883aae14b7b272e3c475381"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Automated backport from master-next PR #16662.

  Recipe: `aws-sdk-cpp`
  Version: `1.11.868`