### PR TITLE
[Backport wrynose-next] aws-checksums: upgrade to 0.2.11

### DIFF
--- a/recipes-sdk/aws-checksums/aws-checksums_0.2.11.bb
+++ b/recipes-sdk/aws-checksums/aws-checksums_0.2.11.bb
@@ -19,7 +19,7 @@ SRC_URI = "\
     file://run-ptest \
     "
 
-SRCREV = "1d5f2f1f3e5d013aae8810878ceb5b3f6f258c4e"
+SRCREV = "32fed6fc25a90146bd0ac7e5c639e3778b78fdf1"
 
 inherit cmake ptest pkgconfig
 


### PR DESCRIPTION
Automated backport from master-next PR #16797.

  Recipe: `aws-checksums`
  Version: `0.2.11`