### PR TITLE
[Backport whinlatter-next] aws-sdk-cpp: upgrade to 1.11.878

### DIFF
--- a/recipes-sdk/aws-sdk-cpp/aws-sdk-cpp_1.11.878.bb
+++ b/recipes-sdk/aws-sdk-cpp/aws-sdk-cpp_1.11.878.bb
@@ -19,7 +19,7 @@ SRC_URI = "\
     file://ptest_result.py \
     "
 
-SRCREV = "551f9efb8db9b007216fd6e98ceda0f89d9bb03e"
+SRCREV = "5650a800bfaca7326a4da336df2e4053ad559867"
 
 inherit cmake ptest pkgconfig
 


### PR DESCRIPTION
Automated backport from master-next PR #16874.

  Recipe: `aws-sdk-cpp`
  Version: `1.11.878`