### PR TITLE
[Backport wrynose-next] s2n: upgrade to 1.7.8

### DIFF
--- a/recipes-sdk/s2n/s2n_1.7.8.bb
+++ b/recipes-sdk/s2n/s2n_1.7.8.bb
@@ -17,7 +17,7 @@ SRC_URI = "\
     file://run-ptest \
     "
 
-SRCREV = "853d1943bbbd7f782a159e77830cdaaf520d68ed"
+SRCREV = "3b975bf3fd9a50def97573afa859e8eb83931928"
 UPSTREAM_CHECK_GITTAGREGEX = "v(?P<pver>.*)"
 
 inherit cmake ptest pkgconfig


### PR DESCRIPTION
Automated backport from master-next PR #16844.

  Recipe: `s2n`
  Version: `1.7.8`