### PR TITLE
[Backport wrynose-next] aws-c-sdkutils: upgrade to 0.2.10

### DIFF
--- a/recipes-sdk/aws-c-sdkutils/aws-c-sdkutils_0.2.10.bb
+++ b/recipes-sdk/aws-c-sdkutils/aws-c-sdkutils_0.2.10.bb
@@ -15,7 +15,7 @@ SRC_URI = "\
     file://run-ptest \
     file://001-enable-tests-with-crosscompiling.patch \
     "
-SRCREV = "a1cc19f53b63658f1b1400b36f199eafeeb895a6"
+SRCREV = "bb4c0918b84a1a5e0ecfafb960711024cfee916f"
 
 inherit cmake ptest pkgconfig
 


### PR DESCRIPTION
Automated backport from master-next PR #16788.

  Recipe: `aws-c-sdkutils`
  Version: `0.2.10`