### PR TITLE
[Backport whinlatter-next] aws-cli-v2: upgrade to 2.36.32

### DIFF
--- a/recipes-support/aws-cli-v2/aws-cli-v2_2.36.32.bb
+++ b/recipes-support/aws-cli-v2/aws-cli-v2_2.36.32.bb
@@ -32,7 +32,7 @@ SRC_URI = "\
     file://run-ptest \
 "
 
-SRCREV = "fd09847a724989f3c415c38ce61711cda2d1af64"
+SRCREV = "083d58b81eee8b96cf530815b314b4873b45ac98"
 
 # version 2.x
 UPSTREAM_CHECK_GITTAGREGEX = "(?P<pver>2\.\d+(\.\d+)+)"


### PR DESCRIPTION
Automated backport from master-next PR #16907.

  Recipe: `aws-cli-v2`
  Version: `2.36.32`