### PR TITLE
[Backport whinlatter-next] python3-boto3: upgrade to 1.43.79

### DIFF
--- a/recipes-devtools/python/python3-boto3_1.43.79.bb
+++ b/recipes-devtools/python/python3-boto3_1.43.79.bb
@@ -12,7 +12,7 @@ SRC_URI = "\
     file://python_dependency_test.py \
     "
 
-SRCREV = "f53e30a443e0fb5f71b8765658c0ef0a9206ef2b"
+SRCREV = "5e481390605b62641627e5d4af3926dce9a0ec0c"
 
 inherit setuptools3 ptest
 


### PR DESCRIPTION
Automated backport from master-next PR #16849.

  Recipe: `python3-boto3`
  Version: `1.43.79`