### PR TITLE
[Backport wrynose-next] aws-cli-v2: upgrade to 2.36.30

### DIFF
--- a/recipes-support/aws-cli-v2/aws-cli-v2_2.36.30.bb
+++ b/recipes-support/aws-cli-v2/aws-cli-v2_2.36.30.bb
@@ -32,7 +32,7 @@ SRC_URI = "\
     file://run-ptest \
 "
 
-SRCREV = "1ea825bf0ae70bf1014d996d35911ff872323839"
+SRCREV = "2552cbe0ac85d8f8d2ad8d1a22b2bcded2a048a3"
 
 # version 2.x
 UPSTREAM_CHECK_GITTAGREGEX = "(?P<pver>2\.\d+(\.\d+)+)"


### PR DESCRIPTION
Automated backport from master-next PR #16846.

  Recipe: `aws-cli-v2`
  Version: `2.36.30`