### PR TITLE
[Backport whinlatter-next] aws-c-common: upgrade to 1.0.0

### DIFF
--- a/recipes-sdk/aws-c-common/aws-c-common_1.0.0.bb
+++ b/recipes-sdk/aws-c-common/aws-c-common_1.0.0.bb
@@ -14,7 +14,7 @@ SRC_URI = "\
     file://ptest_result.py \
     file://0001-skip-iso8601-tests-on-32bit.patch \
 "
-SRCREV = "f7d471b1feaea9a310851672580f9ac7e031cfc0"
+SRCREV = "3d274e1af954592b344a33fdf042af37b936f3d5"
 
 # will match only x.x.x for auto upgrades, because: https://github.com/awslabs/aws-c-common/issues/1025
 UPSTREAM_CHECK_GITTAGREGEX = "(?P<pver>\d\.\d+(\.\d+)+)"


### PR DESCRIPTION
Automated backport from master-next PR #16877.

  Recipe: `aws-c-common`
  Version: `1.0.0`