### PR TITLE
greengrass-lite: fix 32-bit build by enabling UNITY_SUPPORT_64

### DIFF
--- a/recipes-iot/aws-iot-greengrass/greengrass-lite_2.6.0.bb
+++ b/recipes-iot/aws-iot-greengrass/greengrass-lite_2.6.0.bb
@@ -133,6 +133,13 @@ EXTRA_OECMAKE:append = " -DGG_LOG_LEVEL=INFO"
 CFLAGS:append = " -Werror"
 # Workaround: GCC 16 raises new warnings not yet fixed upstream (maybe-uninitialized via LTO)
 CFLAGS:append = " -Wno-error=format-security -Wno-error=int-conversion -Wno-error=maybe-uninitialized"
+# Workaround: on 32-bit targets (e.g. arm/cortexa15t2hf-neon for qemuarm) Unity
+# does not auto-enable 64-bit assertion support, so UNITY_DISPLAY_STYLE_INT64 /
+# UNITY_DISPLAY_STYLE_UINT64 are undeclared and the bundled gg_sdk test helpers
+# (thirdparty/gg_sdk/unity/gg_test) fail to compile. Force it on. Harmless on
+# 64-bit where Unity already defines it (guarded by #ifndef UNITY_SUPPORT_64).
+# Remove once the upstream aws-greengrass-component-sdk fix is in the pinned rev.
+CFLAGS:append = " -DUNITY_SUPPORT_64"
 
 # Disable -D_FORTIFY_SOURCE=2 as we set it to -D_FORTIFY_SOURCE=3
 TARGET_CFLAGS:remove = "-D_FORTIFY_SOURCE=2"


### PR DESCRIPTION
*Issue #, if available:*

#17127 

*Description of changes:*

Stopgap to get the Greengrass nucleus lite building until we get upstream fixes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
