### PR TITLE
[Backport wrynose-next] aws-sdk-cpp: upgrade to 1.11.869

### DIFF
--- a/recipes-sdk/aws-sdk-cpp/aws-sdk-cpp_1.11.869.bb
+++ b/recipes-sdk/aws-sdk-cpp/aws-sdk-cpp_1.11.869.bb
@@ -19,7 +19,7 @@ SRC_URI = "\
     file://ptest_result.py \
     "
 
-SRCREV = "69ee6af945be7c3f9883aae14b7b272e3c475381"
+SRCREV = "c84017197daa00de9cc05b1166e9106e1079f7f3"
 
 inherit cmake ptest pkgconfig
 


### PR DESCRIPTION
Automated backport from master-next PR #16687.

  Recipe: `aws-sdk-cpp`
  Version: `1.11.869`