### PR TITLE
[Backport wrynose-next] aws-sdk-cpp: upgrade to 1.11.877

### DIFF
--- a/recipes-sdk/aws-sdk-cpp/aws-sdk-cpp_1.11.877.bb
+++ b/recipes-sdk/aws-sdk-cpp/aws-sdk-cpp_1.11.877.bb
@@ -19,7 +19,7 @@ SRC_URI = "\
     file://ptest_result.py \
     "
 
-SRCREV = "23618a8d660bc4e3ca7d57588546ba0450541329"
+SRCREV = "551f9efb8db9b007216fd6e98ceda0f89d9bb03e"
 
 inherit cmake ptest pkgconfig
 


### PR DESCRIPTION
Automated backport from master-next PR #16852.

  Recipe: `aws-sdk-cpp`
  Version: `1.11.877`