### PR TITLE
[Backport wrynose-next] python3-boto3: upgrade to 1.43.81

### DIFF
--- a/recipes-devtools/python/python3-boto3_1.43.81.bb
+++ b/recipes-devtools/python/python3-boto3_1.43.81.bb
@@ -12,7 +12,7 @@ SRC_URI = "\
     file://python_dependency_test.py \
     "
 
-SRCREV = "494798148af9c92f2b17b2ac63f342951540cf63"
+SRCREV = "1ee61ff25b7b2a11577095ac1d478f975c454b1a"
 
 inherit setuptools3 ptest
 


### PR DESCRIPTION
Automated backport from master-next PR #16912.

  Recipe: `python3-boto3`
  Version: `1.43.81`