### PR TITLE
[Backport scarthgap-next] python3-boto3: upgrade to 1.43.81

### DIFF
--- a/recipes-devtools/python/python3-boto3_1.43.81.bb
+++ b/recipes-devtools/python/python3-boto3_1.43.81.bb
@@ -12,7 +12,7 @@ SRC_URI = "\
     file://python_dependency_test.py \
     "
 
-SRCREV = "f53e30a443e0fb5f71b8765658c0ef0a9206ef2b"
+SRCREV = "1ee61ff25b7b2a11577095ac1d478f975c454b1a"
 S = "${WORKDIR}/git"
 
 inherit setuptools3 ptest

--- a/recipes-devtools/python/python3-boto3_1.43.81.bb
+++ b/recipes-devtools/python/python3-boto3_1.43.81.bb
@@ -31,6 +31,7 @@ RDEPENDS:${PN}-ptest += "\
         ${PYTHON_PN}-pytest \
         ${PYTHON_PN}-setuptools \
 "
+# nooelint: oelint.task.nocopy
 do_install_ptest() {
         install -d ${D}${PTEST_PATH}/tests
         cp -rf ${S}/tests/* ${D}${PTEST_PATH}/tests/


### PR DESCRIPTION
Automated backport from master-next PR #16912.

  Recipe: `python3-boto3`
  Version: `1.43.81`