### PR TITLE
[Backport scarthgap-next] aws-c-s3: upgrade to 0.13.7

### DIFF
--- a/recipes-sdk/aws-c-s3/aws-c-s3_0.13.7.bb
+++ b/recipes-sdk/aws-c-s3/aws-c-s3_0.13.7.bb
@@ -19,7 +19,7 @@ SRC_URI = "\
     git://github.com/awslabs/aws-c-s3.git;protocol=https;branch=${BRANCH} \
     file://run-ptest \
     "
-SRCREV = "72e355a0a51fb82ba33a1f64bc9090b0a1d76dd7"
+SRCREV = "45c946d1e83c990e5fd33c0b1aaac56c911460b1"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Automated backport from master-next PR #16850.

  Recipe: `aws-c-s3`
  Version: `0.13.7`