### PR TITLE
[Backport wrynose-next] python3-botocore: upgrade to 1.43.91

### DIFF
--- a/recipes-devtools/python/python3-botocore_1.43.91.bb
+++ b/recipes-devtools/python/python3-botocore_1.43.91.bb
@@ -12,7 +12,7 @@ SRC_URI = "\
     file://python_dependency_test.py \
     "
 
-SRCREV = "b5c1794f453f0a0a56f3f619baba223d9321a3f9"
+SRCREV = "49ca08deed32d358fa12221f3903f282eeceaa09"
 
 inherit setuptools3 ptest
 


### PR DESCRIPTION
Automated backport from master-next PR #17103.

  Recipe: `python3-botocore`
  Version: `1.43.91`