### PR TITLE
[Backport scarthgap-next] aws-lc: upgrade to 5.6.0

### DIFF
--- a/recipes-sdk/aws-lc/aws-lc_5.6.0.bb
+++ b/recipes-sdk/aws-lc/aws-lc_5.6.0.bb
@@ -878,7 +878,7 @@ SRC_URI = "\
     git://github.com/awslabs/aws-lc.git;protocol=https;branch=${BRANCH} \
     file://run-ptest \
     "
-SRCREV = "991e67ff4cf04df4dd89e407f8b920c6936cb56a"
+SRCREV = "51cbeccf8ea55db59a5e53f405e17a5468d9f62b"
 S = "${WORKDIR}/git"
 UPSTREAM_CHECK_GITTAGREGEX = "v(?P<pver>.*)"
 


### PR DESCRIPTION
Automated backport from master-next PR #16930.

  Recipe: `aws-lc`
  Version: `5.6.0`