### PR TITLE
[Backport whinlatter-next] python3-botocore: upgrade to 1.43.81

### DIFF
--- a/recipes-devtools/python/python3-botocore_1.43.81.bb
+++ b/recipes-devtools/python/python3-botocore_1.43.81.bb
@@ -12,7 +12,7 @@ SRC_URI = "\
     file://python_dependency_test.py \
     "
 
-SRCREV = "f60d73ccdf820c1aab8388e5e03f555ccb2a4344"
+SRCREV = "b5c1794f453f0a0a56f3f619baba223d9321a3f9"
 
 inherit setuptools3 ptest
 


### PR DESCRIPTION
Automated backport from master-next PR #16908.

  Recipe: `python3-botocore`
  Version: `1.43.81`