### PR TITLE
[Backport whinlatter-next] aws-c-mqtt: upgrade to 0.16.2

### DIFF
--- a/recipes-sdk/aws-c-mqtt/aws-c-mqtt_0.16.2.bb
+++ b/recipes-sdk/aws-c-mqtt/aws-c-mqtt_0.16.2.bb
@@ -23,7 +23,7 @@ SRC_URI = "\
     file://run-ptest \
     "
 
-SRCREV = "e35b9ca3f9fcbf1a972c831c5e79046ce56959d1"
+SRCREV = "95739b3f34830e9e32a392b783994df5279387d9"
 
 inherit cmake ptest
 


### PR DESCRIPTION
Automated backport from master-next PR #16778.

  Recipe: `aws-c-mqtt`
  Version: `0.16.2`