### PR TITLE
[Backport whinlatter-next] python3-botocore: upgrade to 1.43.92

### DIFF
--- a/recipes-devtools/python/python3-botocore_1.43.92.bb
+++ b/recipes-devtools/python/python3-botocore_1.43.92.bb
@@ -12,7 +12,7 @@ SRC_URI = "\
     file://python_dependency_test.py \
     "
 
-SRCREV = "b5c1794f453f0a0a56f3f619baba223d9321a3f9"
+SRCREV = "dfd7fee829163fd6b1afdd24b8ea84ecc442f99a"
 
 inherit setuptools3 ptest
 


### PR DESCRIPTION
Automated backport from master-next PR #17153.

  Recipe: `python3-botocore`
  Version: `1.43.92`