### PR TITLE
[Backport wrynose-next] python3-boto3: upgrade to 1.43.91

### DIFF
--- a/recipes-devtools/python/python3-boto3_1.43.91.bb
+++ b/recipes-devtools/python/python3-boto3_1.43.91.bb
@@ -12,7 +12,7 @@ SRC_URI = "\
     file://python_dependency_test.py \
     "
 
-SRCREV = "1ee61ff25b7b2a11577095ac1d478f975c454b1a"
+SRCREV = "5073bdedf2dfb33b5b5639baa6ce75cbf222f496"
 
 inherit setuptools3 ptest
 


### PR DESCRIPTION
Automated backport from master-next PR #17119.

  Recipe: `python3-boto3`
  Version: `1.43.91`