### PR TITLE
[Backport whinlatter-next] aws-cli-v2: upgrade to 2.36.28

### DIFF
--- a/recipes-support/aws-cli-v2/aws-cli-v2_2.36.28.bb
+++ b/recipes-support/aws-cli-v2/aws-cli-v2_2.36.28.bb
@@ -32,7 +32,7 @@ SRC_URI = "\
     file://run-ptest \
 "
 
-SRCREV = "36ad2be7b1e1c98ece2dc2fa1ebdf08cb6b364f8"
+SRCREV = "1ea825bf0ae70bf1014d996d35911ff872323839"
 
 # version 2.x
 UPSTREAM_CHECK_GITTAGREGEX = "(?P<pver>2\.\d+(\.\d+)+)"


### PR DESCRIPTION
Automated backport from master-next PR #16783.

  Recipe: `aws-cli-v2`
  Version: `2.36.28`