### PR TITLE
[Backport scarthgap-next] python3-boto3: upgrade to 1.43.76

### DIFF
--- a/recipes-devtools/python/python3-boto3_1.43.76.bb
+++ b/recipes-devtools/python/python3-boto3_1.43.76.bb
@@ -12,7 +12,7 @@ SRC_URI = "\
     file://python_dependency_test.py \
     "
 
-SRCREV = "f53e30a443e0fb5f71b8765658c0ef0a9206ef2b"
+SRCREV = "8a88b26bcdfc66d06a404bb191a3405fb6869071"
 S = "${WORKDIR}/git"
 
 inherit setuptools3 ptest


### PR DESCRIPTION
Automated backport from master-next PR #16792.

  Recipe: `python3-boto3`
  Version: `1.43.76`