### PR TITLE
[Backport wrynose-next] python3-botocore: upgrade to 1.43.76

### DIFF
--- a/recipes-devtools/python/python3-botocore_1.43.76.bb
+++ b/recipes-devtools/python/python3-botocore_1.43.76.bb
@@ -12,7 +12,7 @@ SRC_URI = "\
     file://python_dependency_test.py \
     "
 
-SRCREV = "144a686dde0a37b694e6b67e073a9c8b4bbc4afe"
+SRCREV = "648ecf41e2472bac42182756b9768a10b3a4add8"
 
 inherit setuptools3 ptest
 


### PR DESCRIPTION
Automated backport from master-next PR #16784.

  Recipe: `python3-botocore`
  Version: `1.43.76`