### PR TITLE
[Backport wrynose-next] aws-sdk-cpp: upgrade to 1.11.875

### DIFF
--- a/recipes-sdk/aws-sdk-cpp/aws-sdk-cpp_1.11.875.bb
+++ b/recipes-sdk/aws-sdk-cpp/aws-sdk-cpp_1.11.875.bb
@@ -19,7 +19,7 @@ SRC_URI = "\
     file://ptest_result.py \
     "
 
-SRCREV = "5039dbec647df842ab739e1cb225acacaacb6ba3"
+SRCREV = "23618a8d660bc4e3ca7d57588546ba0450541329"
 
 inherit cmake ptest pkgconfig
 


### PR DESCRIPTION
Automated backport from master-next PR #16796.

  Recipe: `aws-sdk-cpp`
  Version: `1.11.875`