### PR TITLE
[Backport whinlatter-next] python3-botocore: upgrade to 1.43.80

### DIFF
--- a/recipes-devtools/python/python3-botocore_1.43.80.bb
+++ b/recipes-devtools/python/python3-botocore_1.43.80.bb
@@ -12,7 +12,7 @@ SRC_URI = "\
     file://python_dependency_test.py \
     "
 
-SRCREV = "14aac28ff1c258709e216a13f26731dbcbb2cbf2"
+SRCREV = "f60d73ccdf820c1aab8388e5e03f555ccb2a4344"
 
 inherit setuptools3 ptest
 


### PR DESCRIPTION
Automated backport from master-next PR #16880.

  Recipe: `python3-botocore`
  Version: `1.43.80`