### PR TITLE
[Backport whinlatter-next] amazon-ssm-agent: upgrade to 3.3.5226.0

### DIFF
--- a/recipes-support/amazon-ssm-agent/amazon-ssm-agent_3.3.5226.0.bb
+++ b/recipes-support/amazon-ssm-agent/amazon-ssm-agent_3.3.5226.0.bb
@@ -13,7 +13,7 @@ SRC_URI = "\
     file://run-ptest \
     "
 
-SRCREV = "11eb6116d914772f67086d73b8007424cfb7b158"
+SRCREV = "b05af2a0692279734949821225288276b5efab0d"
 
 GO_IMPORT = ""
 


### PR DESCRIPTION
Automated backport from master-next PR #16794.

  Recipe: `amazon-ssm-agent`
  Version: `3.3.5226.0`