### PR TITLE
[Backport scarthgap-next] aws-c-iot: upgrade to 0.2.2

### DIFF
--- a/recipes-sdk/aws-c-iot/aws-c-iot_0.2.2.bb
+++ b/recipes-sdk/aws-c-iot/aws-c-iot_0.2.2.bb
@@ -28,7 +28,7 @@ SRC_URI = "\
     file://run-ptest \
     "
 
-SRCREV = "9f0c152ed76af1a45d99fb98286707aa23c728af"
+SRCREV = "84c7a1a4182ecdc8d86405a5c86bd39a9995193b"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Automated backport from master-next PR #16774.

  Recipe: `aws-c-iot`
  Version: `0.2.2`