### PR TITLE
[Backport scarthgap-next] python3-boto3: upgrade to 1.43.70

### DIFF
--- a/recipes-devtools/python/python3-boto3_1.43.70.bb
+++ b/recipes-devtools/python/python3-boto3_1.43.70.bb
@@ -12,7 +12,7 @@ SRC_URI = "\
     file://python_dependency_test.py \
     "
 
-SRCREV = "f53e30a443e0fb5f71b8765658c0ef0a9206ef2b"
+SRCREV = "8c2ae687338ebadf80dfd92114e12708304a545d"
 S = "${WORKDIR}/git"
 
 inherit setuptools3 ptest


### PR DESCRIPTION
Automated backport from master-next PR #16686.

  Recipe: `python3-boto3`
  Version: `1.43.70`