### PR TITLE
[Backport scarthgap-next] aws-lc: upgrade to 5.7.0

### DIFF
--- a/recipes-sdk/aws-lc/aws-lc_5.7.0.bb
+++ b/recipes-sdk/aws-lc/aws-lc_5.7.0.bb
@@ -878,7 +878,7 @@ SRC_URI = "\
     git://github.com/awslabs/aws-lc.git;protocol=https;branch=${BRANCH} \
     file://run-ptest \
     "
-SRCREV = "51cbeccf8ea55db59a5e53f405e17a5468d9f62b"
+SRCREV = "02561621ffa4cf17c0c4f70bc11a82df36b42ae9"
 S = "${WORKDIR}/git"
 UPSTREAM_CHECK_GITTAGREGEX = "v(?P<pver>.*)"
 


### PR DESCRIPTION
Automated backport from master-next PR #16958.

  Recipe: `aws-lc`
  Version: `5.7.0`