### PR TITLE
[Backport whinlatter-next] aws-sdk-cpp: upgrade to 1.11.884

### DIFF
--- a/recipes-sdk/aws-sdk-cpp/aws-sdk-cpp_1.11.884.bb
+++ b/recipes-sdk/aws-sdk-cpp/aws-sdk-cpp_1.11.884.bb
@@ -19,7 +19,7 @@ SRC_URI = "\
     file://ptest_result.py \
     "
 
-SRCREV = "a6fb129fe7bd8b7f4bce78e73718a9a4bf94d54c"
+SRCREV = "acb9a0a9bcc48065bcfa71c73240c34da8deccb9"
 
 inherit cmake ptest pkgconfig
 


### PR DESCRIPTION
Automated backport from master-next PR #16995.

  Recipe: `aws-sdk-cpp`
  Version: `1.11.884`