### PR TITLE
meta-aws: fix trailing whitespace in layer.conf

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -4,7 +4,7 @@ BBPATH .= ":${LAYERDIR}"
 # We have recipes-* directories, add to BBFILES
 BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
             ${LAYERDIR}/recipes-*/*/*.bbappend"
-BBFILES += "${@bb.utils.contains("GG_KERNEL_MOD", "Y", "${LAYERDIR}/recipes-*/*/base/*.bbappend", "", d)}" 
+BBFILES += "${@bb.utils.contains("GG_KERNEL_MOD", "Y", "${LAYERDIR}/recipes-*/*/base/*.bbappend", "", d)}"
 
 BBFILE_COLLECTIONS += "meta-aws"
 BBFILE_PATTERN_meta-aws = "^${LAYERDIR}/"


### PR DESCRIPTION
Fix trailing whitespace in layer.conf to resolve bitbake parsing warnings.

Reported on:
https://autobuilder.yoctoproject.org/valkyrie/#/builders/14/builds/4270/steps/13/logs/warnings

*Issue #, if available:*
N/A

*Description of changes:*
Remove trailing whitespace on line 7 of conf/layer.conf that triggers a bitbake parsing warning.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
