### PR TITLE
[Backport wrynose-next] aws-c-compression: upgrade to 0.3.3

### DIFF
--- a/recipes-sdk/aws-c-compression/aws-c-compression_0.3.3.bb
+++ b/recipes-sdk/aws-c-compression/aws-c-compression_0.3.3.bb
@@ -22,7 +22,7 @@ SRC_URI = "\
     file://run-ptest \
     "
 
-SRCREV = "d8264e64f698341eb03039b96b4f44702a9b3f83"
+SRCREV = "281801657a7b69c316e2a52689365bc8256cbb15"
 
 inherit cmake ptest pkgconfig
 


### PR DESCRIPTION
Automated backport from master-next PR #16780.

  Recipe: `aws-c-compression`
  Version: `0.3.3`