### PR TITLE
[Backport scarthgap-next] aws-c-event-stream: upgrade to 0.7.2

### DIFF
--- a/recipes-sdk/aws-c-event-stream/aws-c-event-stream_0.7.2.bb
+++ b/recipes-sdk/aws-c-event-stream/aws-c-event-stream_0.7.2.bb
@@ -20,7 +20,7 @@ SRC_URI = "\
     git://github.com/awslabs/aws-c-event-stream.git;protocol=https;branch=${BRANCH} \
     file://run-ptest \
     "
-SRCREV = "51bef3c44e1058b1689751539170b2e0f589ccdb"
+SRCREV = "be448067250706b2f2739c7a3b1c0db0e19c5aed"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Automated backport from master-next PR #16781.

  Recipe: `aws-c-event-stream`
  Version: `0.7.2`