### PR TITLE
[Backport whinlatter-next] python3-botocore: upgrade to 1.43.70

### DIFF
--- a/recipes-devtools/python/python3-botocore_1.43.70.bb
+++ b/recipes-devtools/python/python3-botocore_1.43.70.bb
@@ -12,7 +12,7 @@ SRC_URI = "\
     file://python_dependency_test.py \
     "
 
-SRCREV = "88995d62c31cfec6b7727c3e9f14bc960b5999a9"
+SRCREV = "144a686dde0a37b694e6b67e073a9c8b4bbc4afe"
 
 inherit setuptools3 ptest
 


### PR DESCRIPTION
Automated backport from master-next PR #16685.

  Recipe: `python3-botocore`
  Version: `1.43.70`