### PR TITLE
[Backport whinlatter-next] aws-sdk-cpp: upgrade to 1.11.880

### DIFF
--- a/recipes-sdk/aws-sdk-cpp/aws-sdk-cpp_1.11.880.bb
+++ b/recipes-sdk/aws-sdk-cpp/aws-sdk-cpp_1.11.880.bb
@@ -19,7 +19,7 @@ SRC_URI = "\
     file://ptest_result.py \
     "
 
-SRCREV = "5f1fdfe4024bb95ed50efbdce4919c613a6e17a8"
+SRCREV = "bf8470a9fecb71a840a550a7e817d85ae6229bcd"
 
 inherit cmake ptest pkgconfig
 


### PR DESCRIPTION
Automated backport from master-next PR #16934.

  Recipe: `aws-sdk-cpp`
  Version: `1.11.880`