### PR TITLE
[Backport wrynose-next] aws-c-http: upgrade to 0.11.1

### DIFF
--- a/recipes-sdk/aws-c-http/aws-c-http_0.11.1.bb
+++ b/recipes-sdk/aws-c-http/aws-c-http_0.11.1.bb
@@ -23,7 +23,7 @@ SRC_URI = "\
     file://run-ptest \
     "
 
-SRCREV = "8aefd899fc3210bfd0e3fd414011a3cb708bf6e4"
+SRCREV = "bd6f0b0cf0814e87249cc621466800ab1ae2aa5d"
 
 inherit cmake ptest pkgconfig
 


### PR DESCRIPTION
Automated backport from master-next PR #16777.

  Recipe: `aws-c-http`
  Version: `0.11.1`