### PR TITLE
[Backport scarthgap-next] aws-sdk-cpp: upgrade to 1.11.870

### DIFF
--- a/recipes-sdk/aws-sdk-cpp/aws-sdk-cpp_1.11.870.bb
+++ b/recipes-sdk/aws-sdk-cpp/aws-sdk-cpp_1.11.870.bb
@@ -21,7 +21,7 @@ SRC_URI = "\
     file://ptest_result.py \
     "
 
-SRCREV = "c84017197daa00de9cc05b1166e9106e1079f7f3"
+SRCREV = "5039dbec647df842ab739e1cb225acacaacb6ba3"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Automated backport from master-next PR #16703.

  Recipe: `aws-sdk-cpp`
  Version: `1.11.870`