### PR TITLE
[Backport wrynose-next] python3-boto3: upgrade to 1.43.90

### DIFF
--- a/recipes-devtools/python/python3-boto3_1.43.90.bb
+++ b/recipes-devtools/python/python3-boto3_1.43.90.bb
@@ -12,7 +12,7 @@ SRC_URI = "\
     file://python_dependency_test.py \
     "
 
-SRCREV = "1ee61ff25b7b2a11577095ac1d478f975c454b1a"
+SRCREV = "fb57e55f85acc7d5b95a05b4d8ad4a2145c60e1a"
 
 inherit setuptools3 ptest
 


### PR DESCRIPTION
Automated backport from master-next PR #17089.

  Recipe: `python3-boto3`
  Version: `1.43.90`