### PR TITLE
[Backport scarthgap-next] aws-cli-v2: upgrade to 2.36.22

### DIFF
--- a/recipes-support/aws-cli-v2/aws-cli-v2_2.36.22.bb
+++ b/recipes-support/aws-cli-v2/aws-cli-v2_2.36.22.bb
@@ -32,7 +32,7 @@ SRC_URI = "\
     file://run-ptest \
 "
 
-SRCREV = "70da93ccdec4e61a97b50ec7e9414776601cd89d"
+SRCREV = "36ad2be7b1e1c98ece2dc2fa1ebdf08cb6b364f8"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Automated backport from master-next PR #16684.

  Recipe: `aws-cli-v2`
  Version: `2.36.22`