### PR TITLE
[Backport wrynose-next] aws-cli-v2: upgrade to 2.36.31

### DIFF
--- a/recipes-support/aws-cli-v2/aws-cli-v2_2.36.31.bb
+++ b/recipes-support/aws-cli-v2/aws-cli-v2_2.36.31.bb
@@ -32,7 +32,7 @@ SRC_URI = "\
     file://run-ptest \
 "
 
-SRCREV = "2552cbe0ac85d8f8d2ad8d1a22b2bcded2a048a3"
+SRCREV = "fd09847a724989f3c415c38ce61711cda2d1af64"
 
 # version 2.x
 UPSTREAM_CHECK_GITTAGREGEX = "(?P<pver>2\.\d+(\.\d+)+)"


### PR DESCRIPTION
Automated backport from master-next PR #16881.

  Recipe: `aws-cli-v2`
  Version: `2.36.31`