### PR TITLE
[Backport scarthgap-next] python3-botocore: upgrade to 1.43.79

### DIFF
--- a/recipes-devtools/python/python3-botocore_1.43.79.bb
+++ b/recipes-devtools/python/python3-botocore_1.43.79.bb
@@ -12,7 +12,7 @@ SRC_URI = "\
     file://python_dependency_test.py \
     "
 
-SRCREV = "648ecf41e2472bac42182756b9768a10b3a4add8"
+SRCREV = "14aac28ff1c258709e216a13f26731dbcbb2cbf2"
 S = "${WORKDIR}/git"
 
 inherit setuptools3 ptest


### PR DESCRIPTION
Automated backport from master-next PR #16847.

  Recipe: `python3-botocore`
  Version: `1.43.79`