### PR TITLE
[Backport scarthgap-next] aws-sdk-cpp: upgrade to 1.11.879

### DIFF
--- a/recipes-sdk/aws-sdk-cpp/aws-sdk-cpp_1.11.879.bb
+++ b/recipes-sdk/aws-sdk-cpp/aws-sdk-cpp_1.11.879.bb
@@ -21,7 +21,7 @@ SRC_URI = "\
     file://ptest_result.py \
     "
 
-SRCREV = "5650a800bfaca7326a4da336df2e4053ad559867"
+SRCREV = "5f1fdfe4024bb95ed50efbdce4919c613a6e17a8"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Automated backport from master-next PR #16910.

  Recipe: `aws-sdk-cpp`
  Version: `1.11.879`